### PR TITLE
feat: NodeText selection / highlight

### DIFF
--- a/.claude/skills/redin-dev/SKILL.md
+++ b/.claude/skills/redin-dev/SKILL.md
@@ -40,6 +40,8 @@ src/runtime/        Fennel runtime (loaded by bridge at startup)
 
 `NodeStack`, `NodeCanvas`, `NodeVbox`, `NodeHbox`, `NodeInput`, `NodeButton`, `NodeText`, `NodeImage`, `NodePopout`, `NodeModal`
 
+NodeText accepts `:selectable` (boolean, default `true`); set to `false` to opt the node out of mouse-selection.
+
 ## Frame format (Fennel)
 
 ```fennel
@@ -137,6 +139,7 @@ canvas.register("my-provider", my_provider)
 
 - State variants use `#` notation: `button#hover`, `input#focus`
 - Properties: `bg`, `color`, `border`, `border-width`, `radius`, `padding` [top right bottom left], `font-size`, `font`, `weight` (0=normal, 1=bold), `line-height` (ratio, e.g. 1.5), `opacity` (0-1, affects bg alpha), `shadow` `[x y blur [r g b a]]` (drop shadow; consumed by vbox/hbox/button/popout/canvas)
+- `:selection` controls the selection highlight color for both `:input` nodes and `:text` nodes (text selection added on feat/text-highlight)
 
 ## Dataflow (re-frame pattern)
 
@@ -173,6 +176,7 @@ canvas.register("my-provider", my_provider)
 | GET | /state | Full app state |
 | GET | /state/path.to.value | Nested state lookup |
 | GET | /aspects | Current theme |
+| GET | /selection | Current text/input selection: `{kind: none\|input\|text, start, end, text}` |
 | GET | /screenshot | PNG screenshot |
 | POST | /events | Dispatch event (JSON: `["event-name", payload]`) |
 | POST | /click | Inject click (JSON: `{"x":N,"y":N}`) |

--- a/.claude/skills/redin-maintenance/SKILL.md
+++ b/.claude/skills/redin-maintenance/SKILL.md
@@ -47,7 +47,7 @@ curl -s -X POST http://localhost:8800/shutdown
 
 ### Available test suites
 
-`smoke`, `input`, `button`, `canvas`, `drag`, `image`, `line_height`, `modal`, `multiline`, `popout`, `resize`, `scroll`, `scroll_x`, `shadow`, `viewport`
+`smoke`, `input`, `button`, `canvas`, `drag`, `image`, `line_height`, `modal`, `multiline`, `popout`, `resize`, `scroll`, `scroll_x`, `shadow`, `text_select`, `viewport`
 
 ## Memory leak detection
 

--- a/docs/core-api.md
+++ b/docs/core-api.md
@@ -445,6 +445,12 @@ Calls into Lua (`view.get-last-push`) to retrieve the last pushed frame.
 
 Path navigation: `/state/items.0.text` walks into the state table. Note: the `redin_get_state` global must be defined by the app for these endpoints to return data.
 
+### Selection
+
+| Method | Path          | Body | Response                                                                   |
+| ------ | ------------- | ---- | -------------------------------------------------------------------------- |
+| GET    | `/selection`  | --   | Current text/input selection: `{kind: none\|input\|text, start, end, text}` |
+
 ### Events
 
 | Method | Path      | Body          | Response        |

--- a/docs/reference/elements.md
+++ b/docs/reference/elements.md
@@ -83,6 +83,7 @@ Renders a string of text. The text content is the last positional argument, not 
 | Attribute | Type | Default | Notes |
 | --------- | ---- | ------- | ----- |
 | `wrap` | `"word"` \| `"char"` \| `"none"` | `"word"` | Line-wrapping strategy. |
+| `selectable` | boolean | `true` | Set to `false` to opt the node out of mouse-selection. |
 
 Typography (`font-size`, `weight`, `color`) comes from `aspect`.
 

--- a/docs/reference/theme.md
+++ b/docs/reference/theme.md
@@ -197,7 +197,7 @@ Validation is implemented in `src/runtime/theme.fnl`. Checks include:
 
 | Check | Rule |
 | ----- | ---- |
-| Color format | `bg`, `color`, `border`, `cursor`, `selection`, `placeholder`, `scrollbar` must be `[r g b]` or `[r g b a]` with channels 0--255 |
+| Color format | `bg`, `color`, `border`, `cursor`, `selection`, `placeholder`, `scrollbar` must be `[r g b]` or `[r g b a]` with channels 0--255. `:selection` controls the highlight color for both `:input` nodes (original consumer) and `:text` nodes (text selection, added in this release). |
 | Font type | `font` must be a string |
 | | `weight` must be `"normal"` or `"bold"` |
 | | `align` must be `"left"`, `"center"`, or `"right"` |

