### PR TITLE
perf: unify intrinsic-height cache, key by node idx

### DIFF
--- a/.claude/skills/redin-dev/SKILL.md
+++ b/.claude/skills/redin-dev/SKILL.md
@@ -267,7 +267,7 @@ my-app/
 - String ownership in bridge: `strings.clone_from_cstring` for persisted strings, `string(lua_tostring_raw(...))` for transient reads
 - Lua stack: every push needs a matching pop/defer-pop
 - Host callbacks: `proc "c"` needs `context = g_context` at the start (uses saved init context for tracking allocator compatibility)
-- Flat parallel arrays for view tree: `nodes[]`, `paths[]`, `parent_indices[]`, `children_list[]` (DFS order, i32 indices)
+- Flat parallel arrays (Structure of Arrays / SoA) for view tree: `nodes[]`, `paths[]`, `parent_indices[]`, `children_list[]` — DFS order, i32 indices. Any per-node side table (scroll offsets, intrinsic-height cache, `node_rects`) should be indexed by the same idx so lookups stay O(1) and invariants hold across packages. On re-flatten, Bridge's `clear_frame` must invalidate every idx-keyed side table.
 - `focused_idx` lives in the `input` package, read by `render` for cursor
 - `node_rects` lives in `render`, passed as parameter to input functions
 

--- a/src/host/bridge/bridge.odin
+++ b/src/host/bridge/bridge.odin
@@ -266,6 +266,11 @@ redin_set_theme :: proc "c" (L: ^Lua_State) -> i32 {
 		}
 		delete(g_bridge.theme)
 		g_bridge.theme = lua_to_theme(L, 1)
+
+		// Theme params (font_size, lh_ratio, font atlas) feed cached
+		// intrinsic heights; invalidate since the cache is idx-keyed
+		// and doesn't detect indirect param changes on its own.
+		text_pkg.invalidate_height_cache()
 	}
 	return 0
 }

--- a/src/host/render.odin
+++ b/src/host/render.odin
@@ -50,19 +50,10 @@ Scroll_Info :: struct {
 }
 node_scroll_info: map[int]Scroll_Info
 
-// Per-frame cache for intrinsic_height. The size-emission pair in
-// layout_box calls intrinsic_height twice for each scroll-y child (once
-// to sum fixed_total, once to assign child height); also used by nested
-// Vbox recursion. Cache hit count grows with tree depth × child count.
-// Sentinel: width < 0 means unpopulated (widths are always non-negative).
-Intrinsic_Entry :: struct {
-	width:  f32,
-	height: f32,
-}
-node_intrinsic_cache: [dynamic]Intrinsic_Entry
-
-// Cross-frame text-height cache lives in text_pkg; Bridge invalidates
-// it from clear_frame. See text_pkg.Height_Key.
+// Intrinsic-height cache lives in text_pkg, keyed by node idx. It
+// serves both roles: same-frame dedup (layout_box size + emission
+// passes, nested Vbox recursion) and cross-frame survival while the
+// tree is unchanged. Bridge invalidates on re-flatten and theme swap.
 
 SCROLL_SPEED :: 30.0 // pixels per wheel tick
 
