### PR TITLE
perf: 10k-row scroll list at 120 FPS

### DIFF
--- a/examples/perf-10k.fnl
+++ b/examples/perf-10k.fnl
@@ -1,0 +1,38 @@
+;; Performance test: 10,000 vbox rows, each with 1000 characters of
+;; text, inside a single scroll-y container. Run with --profile to
+;; observe per-phase costs under load.
+;;
+;;   ./build/redin --profile examples/perf-10k.fnl
+;;   ./build/redin --dev --profile examples/perf-10k.fnl   ; + /profile
+(local dataflow (require :dataflow))
+(local theme-mod (require :theme))
+
+(theme-mod.set-theme
+  {:body      {:font-size 14 :color [40 40 40]}
+   :row       {:bg [245 245 245] :padding [6 10 6 10]}
+   :row-alt   {:bg [235 235 235] :padding [6 10 6 10]}
+   :container {:bg [255 255 255] :padding [8 8 8 8]}})
+
+(dataflow.init {})
+(global redin_get_state (. dataflow :_get-raw-db))
+
+;; Roughly 1000 characters of deterministic text.
+(local pattern
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. ")
+(local text-1000 (string.sub (.. pattern pattern pattern pattern) 1 1000))
+
+(local ROW-COUNT 10000)
+
+;; Build the view tree once at load time. main_view returns the same
+;; table reference each frame — the Bridge still flattens it fresh,
+;; so this measures framework cost rather than Fennel tree-allocation.
+(local tree
+  (let [root [:vbox {:aspect :container :overflow :scroll-y}]]
+    (for [i 1 ROW-COUNT]
+      (let [aspect (if (= 0 (% i 2)) :row :row-alt)]
+        (table.insert root
+          [:vbox {:aspect aspect}
+           [:text {:aspect :body} text-1000]])))
+    root))
+
+(global main_view (fn [] tree))

--- a/examples/perf-10k.fnl
+++ b/examples/perf-10k.fnl
@@ -21,7 +21,7 @@
   "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. ")
 (local text-1000 (string.sub (.. pattern pattern pattern pattern) 1 1000))
 
-(local ROW-COUNT 10000)
+(local ROW-COUNT (tonumber (or (os.getenv "PERF_ROWS") "10000")))
 
 ;; Build the view tree once at load time. main_view returns the same
 ;; table reference each frame — the Bridge still flattens it fresh,

--- a/src/host/bridge/bridge.odin
+++ b/src/host/bridge/bridge.odin
@@ -8,6 +8,7 @@ import "core:time"
 import "core:unicode/utf8"
 import "base:runtime"
 import "../font"
+import text_pkg "../text"
 import "../types"
 import rl "vendor:raylib"
 import "../canvas"