--- a/docs/superpowers/plans/2026-04-20-text-highlight.md
+++ b/docs/superpowers/plans/2026-04-20-text-highlight.md
@@ -1,0 +1,1552 @@
+# NodeText selection / highlight Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make plain `NodeText` selectable by mouse with the same highlight, click-drag, shift-click, double/triple-click and Ctrl-C behavior users expect from native text widgets. Read the spec at `docs/superpowers/specs/2026-04-20-text-highlight-design.md`.
+
+**Architecture:** Extend the existing singleton `input.state` with a `Selection_Kind` tag and a path-keyed anchor so selections survive view re-flattens. A new `input/text_select.odin` owns the mouse gesture state machine. `render.odin`'s existing input-selection rect block is factored into a shared helper and called for both `NodeInput` and `NodeText`. The `:selection` theme property (already declared but unread) gets plumbed end-to-end as the color source, defaulting to today's hardcoded blue when unset. A read-only `GET /selection` dev-server endpoint makes the UI tests assertable.
+
+**Tech Stack:** Odin (host), raylib (rendering + mouse/keyboard), LuaJIT (bridge), Fennel (test apps), Babashka (UI test harness).
+
+**Branch:** Work happens on `feat/text-highlight` (already checked out). All tasks land on this branch, final PR merges to `main`.
+
+---
+
+## File structure
+
+| File | Role | Action |
+|---|---|---|
+| `src/host/types/theme.odin` | `Theme` struct | **modify** — add `selection: [4]u8` |
+| `src/host/bridge/bridge.odin` | Lua → Theme parsing | **modify** — parse `selection` RGBA, add `lua_get_rgba_field` helper |
+| `src/host/parser/theme_parser.odin` | EDN → Theme parsing (test fixtures) | **modify** — parse `selection` key |
+| `src/host/parser/theme_parser_test.odin` | EDN theme parser tests | **modify** — add selection coverage |
+| `src/host/input/state.odin` | `Input_State` | **modify** — add `Selection_Kind`, `selection_kind`, `selection_path` |
+| `src/host/input/state_test.odin` | Selection-state unit tests | **create** |
+| `src/host/input/text_select.odin` | NodeText gesture + path resolver | **create** |
+| `src/host/input/text_select_test.odin` | Gesture unit tests | **create** |
+| `src/host/input/edit.odin` | `copy_selection`, `select_all` | **modify** — branch by kind |
+| `src/host/input/apply.odin` | Focus-enter side effects | **modify** — clear text selection when an input gains focus |
+| `src/host/input/input.odin` | Main input entrypoint + listener extraction | **modify** — emit `Text_Select_Listener`, drive gesture each frame, set I-beam cursor |
+| `src/host/types/listeners.odin` | Listener union | **modify** — add `Text_Select_Listener` |
+| `src/host/render.odin` | Selection rect rendering | **modify** — extract `draw_selection_rects`, call for both kinds, read theme color |
+| `src/host/bridge/devserver.odin` | Dev-server routing | **modify** — add `GET /selection` |
+| `test/ui/text_select_app.fnl` | UI test app | **create** |
+| `test/ui/test_text_select.bb` | UI test | **create** |
+| `docs/reference/theme.md` | Theme property reference | **modify** — note `:selection` now wired end-to-end |
+| `docs/reference/elements.md` | `:selectable` attribute | **modify** — document it on NodeText |
+| `.claude/skills/redin-dev/SKILL.md` | Skill theme + node list | **modify** — mention `:selectable`, `:selection` |
+
+---
+
+## Task 1: Add `selection` field to `Theme` struct and parse it (Lua + EDN paths)
+
+**Files:**
+- Modify: `src/host/types/theme.odin:10-23`
+- Modify: `src/host/bridge/bridge.odin:1150-1193` (`lua_to_theme`)
+- Create: `src/host/bridge/bridge.odin:1195-1210` (new `lua_get_rgba_field` near the existing `lua_get_rgb_field`)
+- Modify: `src/host/parser/theme_parser.odin` (EDN parser — grep for where `:color` is parsed, add `:selection` alongside)
+- Modify: `src/host/parser/theme_parser_test.odin`
+
+- [ ] **Step 1: Write the failing theme-parser test**
+
+Add to `src/host/parser/theme_parser_test.odin`:
+
+```odin
+@(test)
+test_parse_theme_selection :: proc(t: ^testing.T) {
+	input := `{:body {:selection [255 220 0 120]}}`
+	theme, ok := _parse_theme_string(input)
+	defer {
+		for k in theme do delete(k)
+		delete(theme)
+	}
+	testing.expect(t, ok, "parse should succeed")
+	body := theme["body"]
+	testing.expect_value(t, body.selection, [4]u8{255, 220, 0, 120})
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `odin test src/host/parser`
+Expected: `selection` field not declared on `types.Theme` → compile error.
+
+- [ ] **Step 3: Add `selection` field to `Theme` struct**
+
+In `src/host/types/theme.odin`, after `shadow:       Shadow,` add:
+
+```odin
+	selection:    [4]u8,   // RGBA; {0,0,0,0} = unset, use default
+```
+
+- [ ] **Step 4: Make the EDN parser populate it**
+
+In `src/host/parser/theme_parser.odin` find the block that reads `:color` into the Theme (grep for `"color"` and a 3-byte rgb parse). Right after the `color` case add a `selection` case that consumes a 4-element RGBA vector. (The parser already has 3-byte rgb and 4-byte shadow-color helpers; reuse the 4-byte path.)
+
+- [ ] **Step 5: Re-run the parser test**
+
+Run: `odin test src/host/parser`
+Expected: all 25 tests pass (24 existing + 1 new).
+
+- [ ] **Step 6: Add the Lua → Theme path**
+
+In `src/host/bridge/bridge.odin` add a new helper near `lua_get_rgb_field`:
+
+```odin
+lua_get_rgba_field :: proc(L: ^Lua_State, index: i32, field: cstring) -> [4]u8 {
+	lua_getfield(L, index, field)
+	defer lua_pop(L, 1)
+	if !lua_istable(L, -1) do return {}
+	abs := lua_gettop(L)
+	out: [4]u8
+	for i in 0 ..< 4 {
+		lua_rawgeti(L, abs, i32(i + 1))
+		out[i] = u8(lua_tonumber(L, -1))
+		lua_pop(L, 1)
+	}
+	return out
+}
+```
+
+Then inside `lua_to_theme`, right after `t.shadow = lua_get_shadow_field(...)`, add:
+
+```odin
+t.selection = lua_get_rgba_field(L, props_idx, "selection")
+```
+
+- [ ] **Step 7: Build + verify nothing broke**
+
+Run:
+```
+odin build src/host -out:build/redin
+odin test src/host/parser
+```
+Expected: clean build, 25 parser tests pass.
+
+- [ ] **Step 8: Commit**
+
+```
+git add src/host/types/theme.odin src/host/bridge/bridge.odin src/host/parser/theme_parser.odin src/host/parser/theme_parser_test.odin
+git commit -m "feat(theme): plumb :selection rgba property into Theme struct"
+```
+
+---
+
+## Task 2: Use themed selection color in `NodeInput` (no behavior change, just replace the hardcoded constant)
+
+**Files:**
+- Modify: `src/host/render.odin:837` (the hardcoded constant) and the block at 919–933 that references it
+
+- [ ] **Step 1: Read the existing block**
+
+Open `src/host/render.odin` and locate (near line 837):
+
+```odin
+selection_color := rl.Color{51, 153, 255, 100}
+```
+
+and the rendering block (near 919–933) which references `selection_color`.
+
+- [ ] **Step 2: Replace with theme lookup + fallback**
+
+Replace the `selection_color := ...` line with:
+
+```odin
+// Theme selection color; fall back to the legacy blue when unset.
+selection_color := rl.Color{51, 153, 255, 100}
+if len(n.aspect) > 0 {
+	if aspect, ok := theme[n.aspect]; ok {
+		if aspect.selection != ([4]u8{}) {
+			selection_color = rl.Color{
+				aspect.selection[0], aspect.selection[1],
+				aspect.selection[2], aspect.selection[3],
+			}
+		}
+	}
+}
+```
+
+(`n` here is the bound `NodeInput`; `theme` is already in scope — check the function signature; it's passed through `draw_input`.)
+
+- [ ] **Step 3: Build**
+
+Run: `odin build src/host -out:build/redin`
+Expected: clean.
+
+- [ ] **Step 4: Regression UI test**
+
+```
+bash test/ui/run-all.sh 2>&1 | grep -E "^Running:|^Results:|test suite"
+```
+Expected: all suites report `0 failed`. `test_input` in particular must still pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/host/render.odin
+git commit -m "feat(render): source NodeInput selection color from theme :selection"
+```
+
+---
+
+## Task 3: Extract `draw_selection_rects` helper (prep for NodeText reuse)
+
+**Files:**
+- Modify: `src/host/render.odin` (extract the existing multi-line rect code into a reusable proc)
+
+- [ ] **Step 1: Read the existing rendering block**
+
+Locate the block (currently ~lines 919–933) that iterates wrapped lines and emits `DrawRectangleRec` for each line segment.
+
+- [ ] **Step 2: Extract a helper**
+
+Add (near the other `draw_*` helpers in `render.odin`):
+
+```odin
+// Draw one selection rect per wrapped line, clipping the [lo, hi) byte range
+// against each line's byte span. rect is the text node's content rect (pre-
+// scrolled). Assumes `lines` are the result of text_pkg.compute_lines for the
+// same text + width.
+draw_selection_rects :: proc(
+	lines: []text_pkg.Text_Line,
+	text: string,
+	lo, hi: int,
+	font_obj: rl.Font,
+	font_size, spacing, line_height: f32,
+	rect: rl.Rectangle,
+	color: rl.Color,
+) {
+	if lo >= hi do return
+	for line, i in lines {
+		line_lo := max(lo, line.start)
+		line_hi := min(hi, line.end)
+		if line_lo >= line_hi do continue
+		x0 := text_pkg.measure_range(text, line.start, line_lo, font_obj, font_size, spacing)
+		x1 := text_pkg.measure_range(text, line.start, line_hi, font_obj, font_size, spacing)
+		y := rect.y + f32(i) * line_height
+		rl.DrawRectangleRec(rl.Rectangle{rect.x + x0, y, x1 - x0, line_height}, color)
+	}
+}
+```
+
+- [ ] **Step 3: Replace the inlined block with a call to the helper**
+
+In the `NodeInput` draw path, replace the existing for-loop over lines with:
+
+```odin
+draw_selection_rects(lines, text, lo, hi, font_obj, font_size, spacing, lh, content_rect, selection_color)
+```
+
+(Variable names come from the surrounding code — match them.)
+
+- [ ] **Step 4: Build + regression**
+
+```
+odin build src/host -out:build/redin
+bash test/ui/run-all.sh 2>&1 | grep -E "^Results:|test suite"
+```
+Expected: clean build; all existing UI suites pass; `test_input` visually unchanged.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/host/render.odin
+git commit -m "refactor(render): extract draw_selection_rects helper"
+```
+
+---
+
+## Task 4: Add `Selection_Kind` + `selection_path` to `Input_State`
+
+**Files:**
+- Modify: `src/host/input/state.odin`
+- Create: `src/host/input/state_test.odin`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `src/host/input/state_test.odin`:
+
+```odin
+package input
+
+import "core:testing"
+import "../types"
+
+@(test)
+test_set_text_selection_stores_path_copy :: proc(t: ^testing.T) {
+	state_init()
+	defer state_destroy()
+
+	// Caller-owned buffer; we expect state to copy it.
+	src := []u8{0x01, 0x02, 0x03, 0x04}
+	set_text_selection(src, 2, 5)
+
+	testing.expect_value(t, state.selection_kind, Selection_Kind.Text)
+	testing.expect_value(t, state.selection_start, 2)
+	testing.expect_value(t, state.selection_end, 5)
+	testing.expect_value(t, len(state.selection_path), 4)
+
+	// Mutate source — state should be unaffected.
+	src[0] = 0xFF
+	testing.expect_value(t, state.selection_path[0], u8(0x01))
+}
+
+@(test)
+test_clear_text_selection_frees_path :: proc(t: ^testing.T) {
+	state_init()
+	defer state_destroy()
+
+	src := []u8{0x10, 0x20}
+	set_text_selection(src, 0, 0)
+	clear_text_selection()
+
+	testing.expect_value(t, state.selection_kind, Selection_Kind.None)
+	testing.expect_value(t, len(state.selection_path), 0)
+}
+
+@(test)
+test_focus_enter_clears_text_selection :: proc(t: ^testing.T) {
+	state_init()
+	defer state_destroy()
+	set_text_selection([]u8{0xAA}, 0, 1)
+	focus_enter("buf")
+	testing.expect_value(t, state.selection_kind, Selection_Kind.None)
+	testing.expect_value(t, len(state.selection_path), 0)
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `odin test src/host/input`
+Expected: `Selection_Kind`, `set_text_selection`, `clear_text_selection` not defined.
+
+- [ ] **Step 3: Extend `Input_State`**
+
+In `src/host/input/state.odin`, replace the struct with:
+
+```odin
+Selection_Kind :: enum u8 { None, Input, Text }
+
+Input_State :: struct {
+	text:            [dynamic]u8,
+	cursor:          int,
+	selection_start: int,
+	selection_end:   int,
+	selection_kind:  Selection_Kind,
+	selection_path:  [dynamic]u8,   // owned copy of types.Path.value
+	scroll_offset_x: f32,
+	scroll_offset_y: f32,
+	last_dispatched: string,
+	active:          bool,
+}
+```
+
+- [ ] **Step 4: Initialize / clean up**
+
+In `state_init`:
+
+```odin
+state.selection_start = -1
+state.selection_end = -1
+state.selection_kind = .None
+```
+
+In `state_destroy`:
+
+```odin
+delete(state.text)
+delete(state.selection_path)
+if len(state.last_dispatched) > 0 {
+	delete(state.last_dispatched)
+}
+```
+
+- [ ] **Step 5: Add the new helpers to `state.odin`**
+
+```odin
+// Take ownership of a text-node selection.
+set_text_selection :: proc(path: []u8, lo, hi: int) {
+	clear(&state.selection_path)
+	append(&state.selection_path, ..path)
+	state.selection_kind = .Text
+	state.selection_start = lo
+	state.selection_end = hi
+}
+
+clear_text_selection :: proc() {
+	clear(&state.selection_path)
+	state.selection_kind = .None
+	state.selection_start = -1
+	state.selection_end = -1
+}
+
+// Convenience query used by copy / render.
+text_selection_path :: proc() -> []u8 {
+	return state.selection_path[:]
+}
+```
+
+- [ ] **Step 6: Update `focus_enter` to clear any text selection**
+
+In `focus_enter`, before `state.active = true`:
+
+```odin
+clear_text_selection()
+state.selection_kind = .Input
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `odin test src/host/input`
+Expected: 3 tests pass.
+
+- [ ] **Step 8: Rebuild host to catch struct-change fallout**
+
+Run: `odin build src/host -out:build/redin`
+Expected: clean.
+
+- [ ] **Step 9: Commit**
+
+```
+git add src/host/input/state.odin src/host/input/state_test.odin
+git commit -m "feat(input): add Selection_Kind + selection_path to Input_State"
+```
+
+---
+
+## Task 5: Branch `copy_selection` and `has_selection` by kind; keep `NodeInput` semantics
+
+**Files:**
+- Modify: `src/host/input/edit.odin` (`copy_selection`, `select_all`)
+- Modify: `src/host/input/state.odin` (`has_selection` — check kind)
+- Modify: `src/host/input/state_test.odin`
+
+- [ ] **Step 1: Add a failing test**
+
+Append to `src/host/input/state_test.odin`:
+
+```odin
+@(test)
+test_copy_selection_for_text_uses_node_content :: proc(t: ^testing.T) {
+	state_init()
+	defer state_destroy()
+
+	// Pretend the resolver ran and exposed node content via an input parameter.
+	set_text_selection([]u8{0x01}, 3, 8)
+	got := copy_selection_source_text("the quick brown fox")
+	testing.expect_value(t, got, " qui")
+}
+```
+
+- [ ] **Step 2: Implement the source-text query in `edit.odin`**
+
+```odin
+// Returns the substring implied by the current selection, sourced either from
+// the edit buffer (Input kind) or the caller-supplied node content (Text kind).
+// Empty string when no selection is active.
+copy_selection_source_text :: proc(node_content: string) -> string {
+	if !has_selection() do return ""
+	lo, hi := selection_range()
+	switch state.selection_kind {
+	case .Input:
+		return string(state.text[lo:hi])
+	case .Text:
+		if hi > len(node_content) do hi = len(node_content)
+		if lo >= hi do return ""
+		return node_content[lo:hi]
+	case .None:
+		return ""
+	}
+	return ""
+}
+```
+
+- [ ] **Step 3: Branch `copy_selection` itself**
+
+Replace the body of `copy_selection`:
+
+```odin
+// Copy the active selection to the system clipboard.
+// Caller provides the read-only source for Text-kind selections.
+copy_selection :: proc(node_content_for_text: string = "") {
+	src := copy_selection_source_text(node_content_for_text)
+	if len(src) == 0 do return
+	cstr := strings.clone_to_cstring(src, context.temp_allocator)
+	rl.SetClipboardText(cstr)
+}
+```
+
+(Call sites in `edit.odin` that don't pass a value — e.g. inside `cut_selection` — default to `""`, which is fine because cut is only valid for `.Input` kind where the buffer is the source.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `odin test src/host/input`
+Expected: 4 pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/host/input/state.odin src/host/input/edit.odin src/host/input/state_test.odin
+git commit -m "feat(input): branch copy_selection by Selection_Kind"
+```
+
+---
+
+## Task 6: Add `Text_Select_Listener` and extract-selectable-texts
+
+**Files:**
+- Modify: `src/host/types/listeners.odin` (find with `grep -n "Listener :: union" src/host/types`)
+- Modify: `src/host/input/input.odin` (`extract_listeners`)
+
+- [ ] **Step 1: Find the Listener union**
+
+Run: `grep -n "Listener :: union\|ClickListener\|KeyListener" src/host/types/*.odin`
+
+- [ ] **Step 2: Add the new listener type**
+
+Next to `ClickListener` (or wherever node-indexed listeners live), add:
+
+```odin
+// Emitted for every NodeText whose :selectable attribute is not false.
+// Consumed by input/text_select.odin.
+Text_Select_Listener :: struct {
+	node_idx: int,
+}
+```
+
+And add `Text_Select_Listener,` to the `Listener :: union { … }` list.
+
+- [ ] **Step 3: Add the `:selectable` attribute to NodeText**
+
+Search: `grep -n "NodeText ::" src/host/types/view_tree.odin`. Add a `selectable: bool` field (default `false` will be the "selectable=false" case — we want default-on, so invert semantics: field name `selectable_off` or keep `selectable` default-true by having the parser default it).
+
+The cleanest path: add `not_selectable: bool` (zero-value = selectable, matches default-on behavior without initialization elsewhere).
+
+```odin
+NodeText :: struct {
+	// existing fields …
+	not_selectable: bool,
+}
+```
+
+- [ ] **Step 4: Parse `:selectable` in the bridge**
+
+Search: `grep -n "NodeText{" src/host/bridge/bridge.odin`. In the `:text` attribute parse block (look near the NodeText construction), add:
+
+```odin
+// default true (zero-value = selectable); only the explicit false flips it
+sel := lua_get_bool_field(L, attrs_idx, "selectable", true)
+txt.not_selectable = !sel
+```
+
+(If a `lua_get_bool_field` with default doesn't exist, follow the pattern of the nearby bool fields and write a local fallback.)
+
+- [ ] **Step 5: Emit the listener in `extract_listeners`**
+
+Search: `grep -n "extract_listeners" src/host/input/input.odin`. Inside the per-node loop, after the existing listener emissions for `NodeInput`, add a case for `NodeText`:
+
+```odin
+case types.NodeText:
+	if !n.not_selectable {
+		append(&listeners, types.Listener(types.Text_Select_Listener{node_idx = idx}))
+	}
+```
+
+- [ ] **Step 6: Build**
+
+Run: `odin build src/host -out:build/redin`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```
+git add src/host/types/ src/host/bridge/bridge.odin src/host/input/input.odin
+git commit -m "feat(input): add :selectable attr + Text_Select_Listener"
+```
+
+---
+
+## Task 7: `text_select.odin` skeleton — mouse-down starts a selection
+
+**Files:**
+- Create: `src/host/input/text_select.odin`
+- Modify: `src/host/input/input.odin` (call the new dispatcher each frame)
+
+- [ ] **Step 1: Create the module**
+
+```odin
+package input
+
+import rl "vendor:raylib"
+import "../types"
+import text_pkg "../text"
+import "../font"
+
+@(private)
+gesture: struct {
+	anchor_offset: int,
+	anchor_path:   [dynamic]u8,
+	click_count:   int,
+	last_click_t:  f64,
+	active_drag:   bool,
+}
+
+// Entry called from the input pipeline each frame, AFTER focus/drag have run
+// but BEFORE listener-based click dispatch fires.
+process_text_selection :: proc(
+	input_events: []types.InputEvent,
+	listeners: []types.Listener,
+	nodes: []types.Node,
+	paths: []types.Path,
+	node_rects: []rl.Rectangle,
+	theme: map[string]types.Theme,
+) {
+	mouse := rl.GetMousePosition()
+
+	// Phase A: new mouse-down on a selectable text
+	for event in input_events {
+		me, is_mouse := event.(types.MouseEvent)
+		if !is_mouse || me.button != .LEFT do continue
+		pt := rl.Vector2{me.x, me.y}
+
+		hit := false
+		for listener in listeners {
+			tl, ok := listener.(types.Text_Select_Listener)
+			if !ok do continue
+			if tl.node_idx >= len(node_rects) do continue
+			if !rl.CheckCollisionPointRec(pt, node_rects[tl.node_idx]) do continue
+
+			text_node, is_text := nodes[tl.node_idx].(types.NodeText)
+			if !is_text do continue
+
+			offset := node_byte_offset_at(text_node, node_rects[tl.node_idx], pt, theme)
+
+			// Copy path and record anchor.
+			clear(&gesture.anchor_path)
+			append(&gesture.anchor_path, ..paths[tl.node_idx].value[:paths[tl.node_idx].length])
+			gesture.anchor_offset = offset
+			gesture.active_drag = true
+
+			set_text_selection(gesture.anchor_path[:], offset, offset)
+			// Clear any input focus — mutual exclusion.
+			focused_idx = -1
+			state.active = false
+			hit = true
+			break
+		}
+
+		// Click-elsewhere-to-clear. If this mouse-down didn't land on
+		// selectable text AND didn't start an input focus (focus_enter
+		// handles that path), drop any existing text selection.
+		if !hit && state.selection_kind == .Text {
+			clear_text_selection()
+		}
+	}
+
+	// Phase B: drag extension (Task 8)
+	// Phase C: mouse-up (Task 8)
+	_ = mouse
+}
+
+// Map a point inside a NodeText's rect to a byte offset in its content.
+// Uses the wrapped-line layout + existing x_to_cursor_in_line helper.
+@(private)
+node_byte_offset_at :: proc(
+	n: types.NodeText,
+	rect: rl.Rectangle,
+	pt: rl.Vector2,
+	theme: map[string]types.Theme,
+) -> int {
+	if len(n.content) == 0 do return 0
+
+	font_size: f32 = 18
+	font_name := "sans"
+	font_weight: u8 = 0
+	lh_ratio: f32 = 0
+	if len(n.aspect) > 0 {
+		if t, ok := theme[n.aspect]; ok {
+			if t.font_size > 0 do font_size = f32(t.font_size)
+			if len(t.font) > 0 do font_name = t.font
+			font_weight = t.weight
+			lh_ratio = t.line_height
+		}
+	}
+	f := font.get(font_name, font.style_from_weight(font.Font_Weight(font_weight)))
+	spacing := max(font_size / 10, 1)
+	lh := text_pkg.line_height(font_size, lh_ratio)
+
+	lines := text_pkg.compute_lines(n.content, f, font_size, 0, rect.width)
+	defer delete(lines)
+
+	rel_y := pt.y - rect.y
+	line_idx := int(rel_y / lh)
+	if line_idx < 0 do line_idx = 0
+	if line_idx >= len(lines) do line_idx = len(lines) - 1
+	line := lines[line_idx]
+
+	return x_to_cursor_in_line(n.content, line, pt.x - rect.x, f, font_size, spacing)
+}
+
+// Exposed for tests.
+text_selection_anchor_path :: proc() -> []u8 {
+	return gesture.anchor_path[:]
+}
+```
+
+- [ ] **Step 2: Hook it into the main input pipeline**
+
+In `src/host/main.odin` (or wherever `input.apply_focus` / `input.process_drag` is called — check with `grep -n "process_drag\|apply_focus" src/host/main.odin`), add a call:
+
+```odin
+input.process_text_selection(input_events, listeners[:], b.nodes, b.paths, node_rects[:], b.theme)
+```
+
+right after the drag pass.
+
+- [ ] **Step 3: Build**
+
+Run: `odin build src/host -out:build/redin`
+Expected: clean.
+
+- [ ] **Step 4: Smoke test**
+
+Start the input test app, click into the window but NOT on an input:
+```
+./build/redin --dev test/ui/input_app.fnl &
+sleep 2
+curl -s -X POST http://localhost:$(cat .redin-port)/click -d '{"x":50,"y":50}'
+curl -s -X POST http://localhost:$(cat .redin-port)/shutdown
+```
+Expected: no crash. (No visual assertion yet — that comes with rendering in Task 9.)
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/host/input/text_select.odin src/host/main.odin
+git commit -m "feat(input): text_select gesture module with mouse-down handling"
+```
+
+---
+
+## Task 8: Drag extension + mouse-up in the gesture state machine
+
+**Files:**
+- Modify: `src/host/input/text_select.odin`
+
+- [ ] **Step 1: Add drag / release logic**
+
+Inside `process_text_selection`, after the Phase-A loop, add:
+
+```odin
+// Phase B: drag extension while LMB is held.
+if gesture.active_drag && rl.IsMouseButtonDown(.LEFT) {
+	// Find the node whose path matches our anchor.
+	idx := find_node_by_path(paths, gesture.anchor_path[:])
+	if idx < 0 || idx >= len(node_rects) {
+		// Node vanished — give up.
+		gesture.active_drag = false
+	} else {
+		text_node, is_text := nodes[idx].(types.NodeText)
+		if is_text {
+			rect := node_rects[idx]
+			offset := node_byte_offset_at(text_node, rect, mouse, theme)
+			state.selection_end = offset
+			if offset == gesture.anchor_offset {
+				state.selection_start = -1
+				state.selection_end = -1
+			} else {
+				state.selection_start = gesture.anchor_offset
+			}
+		}
+	}
+}
+
+// Phase C: mouse released — stop tracking drags.
+if gesture.active_drag && !rl.IsMouseButtonDown(.LEFT) {
+	gesture.active_drag = false
+}
+```
+
+- [ ] **Step 2: Add the path resolver**
+
+Still in `text_select.odin`:
+
+```odin
+// Find the node whose path value equals `p`. Returns -1 if not found.
+// (Intentionally exported — devserver's /selection handler reuses it.)
+find_node_by_path :: proc(paths: []types.Path, p: []u8) -> int {
+	for i in 0 ..< len(paths) {
+		if int(paths[i].length) != len(p) do continue
+		match := true
+		for j in 0 ..< len(p) {
+			if paths[i].value[j] != p[j] {
+				match = false
+				break
+			}
+		}
+		if match do return i
+	}
+	return -1
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `odin build src/host -out:build/redin`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/host/input/text_select.odin
+git commit -m "feat(input): drag-extend + release in text selection"
+```
+
+---
+
+## Task 9: Render `NodeText` selection rects + read theme `:selection`
+
+**Files:**
+- Modify: `src/host/render.odin` (text draw path; resolve selection by path, call `draw_selection_rects`)
+
+- [ ] **Step 1: Locate `draw_text` / the NodeText draw branch**
+
+Run: `grep -n "NodeText\|draw_text" src/host/render.odin | head`.
+
+- [ ] **Step 2: In the NodeText draw block, add selection rendering before glyphs**
+
+Just before the glyph loop (so the rect is under the text), add:
+
+```odin
+if input.state.selection_kind == .Text {
+	// Compare stored path to this node's path.
+	if paths[idx].length > 0 &&
+	   int(paths[idx].length) == len(input.state.selection_path) {
+		match := true
+		for j in 0 ..< int(paths[idx].length) {
+			if paths[idx].value[j] != input.state.selection_path[j] {
+				match = false
+				break
+			}
+		}
+		if match && input.has_selection() {
+			lo, hi := input.selection_range()
+			if hi > len(n.content) do hi = len(n.content)
+
+			sel_color := rl.Color{51, 153, 255, 100}
+			if len(n.aspect) > 0 {
+				if aspect, ok := theme[n.aspect]; ok {
+					if aspect.selection != ([4]u8{}) {
+						sel_color = rl.Color{
+							aspect.selection[0], aspect.selection[1],
+							aspect.selection[2], aspect.selection[3],
+						}
+					}
+				}
+			}
+			draw_selection_rects(
+				lines, n.content, lo, hi,
+				font_obj, font_size, spacing, lh,
+				content_rect, sel_color,
+			)
+		}
+	}
+}
+```
+
+(Use the variable names that already exist in the surrounding draw block — `lines`, `n`, `content_rect`, `font_obj`, `font_size`, `spacing`, `lh`.)
+
+- [ ] **Step 3: Build**
+
+Run: `odin build src/host -out:build/redin`
+Expected: clean.
+
+- [ ] **Step 4: Manual smoke**
+
+```
+./build/redin --dev test/ui/multiline_app.fnl &
+sleep 2
+# Click at the start of the text
+curl -s -X POST http://localhost:$(cat .redin-port)/click -d '{"x":100,"y":100}'
+curl -s http://localhost:$(cat .redin-port)/screenshot > /tmp/sel-smoke.png
+curl -s -X POST http://localhost:$(cat .redin-port)/shutdown
+```
+
+Open `/tmp/sel-smoke.png` — a zero-width selection won't render a rect, but the process must not crash.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/host/render.odin
+git commit -m "feat(render): draw selection rects for NodeText"
+```
+
+---
+
+## Task 10: Per-frame selection resolver — drop stale paths, clamp offsets
+
+**Files:**
+- Modify: `src/host/input/text_select.odin` (add `resolve_text_selection`)
+- Modify: `src/host/main.odin` (call it once per frame after bridge, before layout)
+
+- [ ] **Step 1: Add the resolver**
+
+In `src/host/input/text_select.odin`:
+
+```odin
+// Called once per frame after bridge updates `nodes` / `paths`.
+// If the selected path no longer resolves to a NodeText, or the content
+// has shrunk below selection_end, clear the selection.
+resolve_text_selection :: proc(paths: []types.Path, nodes: []types.Node) {
+	if state.selection_kind != .Text do return
+	idx := find_node_by_path(paths, state.selection_path[:])
+	if idx < 0 {
+		clear_text_selection()
+		return
+	}
+	text_node, is_text := nodes[idx].(types.NodeText)
+	if !is_text {
+		clear_text_selection()
+		return
+	}
+	if state.selection_end > len(text_node.content) {
+		clear_text_selection()
+	}
+}
+```
+
+- [ ] **Step 2: Call it from main**
+
+In `src/host/main.odin` after `bridge.render_tick(&b)` returns (right where the main loop learns about the latest frame), add:
+
+```odin
+input.resolve_text_selection(b.paths, b.nodes)
+```
+
+- [ ] **Step 3: Build**
+
+Run: `odin build src/host -out:build/redin`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/host/input/text_select.odin src/host/main.odin
+git commit -m "feat(input): per-frame resolver clears stale text selections"
+```
+
+---
+
+## Task 11: Double-click (word) + triple-click (line) + shift-click (extend)
+
+**Files:**
+- Modify: `src/host/input/text_select.odin`
+
+- [ ] **Step 1: Add click-count tracking in Phase A**
+
+Extend Phase A in `process_text_selection` (before calling `set_text_selection`):
+
+```odin
+now := rl.GetTime()
+if now - gesture.last_click_t < 0.4 && gesture.click_count > 0 {
+	gesture.click_count += 1
+	if gesture.click_count > 3 do gesture.click_count = 3
+} else {
+	gesture.click_count = 1
+}
+gesture.last_click_t = now
+```
+
+- [ ] **Step 2: Branch by click count**
+
+Replace the plain `set_text_selection(gesture.anchor_path[:], offset, offset)` with:
+
+```odin
+lo, hi := offset, offset
+switch gesture.click_count {
+case 2:
+	lo = prev_word(text_node.content[:], offset)
+	hi = next_word(text_node.content[:], offset)
+case 3:
+	// Expand to the whole wrapped line at `offset`.
+	lines := text_pkg.compute_lines(
+		text_node.content,
+		resolve_font(text_node, theme),
+		resolve_font_size(text_node, theme),
+		0, node_rects[tl.node_idx].width,
+	)
+	defer delete(lines)
+	idx, _ := text_pkg.cursor_to_line(lines, offset)
+	lo = lines[idx].start
+	hi = lines[idx].end
+}
+gesture.anchor_offset = lo
+set_text_selection(gesture.anchor_path[:], lo, hi)
+```
+
+Write two small private helpers (`resolve_font`, `resolve_font_size`) at the bottom of the file — factored from `node_byte_offset_at`:
+
+```odin
+@(private)
+resolve_font :: proc(n: types.NodeText, theme: map[string]types.Theme) -> rl.Font {
+	font_name := "sans"
+	font_weight: u8 = 0
+	if len(n.aspect) > 0 {
+		if t, ok := theme[n.aspect]; ok {
+			if len(t.font) > 0 do font_name = t.font
+			font_weight = t.weight
+		}
+	}
+	return font.get(font_name, font.style_from_weight(font.Font_Weight(font_weight)))
+}
+
+@(private)
+resolve_font_size :: proc(n: types.NodeText, theme: map[string]types.Theme) -> f32 {
+	if len(n.aspect) > 0 {
+		if t, ok := theme[n.aspect]; ok {
+			if t.font_size > 0 do return f32(t.font_size)
+		}
+	}
+	return 18
+}
+```
+
+(Refactor `node_byte_offset_at` to call these instead of duplicating the resolution logic.)
+
+- [ ] **Step 3: Shift-click extension**
+
+Still in Phase A, before the click-count block, read the mouse-event mods:
+
+```odin
+if me.mods.shift && state.selection_kind == .Text {
+	// Extend existing selection to the new offset.
+	idx := find_node_by_path(paths, gesture.anchor_path[:])
+	if idx == tl.node_idx {
+		state.selection_end = offset
+		gesture.active_drag = true
+		return
+	}
+}
+```
+
+- [ ] **Step 4: Build + manual smoke**
+
+```
+odin build src/host -out:build/redin
+./build/redin --dev test/ui/multiline_app.fnl &
+sleep 2
+# (visual check via screenshot if desired)
+curl -s -X POST http://localhost:$(cat .redin-port)/shutdown
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/host/input/text_select.odin
+git commit -m "feat(input): word / line / shift-click selection gestures"
+```
+
+---
+
+## Task 12: Ctrl-A on active text selection + Ctrl-C copy
+
+**Files:**
+- Modify: `src/host/input/edit.odin` (`select_all`)
+- Modify: `src/host/input/input.odin` (keyboard dispatch when text selection is active)
+
+- [ ] **Step 1: Extend `select_all`**
+
+Replace the existing `select_all` body:
+
+```odin
+select_all :: proc(text_node_content: string = "") {
+	switch state.selection_kind {
+	case .Input:
+		state.selection_start = 0
+		state.selection_end = len(state.text)
+		state.cursor = len(state.text)
+	case .Text:
+		if len(text_node_content) == 0 do return
+		state.selection_start = 0
+		state.selection_end = len(text_node_content)
+	case .None:
+	}
+}
+```
+
+- [ ] **Step 2: Wire Ctrl-A / Ctrl-C when the kind is Text**
+
+In `src/host/input/input.odin` find the key-event dispatch path for Ctrl-A and Ctrl-C (grep for `copy_selection\|select_all`). Currently it only fires when an input is focused. Split into two paths: inputs use today's logic; when `state.selection_kind == .Text`, resolve the selected NodeText and pass its `content` in:
+
+```odin
+if state.selection_kind == .Text {
+	idx := find_node_by_path(b_paths, state.selection_path[:])
+	content := ""
+	if idx >= 0 {
+		if tn, ok := b_nodes[idx].(types.NodeText); ok do content = tn.content
+	}
+	if ke.mods.ctrl && ke.key == .A do select_all(content)
+	if ke.mods.ctrl && ke.key == .C do copy_selection(content)
+}
+```
+
+(Variable names depend on the surrounding context — keep them consistent with the caller.)
+
+- [ ] **Step 3: Build**
+
+Run: `odin build src/host -out:build/redin`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/host/input/edit.odin src/host/input/input.odin
+git commit -m "feat(input): Ctrl-A / Ctrl-C for NodeText selection"
+```
+
+---
+
+## Task 13: I-beam cursor on hover
+
+**Files:**
+- Modify: `src/host/input/input.odin` (one pass during input poll)
+
+- [ ] **Step 1: Add the cursor pass**
+
+After the listeners loop in the main input entry point, add:
+
+```odin
+set_hover_cursor :: proc(listeners: []types.Listener, node_rects: []rl.Rectangle) {
+	mouse := rl.GetMousePosition()
+	for listener in listeners {
+		tl, ok := listener.(types.Text_Select_Listener)
+		if !ok do continue
+		if tl.node_idx >= len(node_rects) do continue
+		if rl.CheckCollisionPointRec(mouse, node_rects[tl.node_idx]) {
+			rl.SetMouseCursor(.IBEAM)
+			return
+		}
+	}
+	rl.SetMouseCursor(.DEFAULT)
+}
+```
+
+Call it from the main loop (after `process_text_selection` returns):
+
+```odin
+input.set_hover_cursor(listeners[:], node_rects[:])
+```
+
+- [ ] **Step 2: Build + manual check**
+
+Run: `odin build src/host -out:build/redin && ./build/redin examples/kitchen-sink.fnl`
+Expected: cursor becomes an I-beam when hovering any text; default elsewhere.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/host/input/input.odin src/host/main.odin
+git commit -m "feat(input): I-beam cursor on selectable text hover"
+```
+
+---
+
+## Task 14: `GET /selection` dev-server endpoint
+
+**Files:**
+- Modify: `src/host/bridge/devserver.odin` (route + handler)
+
+- [ ] **Step 1: Add the route**
+
+Near the existing `GET /aspects` route (around line 364), add:
+
+```odin
+} else if req.path == "/selection" {
+	handle_get_selection(ds, ch)
+}
+```
+
+- [ ] **Step 2: Implement the handler**
+
+At the bottom of the GET handlers section:
+
+```odin
+handle_get_selection :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
+	b := strings.builder_make()
+	defer strings.builder_destroy(&b)
+	kind := input.state.selection_kind
+	switch kind {
+	case .None:
+		fmt.sbprintf(&b, `{{"kind":"none"}}`)
+	case .Input:
+		if !input.has_selection() {
+			fmt.sbprintf(&b, `{{"kind":"none"}}`)
+		} else {
+			lo, hi := input.selection_range()
+			text := input.copy_selection_source_text("")
+			fmt.sbprintf(&b, `{{"kind":"input","start":%d,"end":%d,"text":%q}}`, lo, hi, text)
+		}
+	case .Text:
+		if !input.has_selection() {
+			fmt.sbprintf(&b, `{{"kind":"none"}}`)
+		} else {
+			lo, hi := input.selection_range()
+			// Resolve path to find the node content.
+			idx := -1
+			for i in 0 ..< len(ds.bridge.paths) {
+				p := ds.bridge.paths[i]
+				if int(p.length) != len(input.state.selection_path) do continue
+				match := true
+				for j in 0 ..< int(p.length) {
+					if p.value[j] != input.state.selection_path[j] {
+						match = false; break
+					}
+				}
+				if match { idx = i; break }
+			}
+			content := ""
+			if idx >= 0 {
+				if tn, ok := ds.bridge.nodes[idx].(types.NodeText); ok {
+					content = tn.content
+				}
+			}
+			sub := ""
+			if hi <= len(content) { sub = content[lo:hi] }
+			fmt.sbprintf(&b, `{{"kind":"text","start":%d,"end":%d,"text":%q}}`, lo, hi, sub)
+		}
+	}
+	respond_json(ch, strings.to_string(b))
+}
+```
+
+(`input` import is already present in `devserver.odin` — if not, `import "../input"` and `import "../types"`.)
+
+- [ ] **Step 3: Build + smoke**
+
+```
+odin build src/host -out:build/redin
+./build/redin --dev examples/kitchen-sink.fnl &
+sleep 2
+curl -s http://localhost:$(cat .redin-port)/selection
+curl -s -X POST http://localhost:$(cat .redin-port)/shutdown
+```
+Expected: `{"kind":"none"}` (no selection yet).
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/host/bridge/devserver.odin
+git commit -m "feat(devserver): GET /selection endpoint"
+```
+
+---
+
+## Task 15: Tests — UI + Odin
+
+**Testability note.** `process_text_selection` reads the live mouse state via `rl.IsMouseButtonDown(.LEFT)` each frame (same pattern as `drag.odin`). Raylib's mouse state is not driven by the `MouseEvent` queue, so `POST /click` can't synthesize a *sustained* drag — it fires a single press event and the next frame sees the button as up. Therefore:
+
+- **UI test (Babashka + `/click`, `/selection`):** click-based paths only — single click sets a zero-width selection on the target node, double/triple-click rapid POSTs trigger word/line promotion via `rl.GetTime()`, opt-out suppresses the click effect, clicking an input clears a prior text selection, `GET /selection` returns the expected shape.
+- **Odin unit test (no raylib):** path-matching (`find_node_by_path`), per-frame resolver clear-on-disappear / clear-on-shrink, `select_all(.Text, content)` offset math, `copy_selection_source_text` for both kinds. These exercise the pure logic without driving a window.
+- **Drag extension + shift-click held-button path:** not covered automatically. Spot-check manually at the end (Task 16, Step 3). If future CI needs drag, a later change can add a synthetic-mouse mode gated behind `--dev`.
+
+**Files:**
+- Create: `src/host/input/text_select_test.odin`
+- Create: `test/ui/text_select_app.fnl`
+- Create: `test/ui/test_text_select.bb`
+
+- [ ] **Step 1: Write the Odin unit tests**
+
+Create `src/host/input/text_select_test.odin`:
+
+```odin
+package input
+
+import "core:testing"
+import "../types"
+
+@(test)
+test_find_node_by_path_returns_match :: proc(t: ^testing.T) {
+	p0 := [2]u8{0x01, 0x02}
+	p1 := [3]u8{0x0A, 0x0B, 0x0C}
+	paths := []types.Path{
+		{value = p0[:], length = 2},
+		{value = p1[:], length = 3},
+	}
+	testing.expect_value(t, find_node_by_path(paths, []u8{0x0A, 0x0B, 0x0C}), 1)
+	testing.expect_value(t, find_node_by_path(paths, []u8{0x01, 0x02}), 0)
+	testing.expect_value(t, find_node_by_path(paths, []u8{0xFF}), -1)
+}
+
+@(test)
+test_resolve_clears_when_path_missing :: proc(t: ^testing.T) {
+	state_init()
+	defer state_destroy()
+	set_text_selection([]u8{0xAA}, 0, 3)
+
+	empty: []types.Path
+	empty_nodes: []types.Node
+	resolve_text_selection(empty, empty_nodes)
+	testing.expect_value(t, state.selection_kind, Selection_Kind.None)
+}
+
+@(test)
+test_resolve_clears_when_content_shrinks :: proc(t: ^testing.T) {
+	state_init()
+	defer state_destroy()
+
+	p := [1]u8{0x01}
+	paths := []types.Path{{value = p[:], length = 1}}
+	nodes := []types.Node{types.NodeText{content = "hi"}}
+	set_text_selection([]u8{0x01}, 0, 5)  // 5 > len("hi") → stale
+	resolve_text_selection(paths, nodes)
+	testing.expect_value(t, state.selection_kind, Selection_Kind.None)
+}
+```
+
+Run: `odin test src/host/input`
+Expected: all input tests pass (the 4 from Task 4-5 plus these 3).
+
+- [ ] **Step 2: Write the app**
+
+`test/ui/text_select_app.fnl`:
+
+```fennel
+(local dataflow (require :dataflow))
+(local theme-mod (require :theme))
+
+(theme-mod.set-theme
+  {:surface {:bg [46 52 64] :padding [24 24 24 24]}
+   :body    {:font-size 16 :color [236 239 244]
+             :selection [255 220 0 120]}
+   :locked  {:font-size 16 :color [180 180 180]}
+   :input   {:bg [59 66 82] :color [236 239 244]
+             :border [76 86 106] :border-width 1
+             :radius 4 :padding [8 12 8 12] :font-size 14}})
+
+(dataflow.init {:input-value "preset"})
+(global redin_get_state (. dataflow :_get-raw-db))
+
+(reg-handler :event/input-change
+  (fn [db event]
+    (let [ctx (. event 2)]
+      (assoc db :input-value (or ctx.value "")))))
+
+(global main_view
+  (fn []
+    [:vbox {:aspect :surface :layout :top_left}
+     [:text {:aspect :body :id :para}
+      "the quick brown fox jumps over the lazy dog"]
+     [:text {:aspect :locked :id :locked-text :selectable false}
+      "this paragraph is not selectable"]
+     [:input {:aspect :input :id :probe-input :value (subscribe :input-value)
+              :change [:event/input-change]}]]))
+```
+
+- [ ] **Step 3: Write the UI tests**
+
+`test/ui/test_text_select.bb`:
+
+```clojure
+(require '[redin-test :refer :all]
+         '[cheshire.core :as json]
+         '[babashka.http-client :as http]
+         '[clojure.string :as str])
+
+(defn get-selection []
+  (let [port (str/trim (slurp ".redin-port"))
+        resp (http/get (str "http://localhost:" port "/selection") {:throw false})]
+    (when (= 200 (:status resp))
+      (json/parse-string (:body resp) true))))
+
+(defn rect-of [id]
+  (let [el (find-element {:id id})]
+    (when el (get-element-rect el))))   ; helper from redin-test — add if missing
+
+(defn click-at [x y]
+  (let [port (str/trim (slurp ".redin-port"))]
+    (http/post (str "http://localhost:" port "/click")
+               {:body (json/generate-string {:x x :y y})
+                :headers {"Content-Type" "application/json"}})))
+
+(deftest no-selection-initially
+  (let [sel (get-selection)]
+    (assert (= "none" (:kind sel)) (str "expected :none, got " (:kind sel)))))
+
+(deftest single-click-sets-zero-width-selection-on-selectable
+  (let [r (rect-of :para)]
+    (click-at (+ (:x r) 30) (+ (:y r) (/ (:height r) 2))))
+  (wait-for (fn [] (= "text" (:kind (get-selection)))) {:timeout 2000})
+  (let [sel (get-selection)]
+    (assert (= (:start sel) (:end sel))
+            "single click should produce an empty selection")))
+
+(deftest opt-out-has-no-text-selection
+  (let [r (rect-of :locked-text)]
+    (click-at (+ (:x r) 20) (+ (:y r) (/ (:height r) 2))))
+  (wait-ms 200)
+  ;; Either still none, or cleared because click-elsewhere-to-clear fired.
+  (assert (not= "text" (:kind (get-selection)))))
+
+(deftest clicking-input-clears-text-selection
+  (let [r (rect-of :para)]
+    (click-at (+ (:x r) 30) (+ (:y r) (/ (:height r) 2))))
+  (wait-for (fn [] (= "text" (:kind (get-selection)))) {:timeout 2000})
+  (let [ri (rect-of :probe-input)]
+    (click-at (+ (:x ri) 20) (+ (:y ri) (/ (:height ri) 2))))
+  (wait-ms 200)
+  (assert (not= "text" (:kind (get-selection)))))
+
+(deftest double-click-selects-word
+  (let [r (rect-of :para)
+        x (+ (:x r) 40)
+        y (+ (:y r) (/ (:height r) 2))]
+    (click-at x y)
+    (Thread/sleep 50)   ; well under 400ms double-click window
+    (click-at x y))
+  (wait-for (fn [] (and (= "text" (:kind (get-selection)))
+                        (< (:start (get-selection)) (:end (get-selection)))))
+            {:timeout 2000})
+  (let [sel (get-selection)]
+    (assert (re-find #"\w+" (:text sel)))
+    (assert (not (str/starts-with? (:text sel) " ")))
+    (assert (not (str/ends-with?   (:text sel) " ")))))
+
+(deftest triple-click-selects-line
+  (let [r (rect-of :para)
+        x (+ (:x r) 40)
+        y (+ (:y r) (/ (:height r) 2))]
+    (click-at x y) (Thread/sleep 50)
+    (click-at x y) (Thread/sleep 50)
+    (click-at x y))
+  (wait-for (fn [] (let [s (get-selection)]
+                     (and (= "text" (:kind s))
+                          (> (- (:end s) (:start s)) 10))))
+            {:timeout 2000})
+  (let [sel (get-selection)]
+    (assert (> (count (:text sel)) 10)
+            "triple-click should select at least the whole visual line")))
+```
+
+- [ ] **Step 4: Check `redin-test` helpers**
+
+Run: `grep -n "find-element\|get-element-rect" test/ui/redin_test.clj`.
+
+If `get-element-rect` doesn't exist, read a nearby existing helper and add it (it reads the element's `[x y w h]` from the frame, which `/frames` already exposes). Do not invent higher-level helpers — `click-at` is local to the test file because it does one thing.
+
+- [ ] **Step 5: Run the test**
+
+```
+./build/redin --dev test/ui/text_select_app.fnl &
+sleep 2
+bb test/ui/run.bb test/ui/test_text_select.bb
+curl -s -X POST http://localhost:$(cat .redin-port)/shutdown
+```
+Expected: 6/6 pass.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/host/input/text_select_test.odin test/ui/text_select_app.fnl test/ui/test_text_select.bb
+# + any redin_test.clj extension
+git commit -m "test: NodeText selection — Odin units + UI integration"
+```
+
+---
+
+## Task 16: Full regression sweep
+
+- [ ] **Step 1: Run every verification the redin-maintenance skill calls for**
+
+```
+odin build src/host -out:build/redin
+odin test src/host/profile
+odin test src/host/parser
+odin test src/host/input
+luajit test/lua/runner.lua test/lua/test_*.fnl
+bash test/ui/run-all.sh
+```
+Expected: builds clean; 4/4 profile, 25/25 parser, N/N input, 122/122 fennel, all UI suites 0-failed (minus the pre-existing `test_profile` quirk — it reports no results line under `run-all.sh` on main, standalone it passes).
+
+- [ ] **Step 2: Memory sanity**
+
+```
+./build/redin --dev --track-mem test/ui/text_select_app.fnl &
+sleep 2
+# Drive a few select/clear cycles via /click or /mouse
+curl -s -X POST http://localhost:$(cat .redin-port)/click -d '{"x":100,"y":100}'
+sleep 0.2
+curl -s -X POST http://localhost:$(cat .redin-port)/click -d '{"x":500,"y":500}'
+curl -s -X POST http://localhost:$(cat .redin-port)/shutdown
+```
+Expected: no `leak` / `outstanding` lines on shutdown stderr.
+
+- [ ] **Step 3: Visual spot check**
+
+```
+./build/redin --dev test/ui/multiline_app.fnl &
+sleep 2
+# drag-select a few lines
+curl -s http://localhost:$(cat .redin-port)/screenshot > /tmp/text-sel.png
+curl -s -X POST http://localhost:$(cat .redin-port)/shutdown
+```
+Inspect `/tmp/text-sel.png` — one rect per wrapped line, glyphs still render over the highlight, selection color is the themed color (if set).
+
+- [ ] **Step 4: Commit anything that moved (if anything)**
+
+Only if fixup edits were needed. Otherwise skip.
+
+---
+
+## Task 17: Docs + skill sync
+
+**Files:**
+- Modify: `docs/reference/theme.md` — note `:selection` is now fully wired (consumed by NodeInput + NodeText)
+- Modify: `docs/reference/elements.md` — add `:selectable` attribute to the NodeText section
+- Modify: `docs/core-api.md` — add `/selection` to the dev-server endpoint table
+- Modify: `.claude/skills/redin-dev/SKILL.md` — mention `:selectable` in the attribute list and `:selection` under theme
+- Leave `CLAUDE.md` as-is (no top-level convention change)
+- Modify: `.claude/skills/redin-maintenance/SKILL.md` — add `text_select` to the "Available test suites" list
+
+- [ ] **Step 1: Apply the edits**
+
+Concrete content for each is dictated by the surrounding style. Match the neighboring table rows.
+
+- [ ] **Step 2: Grep check**
+
+```
+rg -n 'selection_color|:selectable' docs/ .claude/skills/ CLAUDE.md
+```
+Expected: every code reference has a doc counterpart.
+
+- [ ] **Step 3: Commit**
+
+```
+git add docs/ .claude/skills/
+git commit -m "docs: NodeText selection — :selectable, :selection, /selection"
+```
+
+---
+
+## Task 18: Final PR
+
+- [ ] **Step 1: Push the branch**
+
+```
+git push -u origin feat/text-highlight
+```
+
+- [ ] **Step 2: Open PR**
+
+```
+gh pr create --title "feat: NodeText selection / highlight" --body "$(cat docs/superpowers/specs/2026-04-20-text-highlight-design.md | head -40)"
+```
+
+Include a test plan section listing every command from Task 16 and the results.
+
+- [ ] **Step 3: Self-review the diff**
+
+```
+gh pr diff | less
+```
+
+Walk the diff once. Confirm every file listed in the plan header table is touched, and nothing outside it.

--- a/docs/superpowers/specs/2026-04-20-text-highlight-design.md
+++ b/docs/superpowers/specs/2026-04-20-text-highlight-design.md
@@ -1,0 +1,184 @@
+# NodeText selection / highlight — design
+
+## Goal
+
+Make plain `NodeText` selectable with the mouse, matching native text-widget behavior. Copy-to-clipboard via `Ctrl-C`. No editing.
+
+Applies only to `NodeText` in v1. Cross-node selection (browser-style drag through multiple paragraphs) is out of scope. A single active selection exists across the whole app — either inside one `NodeInput` *or* inside one `NodeText*, never both.
+
+## Public surface
+
+### Attribute
+
+```fennel
+[:text {:selectable false} "…"]
+```
+
+`:selectable false` opts a text node out. No attribute = selectable (default-on). Applies only to `NodeText`.
+
+### Theme
+
+The `:selection` color property is already declared in `theme.fnl` and documented in `docs/reference/theme.md` but is not currently read by the Theme struct. This feature wires it up so that:
+
+```fennel
+{:body {:font-size 14 :color [40 40 40] :selection [255 220 0 120]}}
+```
+
+controls the selection highlight color for **both** `NodeInput` and `NodeText`. One knob, consistent look. Default when omitted: `[51 153 255 100]` — the color currently hardcoded in `render.odin`.
+
+### Events
+
+None. Selection is purely view-layer; apps do not observe it. `Ctrl-C` works without app involvement. If a future use case needs app-observable selection, a host function `redin.get_selection()` can be added then.
+
+### Mouse cursor
+
+I-beam (`rl.MouseCursor.IBEAM`) when hovering any selectable `NodeText`, otherwise default. Only set on transitions.
+
+### Interactions
+
+Standard text-widget mouse behavior. No keyboard focus or Tab order — all gestures originate from the mouse.
+
+- Click-drag: select a range.
+- Shift-click: extend the current selection to the click point.
+- Double-click: select the word under the click.
+- Triple-click: select the line (visual wrapped line) under the click.
+- `Ctrl-A`: with an active text selection, expand to the full content of the selected node. No-op when there is no selection.
+- `Ctrl-C`: copy selected text to clipboard.
+- Clicking elsewhere (in whitespace or into a different node) clears the selection.
+
+Out of scope for v1: `Shift+Arrow`, `Shift+Home/End`, auto-scroll when dragging past the viewport edge.
+
+## State model
+
+Extend the existing singleton `Input_State` in `src/host/input/state.odin`:
+
+```odin
+Selection_Kind :: enum { None, Input, Text }
+
+Input_State :: struct {
+    // existing fields: text, cursor, selection_start, selection_end,
+    // scroll_offset_x/y, active, last_dispatched
+    selection_kind: Selection_Kind,
+    selection_path: []u8           // owned copy of types.Path.value,  // owned copy; empty when kind != Text
+}
+```
+
+### Identity
+
+- `kind == Input`: `selection_path` is empty. Byte offsets index the edit buffer. Behavior unchanged from today.
+- `kind == Text`: `selection_path` pins a specific `NodeText` across re-flattens. Byte offsets index `nodes[resolved_idx].content`.
+
+`focused_idx` today is idx-based and hit-tested every frame. Text selection cannot rely on a continuous hit-test — it is set once on mouse-down and held until cleared. Therefore path-based identity is required.
+
+### Per-frame resolution
+
+Before render, `input.resolve_text_selection(paths, nodes)` walks `paths[]` once, finds the slot whose stored path equals `state.selection_path`, and checks that slot is a `NodeText` with `len(content) >= selection_end`. If not found or invalidated, clear the selection. Runs only when `kind == Text`. O(n_nodes) per frame, bounded and cheap in practice.
+
+### Mutual exclusion
+
+- `focus_enter` (NodeInput clicked): sets `kind = None`, frees `selection_path`.
+- `text_select_begin` (selectable NodeText clicked): sets `kind = Text`, sets `active = false`, stores a heap copy of the path.
+- `has_selection()` stays as-is (checks offsets, agnostic to kind).
+- `copy_selection()` branches on `kind` to source the substring from the right buffer.
+
+### Lifetime
+
+`selection_path` is heap-allocated when selection starts; freed when selection clears, when another selection replaces it, and in `state_destroy`.
+
+## Gesture detection
+
+New file: `src/host/input/text_select.odin`. Owns the click/drag state machine for selectable text. Mirrors how `edit.odin` isolates input-specific editing logic.
+
+File-local state (not part of `Input_State`):
+
+```odin
+gesture: struct {
+    anchor_offset: int,
+    anchor_path:   []u8,    // owned copy of types.Path.value
+    click_count:   int,   // 1 / 2 / 3; resets on timeout or node change
+    last_click_t:  f64,
+}
+```
+
+Entry points, called from the main `input` package on each frame (same layer that drives `apply.odin`):
+
+- `text_select_on_mouse_down(pt, shift, nodes, paths, node_rects, theme)` — hit-tests selectable `NodeText`, converts `pt` to a byte offset via existing `text_pkg.compute_lines` and `input.x_to_cursor_in_line`, then starts / extends / promotes to word / promotes to line.
+- `text_select_on_mouse_drag(pt, …)` — re-hits under the cursor, sets `state.selection_end`.
+- `text_select_on_mouse_up()` — no-op in v1.
+- `select_all` extended to check `kind == Text` and set offsets against node content length.
+
+## Rendering
+
+`render.odin` currently draws input-selection rects at lines 919–933. Refactor that block into a helper:
+
+```odin
+draw_selection_rects :: proc(lines: []Text_Line, lo, hi: int, rect: rl.Rectangle, color: rl.Color)
+```
+
+that iterates wrapped lines, clips the byte range to each line, and emits one `DrawRectangleRec` per line segment. Call it from two places:
+
+1. `NodeInput` path — `kind == Input && is_focused`. (Same behavior as today after refactor.)
+2. `NodeText` path — `kind == Text && resolved_text_idx == idx`. New.
+
+The helper gives multi-line selection for `NodeText` for free, which wrapped text requires.
+
+Selection color: resolve from theme via the new `:selection` property on the node's aspect. Fallback to current hardcoded default when unset.
+
+## Listener extraction
+
+Add a trivial `Text_Select_Listener { node_idx: int }` emitted by `input.extract_listeners` for every `NodeText` whose `selectable != false`. This gives the input package a pre-filtered candidate list for mouse events, matching how other listeners (click, hover, etc.) are structured, and avoids re-scanning all nodes during the mouse pipeline.
+
+## Dev server
+
+New endpoint for testability:
+
+```
+GET /selection
+```
+
+Response:
+
+```json
+{"kind":"text","text":"selected substring","start":12,"end":27,"path":[…]}
+{"kind":"input","text":"input buffer selected substring","start":3,"end":9}
+{"kind":"none"}
+```
+
+Read-only. No `PUT /selection`. Reusable for future inspection tools.
+
+## Edge cases
+
+| Case | Behavior |
+|---|---|
+| Re-flatten changes node idx | Path resolver finds new idx next frame; selection persists. |
+| Selected node deleted, or content shrinks below `selection_end` | Resolver clears selection on next frame. |
+| Drag past node bounds | Clamp offset to `[0, len(content)]`. No auto-scroll. |
+| Click inside `:overflow :scroll-y` | Text-select gesture wins when landing on selectable text; wheel still scrolls (different event). |
+| `:overflow :scroll-x` on text | Selection rects honor the existing per-node horizontal scroll offset. |
+| Empty / whitespace-only content | Selectable but no visible rect. Harmless. |
+| Button label (`[:button {} "…"]`) | Not a `NodeText`; not selectable. No conflict. |
+| `Ctrl-A` with no active text selection | No-op for text. NodeInput behavior unchanged. |
+| `Ctrl-A` during text selection | Expand to full node content. |
+| Hotreload mid-selection | Path resolver clears if node is gone. |
+
+## Testing
+
+1. **`GET /selection` endpoint.** Required to make the UI test assertable.
+2. **UI test** — `test/ui/text_select_app.fnl` + `test/ui/test_text_select.bb`:
+   - Drag selects a range; `GET /selection` confirms substring.
+   - `:selectable false` — drag produces no selection.
+   - Shift-click extends.
+   - Double-click selects word; triple-click selects line.
+   - Mutual exclusion: starting a text selection after an input selection clears the input's; clicking an input clears a text selection.
+   - `Ctrl-C` (injected key event) writes to clipboard — asserted via clipboard readback.
+3. **Visual check.** Screenshot mid-drag; rects must align with glyphs. Screenshot a multi-line selection; one rect per wrapped line.
+4. **Memory.** `--track-mem` across repeated select / clear / re-select — `selection_path` heap allocations must balance.
+5. **Regression.** Existing `test_input`, `test_multiline`, `test_scroll`, `test_smoke` must still pass. The render-side refactor (extracting `draw_selection_rects`) keeps `NodeInput` visually identical.
+
+## Out of scope
+
+- Cross-node selection.
+- Keyboard-driven selection in `NodeText` (`Shift+Arrow`, `Shift+Home/End`).
+- Auto-scroll when dragging past a scroll container's viewport.
+- App-observable selection events / host function.
+- Per-node selection color overriding the aspect's theme `:selection`.

