### PR TITLE
perf(render): cache Text_Line[] for NodeText draw reuse

### DIFF
--- a/src/host/render.odin
+++ b/src/host/render.odin
@@ -674,8 +674,10 @@ node_preferred_height :: proc(
 		if available_width > 0 && len(n.content) > 0 && n.overflow != "scroll-x" {
 			f := font.get(font_name, font.style_from_weight(font.Font_Weight(font_weight)))
 			lines := text_pkg.compute_lines(n.content, f, font_size, 0, available_width)
-			defer delete(lines)
 			result = f32(len(lines)) * lh
+			text_pkg.cache_intrinsic(idx, available_width, result)
+			text_pkg.cache_lines(idx, available_width, lines)
+			return result
 		}
 		text_pkg.cache_intrinsic(idx, available_width, result)
 		return result
@@ -1084,13 +1086,27 @@ draw_text :: proc(idx: int, rect: rl.Rectangle, n: types.NodeText, theme: map[st
 	spacing: f32 = 0
 	lh := text_pkg.line_height(font_size, lh_ratio)
 
-	// Compute lines: wrap if not scroll-x
+	// Compute lines: wrap if not scroll-x. Reuse the cached wrap from
+	// layout when the width matches (typical NodeText path). Miss on
+	// scroll-x (cache isn't populated there) and on width mismatch
+	// (centering/anchoring), in which case we compute-and-discard
+	// rather than overwriting the cache — overwriting at a different
+	// width would thrash the layout-pass hit on the next frame.
 	max_width: f32 = 0
 	if n.overflow != "scroll-x" {
 		max_width = rect.width
 	}
-	lines := text_pkg.compute_lines(n.content, f, font_size, spacing, max_width)
-	defer delete(lines)
+	lines: []text_pkg.Text_Line
+	fresh: [dynamic]text_pkg.Text_Line
+	owns_lines := false
+	if cached, ok := text_pkg.lookup_lines(idx, max_width); ok {
+		lines = cached
+	} else {
+		fresh = text_pkg.compute_lines(n.content, f, font_size, spacing, max_width)
+		lines = fresh[:]
+		owns_lines = true
+	}
+	defer if owns_lines do delete(fresh)
 
 	scrollable_y := n.overflow == "scroll-y"
 	scrollable_x := n.overflow == "scroll-x"

--- a/src/host/text/layout.odin
+++ b/src/host/text/layout.odin
@@ -12,10 +12,15 @@ import rl "vendor:raylib"
 //
 // Sentinel: width < 0 means unpopulated. Secondary key params
 // (font_size, lh_ratio, font_tex_id) are not stored — theme-change
-// invalidation covers them.
+// invalidation covers them. `lines` is optionally populated when
+// compute_lines is called during layout; draw can reuse it to skip
+// a second wrap pass at the same width. `lines_valid` gates reuse
+// since an empty slice is a valid wrap result (empty-text node).
 Intrinsic_Entry :: struct {
-	width:  f32,
-	height: f32,
+	width:       f32,
+	height:      f32,
+	lines:       [dynamic]Text_Line,
+	lines_valid: bool,
 }
 @(private)
 intrinsic_cache: [dynamic]Intrinsic_Entry
@@ -41,11 +46,50 @@ lookup_intrinsic :: proc(idx: int, width: f32) -> (f32, bool) {
 
 cache_intrinsic :: proc(idx: int, width: f32, height: f32) {
 	if idx < 0 || idx >= len(intrinsic_cache) do return
-	intrinsic_cache[idx] = Intrinsic_Entry{width = width, height = height}
+	e := &intrinsic_cache[idx]
+	// Only reset lines on a key change — preserve lines cached earlier
+	// this frame at the same width (typical: layout then draw).
+	if e.width != width {
+		if e.lines_valid {
+			delete(e.lines)
+			e.lines = {}
+			e.lines_valid = false
+		}
+	}
+	e.width = width
+	e.height = height
+}
+
+// Look up a cached line array for this node at this width. Returned
+// slice is borrowed — do NOT delete.
+lookup_lines :: proc(idx: int, width: f32) -> ([]Text_Line, bool) {
+	if idx < 0 || idx >= len(intrinsic_cache) do return nil, false
+	e := intrinsic_cache[idx]
+	if !e.lines_valid || e.width != width || e.width < 0 do return nil, false
+	return e.lines[:], true
+}
+
+// Hand ownership of a line array to the cache. After this call, the
+// caller must NOT delete `lines`. Cache frees on invalidation.
+cache_lines :: proc(idx: int, width: f32, lines: [dynamic]Text_Line) {
+	if idx < 0 || idx >= len(intrinsic_cache) {
+		// No slot — caller's responsibility to avoid a leak. Free here
+		// defensively so compute_lines allocations don't bleed.
+		lines := lines
+		delete(lines)
+		return
+	}
+	e := &intrinsic_cache[idx]
+	if e.lines_valid do delete(e.lines)
+	e.width = width
+	e.lines = lines
+	e.lines_valid = true
 }
 
 invalidate_height_cache :: proc() {
 	for i in 0 ..< len(intrinsic_cache) {
+		e := &intrinsic_cache[i]
+		if e.lines_valid do delete(e.lines)
 		intrinsic_cache[i] = Intrinsic_Entry{width = -1}
 	}
 }


### PR DESCRIPTION
## Summary

- Extends `intrinsic_cache` (in `src/host/text/layout.odin`) to hold the wrapped `Text_Line[]` next to the cached height, keyed on the same `(idx, width)`.
- `node_preferred_height` hands lines to the cache during layout; `draw_text` reads them back, skipping the third `compute_lines` pass that issue #32 called out.
- Draw-phase misses compute-and-discard rather than overwrite, to avoid thrashing the layout-pass hit on the next frame.

## Perf

`examples/perf-10k.fnl` (10k × 1000-char rows), 90-frame average after warmup:

| phase   | main    | branch  | Δ       |
|---------|---------|---------|---------|
| input   | 310 µs  | 246 µs  | -64 µs  |
| layout  | 2658 µs | 2690 µs | +32 µs  |
| render  | 1223 µs | 829 µs  | **-394 µs (-32%)** |
| total   | 4195 µs | 3768 µs | -427 µs |

Vsync caps both runs at 120 fps, so wall-clock FPS is unchanged — the win is ~10% more per-frame headroom.

## Scope

Covers NodeText only. `draw_input` / `text_select` still call `compute_lines` directly — tracked in follow-up issues since those aren't per-frame hot paths:

- Closes part of #32 (draw-phase duplicate eliminated)
- Follow-up #39 — `text_select` hit-testing
- Follow-up #40 — NodeInput / editable text (needs content-aware key)

## Test plan

- [x] `odin build src/host -out:build/redin` — clean
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 122 passing
- [x] UI: `test_smoke`, `test_input`, `test_multiline`, `test_line_height`, `test_scroll`, `test_scroll_x`, `test_resize`, `test_text_select` — all green
- [x] Perf measured via `/profile` on `examples/perf-10k.fnl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)