@@ -131,12 +122,13 @@ layout_tree :: proc(
 
 	resize(&node_rects, len(nodes))
 	resize(&node_content_rects, len(nodes))
-	resize(&node_intrinsic_cache, len(nodes))
 	for i in 0 ..< len(nodes) {
 		node_rects[i] = {}
 		node_content_rects[i] = {}
-		node_intrinsic_cache[i] = Intrinsic_Entry{width = -1}
 	}
+	// Grow the intrinsic cache if nodes[] did. Existing entries stay
+	// valid across frames; Bridge invalidates on re-flatten / theme swap.
+	text_pkg.ensure_intrinsic_cache(len(nodes))
 	clear(&node_scroll_info)
 
 	screen := rl.Rectangle{0, 0, f32(rl.GetScreenWidth()), f32(rl.GetScreenHeight())}
@@ -656,13 +648,8 @@ node_preferred_height :: proc(
 		h := size_f32(n.height)
 		if h > 0 do return h
 
-		// Level 1: per-frame cache keyed by node idx + width. Hits on
-		// the second layout pass for the same frame.
-		if idx >= 0 && idx < len(node_intrinsic_cache) {
-			entry := node_intrinsic_cache[idx]
-			if entry.width == available_width {
-				return entry.height
-			}
+		if cached, ok := text_pkg.lookup_intrinsic(idx, available_width); ok {
+			return cached
 		}
 
 		font_size: f32 = 18
@@ -679,48 +666,14 @@ node_preferred_height :: proc(
 		}
 		lh := text_pkg.line_height(font_size, lh_ratio)
 
-		// Resolve font once so we can key the cross-frame cache on a
-		// stable font-atlas identity.
-		f := font.get(font_name, font.style_from_weight(font.Font_Weight(font_weight)))
-
-		// Level 2: cross-frame cache keyed by content.data pointer.
-		// Valid for as long as Bridge hasn't re-flattened the tree —
-		// bridge.clear_frame calls text_pkg.invalidate_height_cache.
-		can_wrap := available_width > 0 && len(n.content) > 0 && n.overflow != "scroll-x"
-		key: text_pkg.Height_Key
-		have_key := false
-		if can_wrap {
-			key = text_pkg.Height_Key{
-				content_ptr = uintptr(raw_data(n.content)),
-				content_len = len(n.content),
-				font_size   = font_size,
-				width       = available_width,
-				lh_ratio    = lh_ratio,
-				font_tex_id = f.texture.id,
-			}
-			have_key = true
-			if cached, ok := text_pkg.lookup_height(key); ok {
-				if idx >= 0 && idx < len(node_intrinsic_cache) {
-					node_intrinsic_cache[idx] = Intrinsic_Entry{
-						width = available_width, height = cached,
-					}
-				}
-				return cached
-			}
-		}
-
 		result := lh
-		if can_wrap {
+		if available_width > 0 && len(n.content) > 0 && n.overflow != "scroll-x" {
+			f := font.get(font_name, font.style_from_weight(font.Font_Weight(font_weight)))
 			lines := text_pkg.compute_lines(n.content, f, font_size, 0, available_width)
 			defer delete(lines)
 			result = f32(len(lines)) * lh
-			if have_key {
-				text_pkg.cache_height(key, result)
-			}
 		}
-		if idx >= 0 && idx < len(node_intrinsic_cache) {
-			node_intrinsic_cache[idx] = Intrinsic_Entry{width = available_width, height = result}
-		}
+		text_pkg.cache_intrinsic(idx, available_width, result)
 		return result
 	case types.NodeImage:
 		return size_f32(n.height)
@@ -751,19 +704,12 @@ intrinsic_height :: proc(
 ) -> f32 {
 	if idx < 0 || idx >= len(nodes) do return 0
 
-	// Per-frame cache: hit when width matches. Populated at the end of
-	// this proc. Cleared in layout_tree.
-	if idx < len(node_intrinsic_cache) {
-		entry := node_intrinsic_cache[idx]
-		if entry.width == available_width {
-			return entry.height
-		}
+	if cached, ok := text_pkg.lookup_intrinsic(idx, available_width); ok {
+		return cached
 	}
 
 	h := intrinsic_height_impl(idx, nodes, children_list, theme, available_width)
-	if idx < len(node_intrinsic_cache) {
-		node_intrinsic_cache[idx] = Intrinsic_Entry{width = available_width, height = h}
-	}
+	text_pkg.cache_intrinsic(idx, available_width, h)
 	return h
 }
 

--- a/src/host/text/layout.odin
+++ b/src/host/text/layout.odin
@@ -4,33 +4,50 @@ import "core:strings"
 import "core:unicode/utf8"
 import rl "vendor:raylib"
 
-// Cross-frame cache for wrapped-text heights. Keyed by content.data
-// pointer: as long as Bridge hasn't re-flattened the tree, the same
-// NodeText has the same pointer each frame and the cache hits. On
-// re-flatten, Bridge calls invalidate_height_cache so stale pointers
-// never return a false positive if an address is reused.
-Height_Key :: struct {
-	content_ptr: uintptr,
-	content_len: int,
-	font_size:   f32,
-	width:       f32,
-	lh_ratio:    f32,
-	font_tex_id: u32,
+// Intrinsic-height cache indexed by node idx. Same key stability as a
+// pointer-keyed cache would be (valid while Bridge hasn't re-flattened),
+// but cheaper to hash/compare. Bridge invalidates from clear_frame
+// (on re-flatten) and from redin_set_theme (on theme swap), since a
+// theme change can alter font params without a re-flatten.
+//
+// Sentinel: width < 0 means unpopulated. Secondary key params
+// (font_size, lh_ratio, font_tex_id) are not stored — theme-change
+// invalidation covers them.
+Intrinsic_Entry :: struct {
+	width:  f32,
+	height: f32,
 }
 @(private)
-height_cache: map[Height_Key]f32
+intrinsic_cache: [dynamic]Intrinsic_Entry
 
-lookup_height :: proc(key: Height_Key) -> (f32, bool) {
-	h, ok := height_cache[key]
-	return h, ok
+// Grow the cache to at least `n` entries. New slots are initialized
+// as unpopulated. Existing entries are preserved (cross-frame hits).
+ensure_intrinsic_cache :: proc(n: int) {
+	old_len := len(intrinsic_cache)
+	if n > old_len {
+		resize(&intrinsic_cache, n)
+		for i in old_len ..< n {
+			intrinsic_cache[i] = Intrinsic_Entry{width = -1}
+		}
+	}
 }
 
-cache_height :: proc(key: Height_Key, h: f32) {
-	height_cache[key] = h
+lookup_intrinsic :: proc(idx: int, width: f32) -> (f32, bool) {
+	if idx < 0 || idx >= len(intrinsic_cache) do return 0, false
+	e := intrinsic_cache[idx]
+	if e.width == width && e.width >= 0 do return e.height, true
+	return 0, false
+}
+
+cache_intrinsic :: proc(idx: int, width: f32, height: f32) {
+	if idx < 0 || idx >= len(intrinsic_cache) do return
+	intrinsic_cache[idx] = Intrinsic_Entry{width = width, height = height}
 }
 
 invalidate_height_cache :: proc() {
-	clear(&height_cache)
+	for i in 0 ..< len(intrinsic_cache) {
+		intrinsic_cache[i] = Intrinsic_Entry{width = -1}
+	}
 }
 
 Text_Line :: struct {


### PR DESCRIPTION
## Summary

Follow-up to #36. The two-layer cache (per-frame idx-keyed in `render.odin` + cross-frame pointer-keyed map in `text_pkg`) collapses into one idx-keyed array in `text_pkg`. Array-indexed lookups replace the map-hash path, and entries now survive across frames for every node type — so steady-state frames hit the cache at the Vbox root instead of recursing through every child.

Invalidation moves from *every* `layout_tree` to *on re-flatten or theme swap*, driven by Bridge. Theme swap needs an explicit `invalidate_height_cache()` call in `redin_set_theme` because the idx-keyed cache can't detect indirect font-param changes on its own.

Also names the SoA invariant in `redin-dev`: per-node side tables must be invalidated on re-flatten.

## Perf (`PERF_ROWS=10000 examples/perf-10k.fnl`)

|  | Before (#36 merged) | After |
|---|---|---|
| Frame total | ~8.3 ms (capped @ 120 FPS) | ~8.3 ms (capped @ 120 FPS) |
| Layout | 7.0 ms | **2.5 ms** |
| Render | 1.3 ms | 1.2 ms |

Layout dropped ~2.8× because the unified cache survives across frames for the whole Vbox subtree, not just leaf text lookups. The old per-frame `node_intrinsic_cache` was cleared every `layout_tree`, so each steady-state frame re-traversed the 10k Vbox subtree and did a map lookup per leaf. Now `intrinsic_height(root)` hits at the top.

## Code delta

`+57 / -89` lines — two caches became one.

## Test plan

- [x] `odin build src/host -out:build/redin` — clean.
- [x] `odin test src/host/profile` — 4/4.
- [x] `odin test src/host/parser` — 24/24.
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 122/122.
- [x] `bash test/ui/run-all.sh` — all real suites pass. The lone `test_profile` hiccup reproduces identically on `origin/main` and is a pre-existing `run-all.sh` issue (script doesn't pass `--profile` to the dev server); test passes when run directly.
- [x] `--track-mem` on smoke and `PERF_ROWS=500` perf-10k — no leaks on shutdown.
- [x] `PERF_ROWS=10000 ./build/redin --dev --profile examples/perf-10k.fnl` → median layout 2.5 ms, total 8.3 ms (120 FPS cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)