--- a/src/host/bridge/bridge.odin
+++ b/src/host/bridge/bridge.odin
@@ -1173,6 +1173,7 @@ lua_to_theme :: proc(L: ^Lua_State, index: i32) -> map[string]types.Theme {
 			t.font = lua_get_string_field(L, props_idx, "font")
 			t.opacity = lua_get_number_field(L, props_idx, "opacity")
 			t.shadow = lua_get_shadow_field(L, props_idx, "shadow")
+			t.selection = lua_get_rgba_field(L, props_idx, "selection")
 
 			lua_getfield(L, props_idx, "weight")
 			if lua_isnumber(L, -1) {
@@ -1190,6 +1191,20 @@ lua_to_theme :: proc(L: ^Lua_State, index: i32) -> map[string]types.Theme {
 	}
 
 	return theme
+}
+
+lua_get_rgba_field :: proc(L: ^Lua_State, index: i32, field: cstring) -> [4]u8 {
+	lua_getfield(L, index, field)
+	defer lua_pop(L, 1)
+	if !lua_istable(L, -1) do return {}
+	abs := lua_gettop(L)
+	out: [4]u8
+	for i in 0 ..< 4 {
+		lua_rawgeti(L, abs, i32(i + 1))
+		out[i] = u8(lua_tonumber(L, -1))
+		lua_pop(L, 1)
+	}
+	return out
 }
 
 lua_get_rgb_field :: proc(L: ^Lua_State, index: i32, field: cstring) -> [3]u8 {

--- a/src/host/bridge/bridge.odin
+++ b/src/host/bridge/bridge.odin
@@ -1068,6 +1068,10 @@ lua_read_node :: proc(L: ^Lua_State, tag: string, attrs_idx: i32, text_content: 
 				t.layout = parse_anchor(layout)
 			}
 			t.overflow = lua_get_string_field(L, attrs_idx, "overflow")
+			// :selectable defaults true; only an explicit false opts out.
+			if sel, exists := lua_get_bool_field_opt(L, attrs_idx, "selectable"); exists {
+				t.not_selectable = !sel
+			}
 		}
 		if len(text_content) > 0 do t.content = text_content
 		return t
@@ -1711,6 +1715,18 @@ lua_get_drag_drop :: proc(L: ^Lua_State, index: i32, field: cstring) -> (group: 
 	}
 
 	return
+}
+
+// Read an optional boolean field. Returns (value, true) when the field exists
+// and is a boolean, (false, false) otherwise. Callers use the existence flag to
+// distinguish "absent" from an explicit false.
+lua_get_bool_field_opt :: proc(L: ^Lua_State, index: i32, field: cstring) -> (value: bool, exists: bool) {
+	lua_getfield(L, index, field)
+	defer lua_pop(L, 1)
+	if lua_type(L, -1) == LUA_TBOOLEAN {
+		return lua_toboolean(L, -1) != 0, true
+	}
+	return false, false
 }
 
 key_to_string :: proc(key: rl.KeyboardKey) -> cstring {

--- a/src/host/bridge/devserver.odin
+++ b/src/host/bridge/devserver.odin
@@ -7,6 +7,7 @@ import "core:os"
 import "core:strings"
 import "core:sync"
 import "core:thread"
+import "../input"
 import "../profile"
 import "../types"
 import rl "vendor:raylib"
@@ -362,6 +363,8 @@ process_request :: proc(ds: ^Dev_Server, req: ^Pending_Request) {
 			handle_get_state_path(ds, ch, req.path[len("/state/"):])
 		} else if req.path == "/aspects" {
 			handle_get_aspects(ds, ch)
+		} else if req.path == "/selection" {
+			handle_get_selection(ds, ch)
 		} else if req.path == "/profile" {
 			handle_get_profile(ch)
 		} else if req.path == "/screenshot" {
@@ -578,6 +581,54 @@ handle_get_profile :: proc(ch: ^Response_Channel) {
 		strings.write_string(&b, `]}`)
 	}
 	strings.write_string(&b, `]}`)
+
+	respond_json(ch, strings.to_string(b))
+}
+
+handle_get_selection :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
+	b := strings.builder_make()
+	defer strings.builder_destroy(&b)
+
+	if !input.has_selection() || input.state.selection_kind == .None {
+		fmt.sbprintf(&b, `{{"kind":"none"}}`)
+		respond_json(ch, strings.to_string(b))
+		return
+	}
+
+	lo, hi := input.selection_range()
+
+	switch input.state.selection_kind {
+	case .None:
+		fmt.sbprintf(&b, `{{"kind":"none"}}`)
+
+	case .Input:
+		// Read buffer from state.text (UTF-8 bytes).
+		content := string(input.state.text[:])
+		clamped_hi := hi
+		if clamped_hi > len(content) do clamped_hi = len(content)
+		sub := ""
+		if lo < clamped_hi do sub = content[lo:clamped_hi]
+		fmt.sbprintf(&b,
+			`{{"kind":"input","start":%d,"end":%d,"text":%q}}`,
+			lo, clamped_hi, sub,
+		)
+
+	case .Text:
+		// Resolve the selected path back to a NodeText.
+		idx := input.find_node_by_path(ds.bridge.paths[:], input.state.selection_path[:])
+		content := ""
+		if idx >= 0 && idx < len(ds.bridge.nodes) {
+			if tn, ok := ds.bridge.nodes[idx].(types.NodeText); ok do content = tn.content
+		}
+		clamped_hi := hi
+		if clamped_hi > len(content) do clamped_hi = len(content)
+		sub := ""
+		if lo < clamped_hi do sub = content[lo:clamped_hi]
+		fmt.sbprintf(&b,
+			`{{"kind":"text","start":%d,"end":%d,"text":%q}}`,
+			lo, clamped_hi, sub,
+		)
+	}
 
 	respond_json(ch, strings.to_string(b))
 }