@@ -156,6 +157,10 @@ clear_node_strings :: proc(n: types.Node) {
 }
 
 clear_frame :: proc(b: ^Bridge) {
+	// Any cross-frame caches keyed by node string pointers become stale
+	// the moment strings are freed. Invalidate before any delete calls.
+	text_pkg.invalidate_height_cache()
+
 	for &p in b.paths {
 		delete(p.value)
 	}

--- a/src/host/main.odin
+++ b/src/host/main.odin
@@ -53,7 +53,7 @@ main :: proc() {
 	rl.SetConfigFlags({.WINDOW_RESIZABLE, .MSAA_4X_HINT})
 	rl.InitWindow(1280, 800, "redin")
 	defer rl.CloseWindow()
-	rl.SetTargetFPS(60)
+	rl.SetTargetFPS(120)
 
 	font.init()
 	defer font.destroy()

--- a/src/host/render.odin
+++ b/src/host/render.odin
@@ -2,7 +2,6 @@ package host
 
 import "canvas"
 import "core:fmt"
-import "core:hash"
 import "core:math"
 import "core:strings"
 import "font"
@@ -62,19 +61,8 @@ Intrinsic_Entry :: struct {
 }
 node_intrinsic_cache: [dynamic]Intrinsic_Entry
 
-// Cross-frame cache for NodeText height. Bridge re-clones string content
-// every frame so node idx + width is only stable within a frame; content
-// bytes are the only stable identity across frames. Key includes length
-// in addition to the hash to avoid the (vanishingly rare) hash collision.
-Text_Height_Key :: struct {
-	content_hash: u64,
-	content_len:  int,
-	font_size:    f32,
-	width:        f32,
-	lh_ratio:     f32,
-	font_tex_id:  u32, // font.texture.id — distinguishes loaded font atlases
-}
-text_height_cache: map[Text_Height_Key]f32
+// Cross-frame text-height cache lives in text_pkg; Bridge invalidates
+// it from clear_frame. See text_pkg.Height_Key.
 
 SCROLL_SPEED :: 30.0 // pixels per wheel tick
 
@@ -695,23 +683,23 @@ node_preferred_height :: proc(
 		// stable font-atlas identity.
 		f := font.get(font_name, font.style_from_weight(font.Font_Weight(font_weight)))
 
-		// Level 2: cross-frame cache keyed by content bytes. Bridge
-		// reclones strings each frame, so pointer identity is lost —
-		// the fnv64a hash of the bytes is the stable key.
+		// Level 2: cross-frame cache keyed by content.data pointer.
+		// Valid for as long as Bridge hasn't re-flattened the tree —
+		// bridge.clear_frame calls text_pkg.invalidate_height_cache.
 		can_wrap := available_width > 0 && len(n.content) > 0 && n.overflow != "scroll-x"
-		key: Text_Height_Key
+		key: text_pkg.Height_Key
 		have_key := false
 		if can_wrap {
-			key = Text_Height_Key{
-				content_hash = hash.fnv64a(transmute([]u8)n.content),
-				content_len  = len(n.content),
-				font_size    = font_size,
-				width        = available_width,
-				lh_ratio     = lh_ratio,
-				font_tex_id  = f.texture.id,
+			key = text_pkg.Height_Key{
+				content_ptr = uintptr(raw_data(n.content)),
+				content_len = len(n.content),
+				font_size   = font_size,
+				width       = available_width,
+				lh_ratio    = lh_ratio,
+				font_tex_id = f.texture.id,
 			}
 			have_key = true
-			if cached, ok := text_height_cache[key]; ok {
+			if cached, ok := text_pkg.lookup_height(key); ok {
 				if idx >= 0 && idx < len(node_intrinsic_cache) {
 					node_intrinsic_cache[idx] = Intrinsic_Entry{
 						width = available_width, height = cached,
@@ -727,7 +715,7 @@ node_preferred_height :: proc(
 			defer delete(lines)
 			result = f32(len(lines)) * lh
 			if have_key {
-				text_height_cache[key] = result
+				text_pkg.cache_height(key, result)
 			}
 		}
 		if idx >= 0 && idx < len(node_intrinsic_cache) {

--- a/src/host/render.odin
+++ b/src/host/render.odin
@@ -2,6 +2,7 @@ package host
 
 import "canvas"
 import "core:fmt"
+import "core:hash"
 import "core:math"
 import "core:strings"
 import "font"
@@ -49,6 +50,31 @@ Scroll_Info :: struct {
 	off:   f32, // clamped scroll offset
 }
 node_scroll_info: map[int]Scroll_Info
+
+// Per-frame cache for intrinsic_height. The size-emission pair in
+// layout_box calls intrinsic_height twice for each scroll-y child (once
+// to sum fixed_total, once to assign child height); also used by nested
+// Vbox recursion. Cache hit count grows with tree depth × child count.
+// Sentinel: width < 0 means unpopulated (widths are always non-negative).
+Intrinsic_Entry :: struct {
+	width:  f32,
+	height: f32,
+}
+node_intrinsic_cache: [dynamic]Intrinsic_Entry
+
+// Cross-frame cache for NodeText height. Bridge re-clones string content
+// every frame so node idx + width is only stable within a frame; content
+// bytes are the only stable identity across frames. Key includes length
+// in addition to the hash to avoid the (vanishingly rare) hash collision.
+Text_Height_Key :: struct {
+	content_hash: u64,
+	content_len:  int,
+	font_size:    f32,
+	width:        f32,
+	lh_ratio:     f32,
+	font_tex_id:  u32, // font.texture.id — distinguishes loaded font atlases
+}
+text_height_cache: map[Text_Height_Key]f32
 
 SCROLL_SPEED :: 30.0 // pixels per wheel tick
 
@@ -117,9 +143,11 @@ layout_tree :: proc(
 
 	resize(&node_rects, len(nodes))
 	resize(&node_content_rects, len(nodes))
+	resize(&node_intrinsic_cache, len(nodes))
 	for i in 0 ..< len(nodes) {
 		node_rects[i] = {}
 		node_content_rects[i] = {}
+		node_intrinsic_cache[i] = Intrinsic_Entry{width = -1}
 	}
 	clear(&node_scroll_info)
 
@@ -531,8 +559,22 @@ draw_box_children :: proc(
 		)
 	}
 
+	// Visibility culling for scrollable containers: skip children whose
+	// rect is entirely outside the scissor content rect. Scales draw
+	// cost with visible rows instead of total children.
+	cr_top    := content_rect.y
+	cr_bottom := content_rect.y + content_rect.height
+	cr_left   := content_rect.x
+	cr_right  := content_rect.x + content_rect.width
+
 	for i in 0 ..< int(ch.length) {
-		draw_node(int(ch.value[i]), nodes, children_list, theme)
+		child_idx := int(ch.value[i])
+		if scrollable {
+			r := node_rects[child_idx]
+			if r.y + r.height < cr_top || r.y > cr_bottom do continue
+			if r.x + r.width  < cr_left || r.x > cr_right  do continue
+		}
+		draw_node(child_idx, nodes, children_list, theme)
 	}
 
 	if scrollable {
@@ -626,6 +668,15 @@ node_preferred_height :: proc(
 		h := size_f32(n.height)
 		if h > 0 do return h
 
+		// Level 1: per-frame cache keyed by node idx + width. Hits on
+		// the second layout pass for the same frame.
+		if idx >= 0 && idx < len(node_intrinsic_cache) {
+			entry := node_intrinsic_cache[idx]
+			if entry.width == available_width {
+				return entry.height
+			}
+		}
+
 		font_size: f32 = 18
 		font_name := "sans"
 		font_weight: u8 = 0
@@ -640,13 +691,49 @@ node_preferred_height :: proc(
 		}
 		lh := text_pkg.line_height(font_size, lh_ratio)
 
-		if available_width > 0 && len(n.content) > 0 && n.overflow != "scroll-x" {
-			f := font.get(font_name, font.style_from_weight(font.Font_Weight(font_weight)))
+		// Resolve font once so we can key the cross-frame cache on a
+		// stable font-atlas identity.
+		f := font.get(font_name, font.style_from_weight(font.Font_Weight(font_weight)))
+
+		// Level 2: cross-frame cache keyed by content bytes. Bridge
+		// reclones strings each frame, so pointer identity is lost —
+		// the fnv64a hash of the bytes is the stable key.
+		can_wrap := available_width > 0 && len(n.content) > 0 && n.overflow != "scroll-x"
+		key: Text_Height_Key
+		have_key := false
+		if can_wrap {
+			key = Text_Height_Key{
+				content_hash = hash.fnv64a(transmute([]u8)n.content),
+				content_len  = len(n.content),
+				font_size    = font_size,
+				width        = available_width,
+				lh_ratio     = lh_ratio,
+				font_tex_id  = f.texture.id,
+			}
+			have_key = true
+			if cached, ok := text_height_cache[key]; ok {
+				if idx >= 0 && idx < len(node_intrinsic_cache) {
+					node_intrinsic_cache[idx] = Intrinsic_Entry{
+						width = available_width, height = cached,
+					}
+				}
+				return cached
+			}
+		}
+
+		result := lh
+		if can_wrap {
 			lines := text_pkg.compute_lines(n.content, f, font_size, 0, available_width)
 			defer delete(lines)
-			return f32(len(lines)) * lh
+			result = f32(len(lines)) * lh
+			if have_key {
+				text_height_cache[key] = result
+			}
 		}
-		return lh
+		if idx >= 0 && idx < len(node_intrinsic_cache) {
+			node_intrinsic_cache[idx] = Intrinsic_Entry{width = available_width, height = result}
+		}
+		return result
 	case types.NodeImage:
 		return size_f32(n.height)
 	case types.NodeVbox:
@@ -676,6 +763,30 @@ intrinsic_height :: proc(
 ) -> f32 {
 	if idx < 0 || idx >= len(nodes) do return 0
 
+	// Per-frame cache: hit when width matches. Populated at the end of
+	// this proc. Cleared in layout_tree.
+	if idx < len(node_intrinsic_cache) {
+		entry := node_intrinsic_cache[idx]
+		if entry.width == available_width {
+			return entry.height
+		}
+	}
+
+	h := intrinsic_height_impl(idx, nodes, children_list, theme, available_width)
+	if idx < len(node_intrinsic_cache) {
+		node_intrinsic_cache[idx] = Intrinsic_Entry{width = available_width, height = h}
+	}
+	return h
+}
+
+@(private)
+intrinsic_height_impl :: proc(
+	idx: int,
+	nodes: []types.Node,
+	children_list: []types.Children,
+	theme: map[string]types.Theme,
+	available_width: f32,
+) -> f32 {
 	switch n in nodes[idx] {
 	case types.NodeVbox:
 		h := size_f16(n.height)

--- a/src/host/text/layout.odin
+++ b/src/host/text/layout.odin
@@ -4,6 +4,35 @@ import "core:strings"
 import "core:unicode/utf8"
 import rl "vendor:raylib"
 
+// Cross-frame cache for wrapped-text heights. Keyed by content.data
+// pointer: as long as Bridge hasn't re-flattened the tree, the same
+// NodeText has the same pointer each frame and the cache hits. On
+// re-flatten, Bridge calls invalidate_height_cache so stale pointers
+// never return a false positive if an address is reused.
+Height_Key :: struct {
+	content_ptr: uintptr,
+	content_len: int,
+	font_size:   f32,
+	width:       f32,
+	lh_ratio:    f32,
+	font_tex_id: u32,
+}
+@(private)
+height_cache: map[Height_Key]f32
+
+lookup_height :: proc(key: Height_Key) -> (f32, bool) {
+	h, ok := height_cache[key]
+	return h, ok
+}
+
+cache_height :: proc(key: Height_Key, h: f32) {
+	height_cache[key] = h
+}
+
+invalidate_height_cache :: proc() {
+	clear(&height_cache)
+}
+
 Text_Line :: struct {
 	start: int, // byte offset inclusive
 	end:   int, // byte offset exclusive

--- a/src/host/text/layout.odin
+++ b/src/host/text/layout.odin
@@ -17,8 +17,27 @@ measure_range :: proc(text: string, start: int, end: int, font_obj: rl.Font, fon
 	return rl.MeasureTextEx(font_obj, cstr, font_size, spacing).x
 }
 
+// Raw advance width of a single codepoint in `font`'s base units.
+// Multiply by `font_size / font.baseSize` to get pixels at a target size.
+// Mirrors the inner arithmetic of rl.MeasureTextEx so compute_lines can
+// track a running width in O(n) rather than remeasuring the growing
+// line prefix on every character.
+@(private)
+glyph_advance_raw :: proc(font_obj: rl.Font, cp: rune) -> f32 {
+	idx := rl.GetGlyphIndex(font_obj, cp)
+	if idx < 0 || idx >= font_obj.glyphCount do return 0
+	advance := font_obj.glyphs[idx].advanceX
+	if advance != 0 do return f32(advance)
+	return font_obj.recs[idx].width
+}
+
 // Compute visual line breaks for text with word-wrap and \n support.
 // max_width <= 0 means no wrapping (only break on \n).
+//
+// Tracks a running `current_px` equal to the pixel width from line_start
+// to pos. Each character contributes exactly one glyph advance, making
+// this O(n). Matches rl.MeasureTextEx semantics: scale by
+// font_size / baseSize and add `spacing` between (not before) glyphs.
 compute_lines :: proc(
 	text: string,
 	font_obj: rl.Font,
@@ -33,61 +52,82 @@ compute_lines :: proc(
 		return lines
 	}
 
+	scale: f32 = 1
+	if font_obj.baseSize > 0 {
+		scale = font_size / f32(font_obj.baseSize)
+	}
+
 	line_start := 0
 	last_space := -1          // byte offset of last space (word break point)
 	last_space_width: f32 = 0 // line width up to (not including) last_space
+	current_px: f32 = 0        // pixel width of [line_start, pos)
+	char_count := 0            // chars added to the current line (spacing gate)
 
 	pos := 0
 	for pos < len(text) {
+		c := text[pos]
+
 		// Hard line break
-		if text[pos] == '\n' {
-			w := measure_range(text, line_start, pos, font_obj, font_size, spacing)
-			append(&lines, Text_Line{start = line_start, end = pos, width = w})
+		if c == '\n' {
+			append(&lines, Text_Line{start = line_start, end = pos, width = current_px})
 			pos += 1
 			line_start = pos
+			current_px = 0
+			char_count = 0
 			last_space = -1
 			continue
 		}
 
-		// Track word boundaries
-		if text[pos] == ' ' {
+		rune_val, size := utf8.decode_rune(transmute([]u8)text[pos:])
+
+		// Record space boundary BEFORE adding its width; last_space_width
+		// is the line width up to (but not including) the space.
+		if c == ' ' {
 			last_space = pos
-			last_space_width = measure_range(text, line_start, pos, font_obj, font_size, spacing)
+			last_space_width = current_px
 		}
 
-		// Advance past this character
-		_, size := utf8.decode_rune(transmute([]u8)text[pos:])
-		next_pos := pos + size
+		glyph_px := glyph_advance_raw(font_obj, rune_val) * scale
+		next_px := current_px + glyph_px
+		if char_count > 0 do next_px += spacing
 
-		// Check if line exceeds max_width
-		if max_width > 0 && next_pos > line_start {
-			line_width := measure_range(text, line_start, next_pos, font_obj, font_size, spacing)
-			if line_width > max_width && pos > line_start {
-				if last_space >= line_start {
-					// Break at last word boundary
-					append(&lines, Text_Line{
-						start = line_start,
-						end   = last_space,
-						width = last_space_width,
-					})
-					line_start = last_space + 1 // skip the space
-					last_space = -1
-				} else {
-					// No word boundary — break at character level
-					w := measure_range(text, line_start, pos, font_obj, font_size, spacing)
-					append(&lines, Text_Line{start = line_start, end = pos, width = w})
-					line_start = pos
-					last_space = -1
-				}
+		// Wrap if the candidate width would exceed max_width. The
+		// `pos > line_start` guard prevents an infinite loop on a line
+		// whose very first char is already wider than max_width.
+		if max_width > 0 && next_px > max_width && pos > line_start {
+			if last_space >= line_start {
+				// Break at last word boundary; skip the space.
+				append(&lines, Text_Line{
+					start = line_start,
+					end   = last_space,
+					width = last_space_width,
+				})
+				line_start = last_space + 1
+				pos = line_start
+				current_px = 0
+				char_count = 0
+				last_space = -1
+				continue
 			}
+
+			// No space on this line — break at char boundary. The
+			// current char becomes the first char of the new line, so
+			// don't advance pos; the next iteration handles it.
+			append(&lines, Text_Line{start = line_start, end = pos, width = current_px})
+			line_start = pos
+			current_px = 0
+			char_count = 0
+			last_space = -1
+			continue
 		}
 
-		pos = next_pos
+		current_px = next_px
+		char_count += 1
+		pos += size
 	}
 
 	// Emit final line
-	w := measure_range(text, line_start, len(text), font_obj, font_size, spacing)
-	append(&lines, Text_Line{start = line_start, end = len(text), width = w})
+	append(&lines, Text_Line{start = line_start, end = len(text), width = current_px})
 
 	return lines
 }


### PR DESCRIPTION
## Summary
Diagnosed and fixed the hot paths in layout/render under scale. A new `examples/perf-10k.fnl` stress test (10,000 scroll-y rows × ~1000 chars each, configurable via `PERF_ROWS`) goes from effectively hung (~0.3 FPS, 3.2s/frame) to **118 FPS (~8.3ms/frame)**.

| Stage | Frame time | FPS | Layout | Render |
|---|---|---|---|---|
| Baseline (`compute_lines` O(n²)) | ~3200 ms | 0.31 | 1845 ms | 1399 ms |
| O(n) `compute_lines` | ~1395 ms | 0.72 | 1393 ms | — |
| + culling + per-frame intrinsic cache | ~467 ms | 2.14 | 465 ms | 1.3 ms |
| + hash-keyed cross-frame cache (target 60) | ~16.7 ms | 59.97 | 14.1 ms | 1.4 ms |
| + pointer-keyed cache + `SetTargetFPS(120)` | **~8.3 ms** | **118.48** | 7.0 ms | 1.3 ms |

### What changed

- **`text/layout.odin`** — `compute_lines` rewritten from O(n²) to O(n). The old loop called `measure_range(line_start..pos)` on every character, re-measuring the whole accumulated prefix. The new version tracks a running pixel width by summing each glyph's advance via a new `glyph_advance_raw` helper that reads `font.glyphs[i].advanceX` / `font.recs[i].width` — same arithmetic `rl.MeasureTextEx` uses, so pixel-identical.
- **`text/layout.odin`** — owns a cross-frame text-height cache keyed by content.data pointer. `Bridge.clear_frame` invalidates it before freeing any node strings, so address reuse after re-flatten cannot return a false hit.
- **`render.odin`** — per-frame `node_intrinsic_cache` keyed by (node idx, width) collapses the 2-4× duplicate `intrinsic_height` calls made by `layout_box`'s size pass + emission pass + nested `Vbox` recursion.
- **`render.odin`** — visibility culling in `draw_box_children`: children whose rect lies outside the scissor rect are not passed to `draw_node`. Cuts per-frame leaf draws in the 10k-row container from 10k to ~30.
- **`main.odin`** — `rl.SetTargetFPS(60)` → `120` so the perf headroom is observable.
- **`examples/perf-10k.fnl`** — stress test with `PERF_ROWS` env var.

### Commits

- `41539fc` test(perf): add 10k-row scrolling stress test
- `058d523` perf: 10k × 1000-char scroll list now renders at 60 FPS
- `208b5c8` perf: key text-height cache by content pointer; 120 FPS target

## Test plan
- [x] `odin build src/host -out:build/redin` — clean.
- [x] `odin test src/host/profile` — 4/4.
- [x] `odin test src/host/parser` — 24/24.
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 122/122.
- [x] `bb test/ui/run.bb test/ui/test_smoke.bb` — 8/8.
- [x] `bb test/ui/run.bb test/ui/test_input.bb` — 14/14.
- [x] `bb test/ui/run.bb test/ui/test_profile.bb` — 3/3.
- [x] `PERF_ROWS=10000 ./build/redin --dev --profile examples/perf-10k.fnl` → `curl /profile` → median 8.3 ms/frame, 118 FPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)