--- a/src/host/input/apply.odin
+++ b/src/host/input/apply.odin
@@ -36,7 +36,7 @@ apply_listeners :: proc(
 						append(&applied, types.ApplyEvents(types.ApplyActive{idx = l.node_idx}))
 					}
 				case types.HoverListener, types.KeyListener, types.ChangeListener,
-				     types.DragListener, types.DropListener:
+				     types.DragListener, types.DropListener, types.Text_Select_Listener:
 				}
 			}
 

--- a/src/host/input/edit.odin
+++ b/src/host/input/edit.odin
@@ -234,10 +234,27 @@ select_all :: proc() {
 
 // --- Clipboard ---
 
-copy_selection :: proc() {
-	if !has_selection() do return
+// Returns the substring implied by the active selection, branching by Selection_Kind.
+// node_content is used for .Text kind; ignored for .Input kind.
+copy_selection_source_text :: proc(node_content: string) -> string {
+	if !has_selection() do return ""
 	lo, hi := selection_range()
-	text := string(state.text[lo:hi])
+	switch state.selection_kind {
+	case .Input:
+		return string(state.text[lo:hi])
+	case .Text:
+		clamped_hi := min(hi, len(node_content))
+		if clamped_hi <= lo do return ""
+		return node_content[lo:clamped_hi]
+	case .None:
+		return ""
+	}
+	return ""
+}
+
+copy_selection :: proc(node_content_for_text: string = "") {
+	text := copy_selection_source_text(node_content_for_text)
+	if len(text) == 0 do return
 	cstr := strings.clone_to_cstring(text, context.temp_allocator)
 	rl.SetClipboardText(cstr)
 }

--- a/src/host/input/edit.odin
+++ b/src/host/input/edit.odin
@@ -226,10 +226,18 @@ move_end :: proc(shift: bool) {
 	}
 }
 
-select_all :: proc() {
-	state.selection_start = 0
-	state.selection_end = len(state.text)
-	state.cursor = len(state.text)
+select_all :: proc(text_node_content: string = "") {
+	switch state.selection_kind {
+	case .Input:
+		state.selection_start = 0
+		state.selection_end = len(state.text)
+		state.cursor = len(state.text)
+	case .Text:
+		if len(text_node_content) == 0 do return
+		state.selection_start = 0
+		state.selection_end = len(text_node_content)
+	case .None:
+	}
 }
 
 // --- Clipboard ---

--- a/src/host/input/input.odin
+++ b/src/host/input/input.odin
@@ -168,6 +168,7 @@ process_user_events :: proc(
 	user_events: []types.UserEvent,
 	input_events: []types.InputEvent,
 	nodes: []types.Node,
+	paths: []types.Path,
 	node_rects: []rl.Rectangle,
 	theme: map[string]types.Theme,
 ) -> [dynamic]types.Dispatch_Event {
@@ -182,6 +183,21 @@ process_user_events :: proc(
 				event_name  = btn.click,
 				context_ref = btn.click_ctx,
 			}))
+		}
+	}
+
+	// Text-kind selection: Ctrl-A / Ctrl-C against the resolved NodeText.
+	if state.selection_kind == .Text {
+		for event in input_events {
+			ke, ok := event.(types.KeyEvent)
+			if !ok do continue
+			idx := find_node_by_path(paths, state.selection_path[:])
+			content := ""
+			if idx >= 0 {
+				if tn, tn_ok := nodes[idx].(types.NodeText); tn_ok do content = tn.content
+			}
+			if ke.mods.ctrl && ke.key == .A do select_all(content)
+			if ke.mods.ctrl && ke.key == .C do copy_selection(content)
 		}
 	}
 

--- a/src/host/input/input.odin
+++ b/src/host/input/input.odin
@@ -395,3 +395,20 @@ key_to_string_input :: proc(key: rl.KeyboardKey) -> string {
 	case:            return "unknown"
 	}
 }
+
+// Set the system mouse cursor to I-beam while hovering a selectable text,
+// otherwise DEFAULT. Safe to call every frame; Raylib debounces redundant
+// sets internally.
+set_hover_cursor :: proc(listeners: []types.Listener, node_rects: []rl.Rectangle) {
+	mouse := rl.GetMousePosition()
+	for listener in listeners {
+		tl, ok := listener.(types.Text_Select_Listener)
+		if !ok do continue
+		if tl.node_idx >= len(node_rects) do continue
+		if rl.CheckCollisionPointRec(mouse, node_rects[tl.node_idx]) {
+			rl.SetMouseCursor(.IBEAM)
+			return
+		}
+	}
+	rl.SetMouseCursor(.DEFAULT)
+}

--- a/src/host/input/input.odin
+++ b/src/host/input/input.odin
@@ -53,6 +53,9 @@ extract_listeners :: proc(
 			}
 		case types.NodeText:
 			aspect = n.aspect
+			if !n.not_selectable {
+				append(&listeners, types.Listener(types.Text_Select_Listener{node_idx = idx}))
+			}
 		case types.NodeImage:
 			aspect = n.aspect
 		case types.NodePopout:

--- a/src/host/input/state.odin
+++ b/src/host/input/state.odin
@@ -22,6 +22,7 @@ Input_State :: struct {
 state: Input_State
 
 state_init :: proc() {
+	delete(state.selection_path)
 	state.selection_start = -1
 	state.selection_end = -1
 	state.selection_kind = .None
@@ -64,8 +65,11 @@ set_text_selection :: proc(path: []u8, lo, hi: int) {
 
 // Clears any text-node selection and frees the owned path storage.
 clear_text_selection :: proc() {
-	clear(&state.selection_path)
-	state.selection_kind = .None
+	delete(state.selection_path)
+	state.selection_path  = {}
+	state.selection_kind  = .None
+	state.selection_start = -1
+	state.selection_end   = -1
 }
 
 // Returns a view into the owned path slice (no allocation).

--- a/src/host/input/state.odin
+++ b/src/host/input/state.odin
@@ -1,5 +1,11 @@
 package input
 
+Selection_Kind :: enum u8 {
+	None,
+	Input,
+	Text,
+}
+
 Input_State :: struct {
 	text:            [dynamic]u8,
 	cursor:          int,    // byte offset
@@ -9,6 +15,8 @@ Input_State :: struct {
 	scroll_offset_y: f32,
 	last_dispatched: string,
 	active:          bool,
+	selection_kind:  Selection_Kind,
+	selection_path:  [dynamic]u8,  // owned copy of types.Path.value
 }
 
 state: Input_State
@@ -16,6 +24,7 @@ state: Input_State
 state_init :: proc() {
 	state.selection_start = -1
 	state.selection_end = -1
+	state.selection_kind = .None
 }
 
 state_destroy :: proc() {
@@ -23,10 +32,12 @@ state_destroy :: proc() {
 	if len(state.last_dispatched) > 0 {
 		delete(state.last_dispatched)
 	}
+	delete(state.selection_path)
 }
 
 // Called when an input gains focus. Copies the node's value into the editing buffer.
 focus_enter :: proc(value: string) {
+	clear_text_selection()
 	clear(&state.text)
 	append(&state.text, ..transmute([]u8)value)
 	state.cursor = len(state.text)
@@ -34,11 +45,32 @@ focus_enter :: proc(value: string) {
 	state.selection_end = -1
 	state.scroll_offset_x = 0
 	state.scroll_offset_y = 0
+	state.selection_kind = .Input
 	state.active = true
 	if len(state.last_dispatched) > 0 {
 		delete(state.last_dispatched)
 	}
 	state.last_dispatched = strings_clone(value)
+}
+
+// Sets a text-node selection (not an input field). Copies path into owned storage.
+set_text_selection :: proc(path: []u8, lo, hi: int) {
+	clear(&state.selection_path)
+	append(&state.selection_path, ..path)
+	state.selection_start = lo
+	state.selection_end   = hi
+	state.selection_kind  = .Text
+}
+
+// Clears any text-node selection and frees the owned path storage.
+clear_text_selection :: proc() {
+	clear(&state.selection_path)
+	state.selection_kind = .None
+}
+
+// Returns a view into the owned path slice (no allocation).
+text_selection_path :: proc() -> []u8 {
+	return state.selection_path[:]
 }
 
 // Called when the input loses focus.

--- a/src/host/input/state_test.odin
+++ b/src/host/input/state_test.odin
@@ -1,0 +1,43 @@
+package input
+
+import "core:testing"
+
+@(test)
+test_set_text_selection_stores_path_copy :: proc(t: ^testing.T) {
+	state_init()
+	defer state_destroy()
+
+	src := []u8{0x01, 0x02, 0x03, 0x04}
+	set_text_selection(src, 2, 5)
+
+	testing.expect_value(t, state.selection_kind, Selection_Kind.Text)
+	testing.expect_value(t, state.selection_start, 2)
+	testing.expect_value(t, state.selection_end, 5)
+	testing.expect_value(t, len(state.selection_path), 4)
+
+	src[0] = 0xFF
+	testing.expect_value(t, state.selection_path[0], u8(0x01))
+}
+
+@(test)
+test_clear_text_selection_frees_path :: proc(t: ^testing.T) {
+	state_init()
+	defer state_destroy()
+
+	src := []u8{0x10, 0x20}
+	set_text_selection(src, 0, 0)
+	clear_text_selection()
+
+	testing.expect_value(t, state.selection_kind, Selection_Kind.None)
+	testing.expect_value(t, len(state.selection_path), 0)
+}
+
+@(test)
+test_focus_enter_clears_text_selection :: proc(t: ^testing.T) {
+	state_init()
+	defer state_destroy()
+	set_text_selection([]u8{0xAA}, 0, 1)
+	focus_enter("buf")
+	testing.expect_value(t, state.selection_kind, Selection_Kind.Input)
+	testing.expect_value(t, len(state.selection_path), 0)
+}

--- a/src/host/input/state_test.odin
+++ b/src/host/input/state_test.odin
@@ -33,6 +33,16 @@ test_clear_text_selection_frees_path :: proc(t: ^testing.T) {
 }
 
 @(test)
+test_clear_text_selection_resets_has_selection :: proc(t: ^testing.T) {
+	state_init()
+	defer state_destroy()
+	set_text_selection([]u8{0x01}, 3, 7)
+	testing.expect(t, has_selection(), "should have selection after set")
+	clear_text_selection()
+	testing.expect(t, !has_selection(), "should not have selection after clear")
+}
+
+@(test)
 test_focus_enter_clears_text_selection :: proc(t: ^testing.T) {
 	state_init()
 	defer state_destroy()

--- a/src/host/input/state_test.odin
+++ b/src/host/input/state_test.odin
@@ -51,3 +51,41 @@ test_focus_enter_clears_text_selection :: proc(t: ^testing.T) {
 	testing.expect_value(t, state.selection_kind, Selection_Kind.Input)
 	testing.expect_value(t, len(state.selection_path), 0)
 }
+
+@(test)
+test_copy_selection_source_text_for_text_kind :: proc(t: ^testing.T) {
+	state_init()
+	defer state_destroy()
+	set_text_selection([]u8{0x01}, 4, 9)
+	got := copy_selection_source_text("the quick brown fox")
+	testing.expect_value(t, got, "quick")
+}
+
+@(test)
+test_copy_selection_source_text_for_input_kind :: proc(t: ^testing.T) {
+	state_init()
+	defer state_destroy()
+	focus_enter("hello world")
+	// focus_enter placed cursor at end; manually set a selection.
+	state.selection_start = 6
+	state.selection_end = 11
+	got := copy_selection_source_text("")
+	testing.expect_value(t, got, "world")
+}
+
+@(test)
+test_copy_selection_source_text_none_kind :: proc(t: ^testing.T) {
+	state_init()
+	defer state_destroy()
+	got := copy_selection_source_text("ignored")
+	testing.expect_value(t, got, "")
+}
+
+@(test)
+test_copy_selection_source_text_clamps_text_kind :: proc(t: ^testing.T) {
+	state_init()
+	defer state_destroy()
+	set_text_selection([]u8{0x01}, 2, 100)   // hi beyond content
+	got := copy_selection_source_text("hello")
+	testing.expect_value(t, got, "llo")
+}

--- a/src/host/input/text_select.odin
+++ b/src/host/input/text_select.odin
@@ -144,6 +144,26 @@ node_byte_offset_at :: proc(
 	return x_to_cursor_in_line(n.content, line, pt.x - rect.x, f, font_size, spacing)
 }
 
+// Called once per frame after bridge updates nodes / paths. If the stored
+// selection path no longer resolves to a NodeText, or if its content has
+// shrunk below selection_end, clear the selection. No-op when kind != .Text.
+resolve_text_selection :: proc(paths: []types.Path, nodes: []types.Node) {
+	if state.selection_kind != .Text do return
+	idx := find_node_by_path(paths, state.selection_path[:])
+	if idx < 0 {
+		clear_text_selection()
+		return
+	}
+	text_node, is_text := nodes[idx].(types.NodeText)
+	if !is_text {
+		clear_text_selection()
+		return
+	}
+	if state.selection_end > len(text_node.content) {
+		clear_text_selection()
+	}
+}
+
 // Find the node whose path value equals `p`. Returns -1 if not found.
 // Exported — also used by the per-frame resolver and the devserver's
 // /selection handler to look up the current text-selection node.

--- a/src/host/input/text_select.odin
+++ b/src/host/input/text_select.odin
@@ -73,7 +73,36 @@ process_text_selection :: proc(
 		}
 	}
 
-	// Phase B (drag) + Phase C (release) are Task 8.
+	// Phase B: drag extension while LMB is held.
+	if gesture.active_drag && rl.IsMouseButtonDown(.LEFT) {
+		idx := find_node_by_path(paths, gesture.anchor_path[:])
+		if idx < 0 || idx >= len(node_rects) {
+			gesture.active_drag = false
+		} else {
+			text_node, is_text := nodes[idx].(types.NodeText)
+			if is_text {
+				mouse := rl.GetMousePosition()
+				rect := node_rects[idx]
+				offset := node_byte_offset_at(text_node, rect, mouse, theme)
+				if offset == gesture.anchor_offset {
+					// Collapsed to a caret; drop the selection range.
+					state.selection_start = -1
+					state.selection_end = -1
+				} else if offset > gesture.anchor_offset {
+					state.selection_start = gesture.anchor_offset
+					state.selection_end = offset
+				} else {
+					state.selection_start = offset
+					state.selection_end = gesture.anchor_offset
+				}
+			}
+		}
+	}
+
+	// Phase C: mouse released — stop tracking drags.
+	if gesture.active_drag && !rl.IsMouseButtonDown(.LEFT) {
+		gesture.active_drag = false
+	}
 }
 
 // Map a point inside a NodeText's rect to a byte offset in its content.
@@ -113,4 +142,22 @@ node_byte_offset_at :: proc(
 	line := lines[line_idx]
 
 	return x_to_cursor_in_line(n.content, line, pt.x - rect.x, f, font_size, spacing)
+}
+
+// Find the node whose path value equals `p`. Returns -1 if not found.
+// Exported — also used by the per-frame resolver and the devserver's
+// /selection handler to look up the current text-selection node.
+find_node_by_path :: proc(paths: []types.Path, p: []u8) -> int {
+	for i in 0 ..< len(paths) {
+		if int(paths[i].length) != len(p) do continue
+		match := true
+		for j in 0 ..< len(p) {
+			if paths[i].value[j] != p[j] {
+				match = false
+				break
+			}
+		}
+		if match do return i
+	}
+	return -1
 }

--- a/src/host/input/text_select.odin
+++ b/src/host/input/text_select.odin
@@ -46,13 +46,62 @@ process_text_selection :: proc(
 
 			offset := node_byte_offset_at(text_node, node_rects[tl.node_idx], pt, theme)
 
+			// Shift-click extends the existing selection to the new offset within
+			// the same node. The anchor remains at its original byte.
+			if me.mods.shift && state.selection_kind == .Text {
+				// Only extend if this click landed on the same node.
+				same_node := len(gesture.anchor_path) == int(paths[tl.node_idx].length)
+				if same_node {
+					for j in 0 ..< len(gesture.anchor_path) {
+						if gesture.anchor_path[j] != paths[tl.node_idx].value[j] {
+							same_node = false
+							break
+						}
+					}
+				}
+				if same_node {
+					state.selection_end = offset
+					gesture.active_drag = true
+					hit = true
+					break
+				}
+			}
+
+			// Track click cadence. Promotes on rapid re-click within the same node.
+			now := rl.GetTime()
+			if now - gesture.last_click_t < 0.4 && gesture.click_count > 0 {
+				gesture.click_count += 1
+				if gesture.click_count > 3 do gesture.click_count = 3
+			} else {
+				gesture.click_count = 1
+			}
+			gesture.last_click_t = now
+
 			clear(&gesture.anchor_path)
 			p := paths[tl.node_idx]
 			append(&gesture.anchor_path, ..p.value[:p.length])
-			gesture.anchor_offset = offset
 			gesture.active_drag = true
 
-			set_text_selection(gesture.anchor_path[:], offset, offset)
+			lo, hi := offset, offset
+			switch gesture.click_count {
+			case 2:
+				content_bytes := transmute([]u8)text_node.content
+				lo = prev_word(content_bytes, offset)
+				hi = next_word(content_bytes, offset)
+			case 3:
+				// Whole wrapped line at this offset.
+				f := resolve_font(text_node, theme)
+				fs := resolve_font_size(text_node, theme)
+				lines := text_pkg.compute_lines(text_node.content, f, fs, 0, node_rects[tl.node_idx].width)
+				defer delete(lines)
+				if len(lines) > 0 {
+					line_idx, _ := text_pkg.cursor_to_line(lines[:], offset)
+					lo = lines[line_idx].start
+					hi = lines[line_idx].end
+				}
+			}
+			gesture.anchor_offset = lo
+			set_text_selection(gesture.anchor_path[:], lo, hi)
 
 			// Clear input focus for mutual exclusion (focus_enter is not
 			// the code path here — apply_focus already ran for this event
@@ -116,20 +165,15 @@ node_byte_offset_at :: proc(
 ) -> int {
 	if len(n.content) == 0 do return 0
 
-	font_size: f32 = 18
-	font_name := "sans"
-	font_weight: u8 = 0
+	f := resolve_font(n, theme)
+	font_size := resolve_font_size(n, theme)
+	spacing: f32 = 0
 	lh_ratio: f32 = 0
 	if len(n.aspect) > 0 {
 		if t, ok := theme[n.aspect]; ok {
-			if t.font_size > 0 do font_size = f32(t.font_size)
-			if len(t.font) > 0 do font_name = t.font
-			font_weight = t.weight
 			lh_ratio = t.line_height
 		}
 	}
-	f := font.get(font_name, font.style_from_weight(font.Font_Weight(font_weight)))
-	spacing: f32 = 0
 	lh := text_pkg.line_height(font_size, lh_ratio)
 
 	lines := text_pkg.compute_lines(n.content, f, font_size, spacing, rect.width)
@@ -142,6 +186,29 @@ node_byte_offset_at :: proc(
 	line := lines[line_idx]
 
 	return x_to_cursor_in_line(n.content, line, pt.x - rect.x, f, font_size, spacing)
+}
+
+@(private)
+resolve_font :: proc(n: types.NodeText, theme: map[string]types.Theme) -> rl.Font {
+	font_name := "sans"
+	font_weight: u8 = 0
+	if len(n.aspect) > 0 {
+		if t, ok := theme[n.aspect]; ok {
+			if len(t.font) > 0 do font_name = t.font
+			font_weight = t.weight
+		}
+	}
+	return font.get(font_name, font.style_from_weight(font.Font_Weight(font_weight)))
+}
+
+@(private)
+resolve_font_size :: proc(n: types.NodeText, theme: map[string]types.Theme) -> f32 {
+	if len(n.aspect) > 0 {
+		if t, ok := theme[n.aspect]; ok {
+			if t.font_size > 0 do return f32(t.font_size)
+		}
+	}
+	return 18
 }
 
 // Called once per frame after bridge updates nodes / paths. If the stored

--- a/src/host/input/text_select.odin
+++ b/src/host/input/text_select.odin
@@ -1,0 +1,116 @@
+package input
+
+import rl "vendor:raylib"
+import "../types"
+import text_pkg "../text"
+import "../font"
+
+@(private)
+gesture: struct {
+	anchor_offset: int,
+	anchor_path:   [dynamic]u8,
+	click_count:   int,
+	last_click_t:  f64,
+	active_drag:   bool,
+}
+
+// Main entry point. Run once per frame after apply_focus / process_drag.
+process_text_selection :: proc(
+	input_events: []types.InputEvent,
+	listeners:    []types.Listener,
+	nodes:        []types.Node,
+	paths:        []types.Path,
+	node_rects:   []rl.Rectangle,
+	theme:        map[string]types.Theme,
+) {
+	// Phase A: fresh mouse-down. Scan events; for each LMB press, check
+	// whether it lands on a selectable NodeText. If yes, start a selection.
+	// If it lands on neither selectable text nor anything that would have
+	// been handled by focus-enter (inputs already handled by apply_focus,
+	// which clears text selection via focus_enter), clear any existing
+	// text selection.
+	for event in input_events {
+		me, is_mouse := event.(types.MouseEvent)
+		if !is_mouse || me.button != .LEFT do continue
+		pt := rl.Vector2{me.x, me.y}
+
+		hit := false
+		for listener in listeners {
+			tl, ok := listener.(types.Text_Select_Listener)
+			if !ok do continue
+			if tl.node_idx >= len(node_rects) do continue
+			if !rl.CheckCollisionPointRec(pt, node_rects[tl.node_idx]) do continue
+
+			text_node, is_text := nodes[tl.node_idx].(types.NodeText)
+			if !is_text do continue
+
+			offset := node_byte_offset_at(text_node, node_rects[tl.node_idx], pt, theme)
+
+			clear(&gesture.anchor_path)
+			p := paths[tl.node_idx]
+			append(&gesture.anchor_path, ..p.value[:p.length])
+			gesture.anchor_offset = offset
+			gesture.active_drag = true
+
+			set_text_selection(gesture.anchor_path[:], offset, offset)
+
+			// Clear input focus for mutual exclusion (focus_enter is not
+			// the code path here — apply_focus already ran for this event
+			// and did not match an input listener, but being defensive).
+			focused_idx = -1
+			state.active = false
+
+			hit = true
+			break
+		}
+
+		// Click-elsewhere-to-clear: mouse-down missed all selectable text.
+		// apply_focus will have already cleared for input clicks via
+		// focus_enter. For a click over nothing interesting, drop any
+		// existing text selection.
+		if !hit && state.selection_kind == .Text {
+			clear_text_selection()
+		}
+	}
+
+	// Phase B (drag) + Phase C (release) are Task 8.
+}
+
+// Map a point inside a NodeText's rect to a byte offset in its content.
+// Uses the same font/size resolution as render.
+@(private)
+node_byte_offset_at :: proc(
+	n: types.NodeText,
+	rect: rl.Rectangle,
+	pt: rl.Vector2,
+	theme: map[string]types.Theme,
+) -> int {
+	if len(n.content) == 0 do return 0
+
+	font_size: f32 = 18
+	font_name := "sans"
+	font_weight: u8 = 0
+	lh_ratio: f32 = 0
+	if len(n.aspect) > 0 {
+		if t, ok := theme[n.aspect]; ok {
+			if t.font_size > 0 do font_size = f32(t.font_size)
+			if len(t.font) > 0 do font_name = t.font
+			font_weight = t.weight
+			lh_ratio = t.line_height
+		}
+	}
+	f := font.get(font_name, font.style_from_weight(font.Font_Weight(font_weight)))
+	spacing := max(font_size / 10, 1)
+	lh := text_pkg.line_height(font_size, lh_ratio)
+
+	lines := text_pkg.compute_lines(n.content, f, font_size, spacing, rect.width)
+	defer delete(lines)
+
+	rel_y := pt.y - rect.y
+	line_idx := int(rel_y / lh)
+	if line_idx < 0 do line_idx = 0
+	if line_idx >= len(lines) do line_idx = len(lines) - 1
+	line := lines[line_idx]
+
+	return x_to_cursor_in_line(n.content, line, pt.x - rect.x, f, font_size, spacing)
+}

--- a/src/host/input/text_select.odin
+++ b/src/host/input/text_select.odin
@@ -100,7 +100,7 @@ node_byte_offset_at :: proc(
 		}
 	}
 	f := font.get(font_name, font.style_from_weight(font.Font_Weight(font_weight)))
-	spacing := max(font_size / 10, 1)
+	spacing: f32 = 0
 	lh := text_pkg.line_height(font_size, lh_ratio)
 
 	lines := text_pkg.compute_lines(n.content, f, font_size, spacing, rect.width)

--- a/src/host/input/text_select_test.odin
+++ b/src/host/input/text_select_test.odin
@@ -1,0 +1,42 @@
+package input
+
+import "core:testing"
+import "../types"
+
+@(test)
+test_find_node_by_path_returns_match :: proc(t: ^testing.T) {
+	p0 := [2]u8{0x01, 0x02}
+	p1 := [3]u8{0x0A, 0x0B, 0x0C}
+	paths := []types.Path{
+		{value = p0[:], length = 2},
+		{value = p1[:], length = 3},
+	}
+	testing.expect_value(t, find_node_by_path(paths, []u8{0x0A, 0x0B, 0x0C}), 1)
+	testing.expect_value(t, find_node_by_path(paths, []u8{0x01, 0x02}), 0)
+	testing.expect_value(t, find_node_by_path(paths, []u8{0xFF}), -1)
+}
+
+@(test)
+test_resolve_clears_when_path_missing :: proc(t: ^testing.T) {
+	state_init()
+	defer state_destroy()
+	set_text_selection([]u8{0xAA}, 0, 3)
+
+	empty_paths: []types.Path
+	empty_nodes: []types.Node
+	resolve_text_selection(empty_paths, empty_nodes)
+	testing.expect_value(t, state.selection_kind, Selection_Kind.None)
+}
+
+@(test)
+test_resolve_clears_when_content_shrinks :: proc(t: ^testing.T) {
+	state_init()
+	defer state_destroy()
+
+	p := [1]u8{0x01}
+	paths := []types.Path{{value = p[:], length = 1}}
+	nodes := []types.Node{types.NodeText{content = "hi"}}
+	set_text_selection([]u8{0x01}, 0, 5) // 5 > len("hi") → stale
+	resolve_text_selection(paths, nodes)
+	testing.expect_value(t, state.selection_kind, Selection_Kind.None)
+}

--- a/src/host/input/user_events.odin
+++ b/src/host/input/user_events.odin
@@ -54,7 +54,7 @@ get_user_events :: proc(
 						)
 					}
 				case types.HoverListener, types.KeyListener, types.ChangeListener,
-				     types.DragListener, types.DropListener:
+				     types.DragListener, types.DropListener, types.Text_Select_Listener:
 				}
 			}
 

--- a/src/host/main.odin
+++ b/src/host/main.odin
@@ -132,6 +132,8 @@ main :: proc() {
 			input_events[:], listeners[:], b.nodes[:], node_rects[:],
 		)
 		defer delete(drag_events)
+
+		input.process_text_selection(input_events[:], listeners[:], b.nodes[:], b.paths[:], node_rects[:], b.theme)
 		profile.end(s_input2a)
 
 		// --- Bridge: deliver drag events (Lua may mutate state before user events) ---

--- a/src/host/main.odin
+++ b/src/host/main.odin
@@ -144,7 +144,7 @@ main :: proc() {
 		// --- Input (3/4): user-event computation ---
 		s_input2b := profile.begin(.Input)
 		dispatch_events := input.process_user_events(
-			user_events[:], input_events[:], b.nodes[:], node_rects[:], b.theme,
+			user_events[:], input_events[:], b.nodes[:], b.paths[:], node_rects[:], b.theme,
 		)
 		defer delete(dispatch_events)
 		profile.end(s_input2b)

--- a/src/host/main.odin
+++ b/src/host/main.odin
@@ -166,6 +166,8 @@ main :: proc() {
 		layout_tree(b.theme, b.nodes[:], b.children_list[:])
 		profile.end(s_layout)
 
+		g_paths = b.paths[:]
+
 		s_render := profile.begin(.Render)
 		draw_tree(b.theme, b.nodes[:], b.children_list[:])
 		profile.end(s_render)

--- a/src/host/main.odin
+++ b/src/host/main.odin
@@ -134,6 +134,7 @@ main :: proc() {
 		defer delete(drag_events)
 
 		input.process_text_selection(input_events[:], listeners[:], b.nodes[:], b.paths[:], node_rects[:], b.theme)
+		input.set_hover_cursor(listeners[:], node_rects[:])
 		profile.end(s_input2a)
 
 		// --- Bridge: deliver drag events (Lua may mutate state before user events) ---

--- a/src/host/main.odin
+++ b/src/host/main.odin
@@ -166,6 +166,7 @@ main :: proc() {
 		layout_tree(b.theme, b.nodes[:], b.children_list[:])
 		profile.end(s_layout)
 
+		input.resolve_text_selection(b.paths[:], b.nodes[:])
 		g_paths = b.paths[:]
 
 		s_render := profile.begin(.Render)

--- a/src/host/parser/theme_parser.odin
+++ b/src/host/parser/theme_parser.odin
@@ -98,6 +98,8 @@ _parse_theme_props :: proc(p: ^_Parser) -> types.Theme {
 				}
 			case "opacity":
 				t.opacity = _read_number(p)
+			case "selection":
+				t.selection = _parse_rgba(p)
 			}
 		} else {
 			p.pos += 1
@@ -120,6 +122,25 @@ _parse_rgb :: proc(p: ^_Parser) -> [3]u8 {
 		_skip_ws(p)
 		if p.pos < len(p.text) && p.text[p.pos] == ']' do p.pos += 1
 		return {r, g, b}
+	}
+	return {}
+}
+
+_parse_rgba :: proc(p: ^_Parser) -> [4]u8 {
+	_skip_ws(p)
+	if p.pos < len(p.text) && p.text[p.pos] == '[' {
+		p.pos += 1
+		_skip_ws(p)
+		r := u8(_read_number(p))
+		_skip_ws(p)
+		g := u8(_read_number(p))
+		_skip_ws(p)
+		b := u8(_read_number(p))
+		_skip_ws(p)
+		a := u8(_read_number(p))
+		_skip_ws(p)
+		if p.pos < len(p.text) && p.text[p.pos] == ']' do p.pos += 1
+		return {r, g, b, a}
 	}
 	return {}
 }

--- a/src/host/parser/theme_parser_test.odin
+++ b/src/host/parser/theme_parser_test.odin
@@ -122,6 +122,19 @@ test_parse_theme_empty :: proc(t: ^testing.T) {
 	testing.expect_value(t, len(theme), 0)
 }
 
+@(test)
+test_parse_theme_selection :: proc(t: ^testing.T) {
+	input := `{:body {:selection [255 220 0 120]}}`
+	theme, ok := _parse_theme_string(input)
+	defer {
+		for k in theme do delete(k)
+		delete(theme)
+	}
+	testing.expect(t, ok, "parse should succeed")
+	body := theme["body"]
+	testing.expect_value(t, body.selection, [4]u8{255, 220, 0, 120})
+}
+
 // Helper: parse theme from string (wraps the file-based loader logic)
 _parse_theme_string :: proc(input: string) -> (map[string]types.Theme, bool) {
 	p := _Parser{text = input, pos = 0}

--- a/src/host/render.odin
+++ b/src/host/render.odin
@@ -37,6 +37,10 @@ node_rects: [dynamic]rl.Rectangle
 // clipping and to avoid recomputing padding.
 node_content_rects: [dynamic]rl.Rectangle
 
+// Per-frame: set by main to b.paths[:] before layout/draw runs so
+// render can match the selection path against this tree's paths.
+g_paths: []types.Path
+
 // Per-node scroll offsets for overflow containers.
 scroll_offsets: map[int]f32
 scroll_offsets_x: map[int]f32
@@ -1120,6 +1124,43 @@ draw_text :: proc(idx: int, rect: rl.Rectangle, n: types.NodeText, theme: map[st
 		y_offset = (rect.height - total_text_h) / 2
 	case .BOTTOM_LEFT, .BOTTOM_CENTER, .BOTTOM_RIGHT:
 		y_offset = rect.height - total_text_h
+	}
+
+	// Render text-selection highlight when this NodeText is the active target.
+	if input.state.selection_kind == .Text && idx < len(g_paths) {
+		this_path := g_paths[idx]
+		sel_path := input.state.selection_path
+		matches := int(this_path.length) == len(sel_path)
+		if matches {
+			for j in 0 ..< int(this_path.length) {
+				if this_path.value[j] != sel_path[j] {
+					matches = false
+					break
+				}
+			}
+		}
+		if matches && input.has_selection() {
+			lo, hi := input.selection_range()
+			if hi > len(n.content) do hi = len(n.content)
+			if lo < hi {
+				sel_color := rl.Color{51, 153, 255, 100}
+				if len(n.aspect) > 0 {
+					if aspect, ok := theme[n.aspect]; ok {
+						if aspect.selection != ([4]u8{}) {
+							sel_color = rl.Color{
+								aspect.selection[0], aspect.selection[1],
+								aspect.selection[2], aspect.selection[3],
+							}
+						}
+					}
+				}
+				draw_selection_rects(
+					lines[:], n.content, lo, hi,
+					f, font_size, spacing, lh,
+					rect, 0, sel_color,
+				)
+			}
+		}
 	}
 
 	for line, i in lines {

--- a/src/host/render.odin
+++ b/src/host/render.odin
@@ -834,7 +834,19 @@ draw_input :: proc(
 	bg_color := rl.Color{0, 0, 0, 0}
 	text_color := rl.WHITE
 	placeholder_color := rl.Color{128, 128, 128, 128}
+	// Theme selection color; fall back to the legacy blue when the aspect
+	// does not set :selection (sentinel is all-zero).
 	selection_color := rl.Color{51, 153, 255, 100}
+	if len(n.aspect) > 0 {
+		if aspect, ok := theme[n.aspect]; ok {
+			if aspect.selection != ([4]u8{}) {
+				selection_color = rl.Color{
+					aspect.selection[0], aspect.selection[1],
+					aspect.selection[2], aspect.selection[3],
+				}
+			}
+		}
+	}
 	font_size: f32 = 14
 	padding_l: f32 = 4
 	padding_r: f32 = 4

--- a/src/host/render.odin
+++ b/src/host/render.odin
@@ -822,6 +822,33 @@ draw_themed_rect :: proc(rect: rl.Rectangle, aspect: string, theme: map[string]t
 	}
 }
 
+// Draw one selection rect per wrapped line, clipping the [lo, hi) byte range
+// against each line's byte span. `rect` is the text content rect (top-left is
+// content_x/content_y). `scroll_y` is the vertical scroll offset in pixels.
+// `lines` must be from text_pkg.compute_lines for `text` at the same width.
+draw_selection_rects :: proc(
+	lines: []text_pkg.Text_Line,
+	text: string,
+	lo, hi: int,
+	font_obj: rl.Font,
+	font_size, spacing, line_height: f32,
+	rect: rl.Rectangle,
+	scroll_y: f32,
+	color: rl.Color,
+) {
+	if lo >= hi do return
+	for line, i in lines {
+		ly := rect.y + f32(i) * line_height - scroll_y
+		if ly + line_height < rect.y || ly > rect.y + rect.height do continue
+		line_lo := max(lo, line.start)
+		line_hi := min(hi, line.end)
+		if line_lo >= line_hi do continue
+		x0 := text_pkg.measure_range(text, line.start, line_lo, font_obj, font_size, spacing)
+		x1 := text_pkg.measure_range(text, line.start, line_hi, font_obj, font_size, spacing)
+		rl.DrawRectangleRec(rl.Rectangle{rect.x + x0, ly, x1 - x0, line_height}, color)
+	}
+}
+
 draw_input :: proc(
 	idx: int,
 	rect: rl.Rectangle,
@@ -931,19 +958,8 @@ draw_input :: proc(
 	// Draw selection highlight (behind text)
 	if is_focused && input.state.active && input.has_selection() {
 		lo, hi := input.selection_range()
-		for line, i in lines {
-			ly := content_y + f32(i) * lh - scroll_y
-			if ly + lh < content_y || ly > content_y + content_h do continue
-
-			sel_start := max(lo, line.start)
-			sel_end := min(hi, line.end)
-			if sel_start >= sel_end do continue
-
-			x0 := text_pkg.measure_range(display_text, line.start, sel_start, f, font_size, spacing)
-			x1 := text_pkg.measure_range(display_text, line.start, sel_end, f, font_size, spacing)
-			sel_rect := rl.Rectangle{content_x + x0, ly, x1 - x0, lh}
-			rl.DrawRectangleRec(sel_rect, selection_color)
-		}
+		content_rect := rl.Rectangle{content_x, content_y, content_w, content_h}
+		draw_selection_rects(lines[:], display_text, lo, hi, f, font_size, spacing, lh, content_rect, scroll_y, selection_color)
 	}
 
 	// Draw text lines

--- a/src/host/types/listener_events.odin
+++ b/src/host/types/listener_events.odin
@@ -32,6 +32,12 @@ DropListener :: struct {
 	group:    string,
 }
 
+// Emitted for every NodeText whose :selectable attribute is not false.
+// Consumed by input/text_select.odin.
+Text_Select_Listener :: struct {
+	node_idx: int,
+}
+
 Listener :: union {
 	HoverListener,
 	FocusListener,
@@ -40,4 +46,5 @@ Listener :: union {
 	ChangeListener,
 	DragListener,
 	DropListener,
+	Text_Select_Listener,
 }

--- a/src/host/types/listener_events.odin
+++ b/src/host/types/listener_events.odin
@@ -33,7 +33,8 @@ DropListener :: struct {
 }
 
 // Emitted for every NodeText whose :selectable attribute is not false.
-// Consumed by input/text_select.odin.
+// Consumed by the text-selection gesture module (input/text_select.odin,
+// added in a follow-up commit).
 Text_Select_Listener :: struct {
 	node_idx: int,
 }

--- a/src/host/types/theme.odin
+++ b/src/host/types/theme.odin
@@ -20,4 +20,5 @@ Theme :: struct {
 	font:         string,
 	opacity:      f32,
 	shadow:       Shadow,
+	selection:    [4]u8,   // RGBA; {0,0,0,0} = unset, use render default
 }

--- a/src/host/types/view_tree.odin
+++ b/src/host/types/view_tree.odin
@@ -135,18 +135,19 @@ NodeButton :: struct {
 }
 
 NodeText :: struct {
-	layout:   Anchor,
-	content:  string,
-	aspect:   string,
-	width:    union {
+	layout:         Anchor,
+	content:        string,
+	aspect:         string,
+	width:          union {
 		SizeValue,
 		f32,
 	},
-	height:   union {
+	height:         union {
 		SizeValue,
 		f32,
 	},
-	overflow: string,
+	overflow:       string,
+	not_selectable: bool,   // zero-value = selectable (default-on)
 }
 
 PopoutMode :: enum {

--- a/test/ui/test_text_select.bb
+++ b/test/ui/test_text_select.bb
@@ -1,0 +1,99 @@
+(require '[redin-test :refer :all]
+         '[cheshire.core :as json]
+         '[babashka.http-client :as http]
+         '[clojure.string :as str])
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn get-selection []
+  (let [resp (http/get (str (base-url) "/selection")
+                       {:headers {"Accept" "application/json"}
+                        :throw false})]
+    (when (= 200 (:status resp))
+      (json/parse-string (:body resp) true))))
+
+;; ---------------------------------------------------------------------------
+;; Reset helper: click an empty corner to clear any existing selection and
+;; wait long enough (>0.4s) that the double-click counter resets.
+(defn reset-selection! []
+  (click 900 700)
+  (wait-ms 600))
+
+;; ---------------------------------------------------------------------------
+;; Layout notes (surface padding 24px, font-size 16px):
+;;   body text  : y ≈ 24–44  (single line, ~20px tall)
+;;   locked text: y ≈ 44–64  (single line, ~20px tall)
+;;   input field: y ≈ 64–94  (with 8px vertical padding each side)
+;;
+;; A single click produces a collapsed caret (start == end) which
+;; has_selection() treats as no selection → /selection returns kind:none.
+;; A double-click selects a word → start < end → /selection returns kind:text.
+;; ---------------------------------------------------------------------------
+
+(deftest no-selection-initially
+  (reset-selection!)
+  (let [sel (get-selection)]
+    (assert (= "none" (:kind sel))
+            (str "expected kind:none initially, got " (:kind sel)))))
+
+(deftest double-click-selects-word
+  ;; Reset and wait >0.4s so click-count resets to 1, then issue two rapid
+  ;; clicks on the body-text line (y ≈ 32).
+  (reset-selection!)
+  (click 200 32)
+  (wait-ms 120)
+  (click 200 32)
+  (wait-for {:desc "kind=text after double-click"
+             :check-fn (fn []
+                         (let [s (get-selection)]
+                           (and (= "text" (:kind s))
+                                (< (:start s) (:end s)))))}
+            {:timeout 2000})
+  (let [sel (get-selection)
+        text (:text sel)]
+    (assert (= "text" (:kind sel))
+            (str "expected kind:text, got " (:kind sel)))
+    (assert (pos? (count (str/trim text)))
+            "double-click should produce a non-empty text selection (ignoring trailing space)")
+    (assert (not (str/starts-with? text " "))
+            (str "selected text should not start with a space, got: " (pr-str text)))))
+
+(deftest opt-out-text-is-not-selectable
+  ;; Establish a text selection on the body node via double-click.
+  (reset-selection!)
+  (click 200 32)
+  (wait-ms 120)
+  (click 200 32)
+  (wait-for {:desc "text selection established"
+             :check-fn (fn [] (= "text" (:kind (get-selection))))}
+            {:timeout 2000})
+  ;; Now click in the locked-text band (y ≈ 50). Because the locked text
+  ;; has :selectable false, it carries no Text_Select_Listener, so the
+  ;; click-elsewhere-to-clear path fires and the selection becomes none.
+  ;; Crucially it must NOT become kind:text.
+  (wait-ms 500)
+  (click 200 50)
+  (wait-ms 300)
+  (let [sel (get-selection)]
+    (assert (not= "text" (:kind sel))
+            (str "locked text should not produce kind:text, got " (:kind sel)))))
+
+(deftest clicking-input-clears-text-selection
+  ;; Establish text selection on body text via double-click.
+  (reset-selection!)
+  (click 200 32)
+  (wait-ms 120)
+  (click 200 32)
+  (wait-for {:desc "text selection established"
+             :check-fn (fn [] (= "text" (:kind (get-selection))))}
+            {:timeout 2000})
+  ;; Click the input field (y ≈ 75). apply_focus calls focus_enter which
+  ;; calls clear_text_selection, so selection_kind changes away from .Text.
+  (wait-ms 500)
+  (click 400 75)
+  (wait-ms 300)
+  (let [sel (get-selection)]
+    (assert (not= "text" (:kind sel))
+            (str "clicking input should clear text selection, got " (:kind sel)))))

--- a/test/ui/text_select_app.fnl
+++ b/test/ui/text_select_app.fnl
@@ -1,0 +1,29 @@
+(local dataflow (require :dataflow))
+(local theme-mod (require :theme))
+
+(theme-mod.set-theme
+  {:surface {:bg [46 52 64] :padding [24 24 24 24]}
+   :body    {:font-size 16 :color [236 239 244]
+             :selection [255 220 0 120]}
+   :locked  {:font-size 16 :color [180 180 180]}
+   :input   {:bg [59 66 82] :color [236 239 244]
+             :border [76 86 106] :border-width 1
+             :radius 4 :padding [8 12 8 12] :font-size 14}})
+
+(dataflow.init {:input-value "preset"})
+(global redin_get_state (. dataflow :_get-raw-db))
+
+(reg-handler :event/input-change
+  (fn [db event]
+    (let [ctx (. event 2)]
+      (assoc db :input-value (or ctx.value "")))))
+
+(global main_view
+  (fn []
+    [:vbox {:aspect :surface :layout :top_left}
+     [:text {:aspect :body :id :para}
+      "the quick brown fox jumps over the lazy dog"]
+     [:text {:aspect :locked :id :locked-text :selectable false}
+      "this paragraph is not selectable"]
+     [:input {:aspect :input :id :probe-input :value (subscribe :input-value)
+              :change [:event/input-change]}]]))


### PR DESCRIPTION
## Summary

Adds native-feeling text selection to plain `NodeText`, matching the behavior of `NodeInput`'s existing selection. Click-drag to select a range inside a single text node, shift-click to extend, double-click for word, triple-click for line, `Ctrl-A` / `Ctrl-C`, click-elsewhere-to-clear, I-beam cursor on hover. Opt out with `[:text {:selectable false} "…"]`.

Design spec: `docs/superpowers/specs/2026-04-20-text-highlight-design.md`
Implementation plan: `docs/superpowers/plans/2026-04-20-text-highlight.md` (18 tasks, executed via subagent-driven development with spec + code-quality review per task)

## Architecture

- **State.** `Input_State` grows a `Selection_Kind { None, Input, Text }` tag and a heap-owned `selection_path: [dynamic]u8`. One active selection in the app at any time; mutual exclusion is enforced in `focus_enter` (clears text selection) and in `text_select_begin` (clears input focus).
- **Gestures.** New `src/host/input/text_select.odin` owns mouse-down / drag / release, click-count tracking (400 ms window), and word/line promotion via existing `prev_word` / `next_word` / `text_pkg.compute_lines` / `cursor_to_line` helpers. Called from the main loop alongside the existing drag pass.
- **Rendering.** The existing NodeInput multi-line selection-rect loop was extracted into a shared `draw_selection_rects` helper (Task 3). `NodeText` now calls the same helper with theme-resolved color. `:selection` theme property — previously declared but unread — is plumbed end-to-end.
- **Identity across frames.** Paths (not indices) identify the selected node; a per-frame resolver (`resolve_text_selection`) drops stale selections when the tree re-flattens or content shrinks.
- **Dev server.** New `GET /selection` returns `{kind: "none"|"input"|"text", start, end, text}` — read-only, for UI test assertions and interactive debugging.

## Surface area

### Attribute
```fennel
[:text {:selectable false} "not selectable"]   ; default is selectable
```

### Theme
```fennel
{:body {:font-size 14 :color [40 40 40] :selection [255 220 0 120]}}
```
Consumed by both `:input` and `:text` nodes. Falls back to `[51 153 255 100]` when unset.

### Dev-server
`GET /selection` → JSON shape as above.

## Test plan

- [x] `odin build src/host -out:build/redin` — clean.
- [x] `odin test src/host/profile` — 4/4.
- [x] `odin test src/host/parser` — 25/25 (24 pre-existing + 1 new for `:selection`).
- [x] `odin test src/host/input -define:ODIN_TEST_THREADS=1` — 11/11 (8 state/selection + 3 new text_select resolver + path-match).
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 122/122.
- [x] `bash test/ui/run-all.sh` — all suites 0 failed, including new `test_text_select` 4/4. `test_profile` no-Results-line remains a pre-existing harness quirk on main.
- [x] `./build/redin --dev --track-mem test/ui/text_select_app.fnl` with repeated select / clear cycles — no leaks on shutdown.
- [x] Visual screenshot captured (double-click word selection rendered correctly).

## Commits

21 commits on the branch, plus docs/spec/plan. Highlights:

- Theme plumbing: `2fb7292`, `b14136e`
- Render refactor: `68236df`
- State model: `64e0616`, `5c88ed4`, `841b738`
- Listener + attr: `ed83a8e`, `2c776bf`
- Gesture: `b59f9b1`, `2eaee4b`, `4e2bad2`, `ffbc269`
- Render for NodeText: `e1a3d6d`
- Resolver, keyboard, cursor, devserver: `66deec5`, `38bd80b`, `5758e83`, `6c6e154`
- Tests + docs: `fc3bb6b`, `9b7a9f4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)