### PR TITLE
feat(input): deepest-node-wins hit testing

### DIFF
--- a/src/host/input/apply.odin
+++ b/src/host/input/apply.odin
@@ -20,28 +20,29 @@ apply_listeners :: proc(
 			if e.button != .LEFT do continue
 			mouse := rl.Vector2{e.x, e.y}
 
-			hit_focus := false
-			for listener in listeners {
-				switch l in listener {
-				case types.FocusListener:
-					if l.node_idx < len(node_rects) &&
-					   rl.CheckCollisionPointRec(mouse, node_rects[l.node_idx]) {
-						focused_idx = l.node_idx
-						append(&applied, types.ApplyEvents(types.ApplyFocus{idx = l.node_idx}))
-						hit_focus = true
+			// Deepest node wins (see get_user_events). Only listeners on
+			// the innermost listener-bearing node under the pointer fire.
+			winner := deepest_listener_idx(listeners[:], node_rects, mouse)
+			new_focus := -1
+			has_active := false
+			if winner >= 0 {
+				for listener in listeners {
+					switch l in listener {
+					case types.FocusListener:
+						if l.node_idx == winner do new_focus = winner
+					case types.ClickListener:
+						if l.node_idx == winner do has_active = true
+					case types.HoverListener, types.KeyListener, types.ChangeListener,
+					     types.DragListener, types.DropListener, types.Text_Select_Listener:
 					}
-				case types.ClickListener:
-					if l.node_idx < len(node_rects) &&
-					   rl.CheckCollisionPointRec(mouse, node_rects[l.node_idx]) {
-						append(&applied, types.ApplyEvents(types.ApplyActive{idx = l.node_idx}))
-					}
-				case types.HoverListener, types.KeyListener, types.ChangeListener,
-				     types.DragListener, types.DropListener, types.Text_Select_Listener:
 				}
 			}
-
-			if !hit_focus {
-				focused_idx = -1
+			focused_idx = new_focus
+			if new_focus >= 0 {
+				append(&applied, types.ApplyEvents(types.ApplyFocus{idx = new_focus}))
+			}
+			if has_active {
+				append(&applied, types.ApplyEvents(types.ApplyActive{idx = winner}))
 			}
 
 		case types.KeyEvent, types.CharEvent, types.ScrollEvent, types.ResizeEvent:

--- a/src/host/input/drag.odin
+++ b/src/host/input/drag.odin
@@ -26,34 +26,44 @@ process_drag :: proc(
 	dispatch: [dynamic]types.Dispatch_Event
 	mouse := rl.GetMousePosition()
 
-	// Phase 1: Check for new drag initiation (mouse press on a DragListener)
+	// Phase 1: Check for new drag initiation (mouse press).
+	// Deepest node wins: only start a drag if the innermost listener
+	// under the pointer has a DragListener. A button with :click
+	// inside a draggable row is deeper than the row, so its click
+	// beats the ancestor's drag and the drag never initiates.
 	if !drag_pending && dragging_idx == -1 {
 		for event in input_events {
 			me, is_mouse := event.(types.MouseEvent)
 			if !is_mouse || me.button != .LEFT do continue
 			pt := rl.Vector2{me.x, me.y}
 
+			winner := deepest_listener_idx(listeners, node_rects, pt)
+			if winner < 0 do continue
+
+			has_drag := false
 			for listener in listeners {
 				dl, ok := listener.(types.DragListener)
 				if !ok do continue
-				if dl.node_idx >= len(node_rects) do continue
-				if !rl.CheckCollisionPointRec(pt, node_rects[dl.node_idx]) do continue
-
-				drag_pending = true
-				drag_start_pos = pt
-
-				switch n in nodes[dl.node_idx] {
-				case types.NodeVbox:
-					drag_source = {n.draggable_group, n.draggable_event, n.draggable_ctx}
-					dragging_idx = dl.node_idx
-				case types.NodeHbox:
-					drag_source = {n.draggable_group, n.draggable_event, n.draggable_ctx}
-					dragging_idx = dl.node_idx
-				case types.NodeStack, types.NodeCanvas, types.NodeInput,
-					types.NodeButton, types.NodeText, types.NodeImage,
-					types.NodePopout, types.NodeModal:
+				if dl.node_idx == winner {
+					has_drag = true
+					break
 				}
-				break
+			}
+			if !has_drag do continue
+
+			drag_pending = true
+			drag_start_pos = pt
+
+			switch n in nodes[winner] {
+			case types.NodeVbox:
+				drag_source = {n.draggable_group, n.draggable_event, n.draggable_ctx}
+				dragging_idx = winner
+			case types.NodeHbox:
+				drag_source = {n.draggable_group, n.draggable_event, n.draggable_ctx}
+				dragging_idx = winner
+			case types.NodeStack, types.NodeCanvas, types.NodeInput,
+				types.NodeButton, types.NodeText, types.NodeImage,
+				types.NodePopout, types.NodeModal:
 			}
 		}
 	}
@@ -80,7 +90,8 @@ process_drag :: proc(
 		}
 	}
 
-	// Phase 3: Active dragging - hit-test drop targets each frame
+	// Phase 3: Active dragging - hit-test drop targets each frame.
+	// Deepest-wins: nested drop zones resolve to the innermost.
 	if !drag_pending && dragging_idx >= 0 {
 		if rl.IsMouseButtonDown(.LEFT) {
 			drag_over_idx = -1
@@ -89,10 +100,8 @@ process_drag :: proc(
 				if !ok do continue
 				if dl.group != drag_source.group do continue
 				if dl.node_idx >= len(node_rects) do continue
-				if rl.CheckCollisionPointRec(mouse, node_rects[dl.node_idx]) {
-					drag_over_idx = dl.node_idx
-					break
-				}
+				if !rl.CheckCollisionPointRec(mouse, node_rects[dl.node_idx]) do continue
+				if dl.node_idx > drag_over_idx do drag_over_idx = dl.node_idx
 			}
 		} else {
 			if drag_over_idx >= 0 {

--- a/src/host/input/input.odin
+++ b/src/host/input/input.odin
@@ -9,6 +9,36 @@ import rl "vendor:raylib"
 // Currently focused node index, -1 means none.
 focused_idx: int = -1
 
+// Deepest event-listener-bearing node under `pt`, or -1 if none.
+// "Deepest" = highest node_idx among listener matches; nodes[] is
+// DFS-ordered, so a descendant always has a higher idx than its
+// ancestors. Hover is excluded: a hovered ancestor stays hovered
+// while the pointer is over a descendant, so it must not compete
+// for the single-winner slot here.
+deepest_listener_idx :: proc(
+	listeners: []types.Listener,
+	node_rects: []rl.Rectangle,
+	pt: rl.Vector2,
+) -> int {
+	best := -1
+	for listener in listeners {
+		idx: int = -1
+		switch l in listener {
+		case types.ClickListener:        idx = l.node_idx
+		case types.FocusListener:        idx = l.node_idx
+		case types.DragListener:         idx = l.node_idx
+		case types.DropListener:         idx = l.node_idx
+		case types.Text_Select_Listener: idx = l.node_idx
+		case types.HoverListener, types.KeyListener, types.ChangeListener:
+		}
+		if idx < 0 || idx >= len(node_rects) do continue
+		if idx <= best do continue
+		if !rl.CheckCollisionPointRec(pt, node_rects[idx]) do continue
+		best = idx
+	}
+	return best
+}
+
 extract_listeners :: proc(
 	paths: [dynamic]types.Path,
 	nodes: [dynamic]types.Node,

--- a/src/host/input/user_events.odin
+++ b/src/host/input/user_events.odin
@@ -35,23 +35,22 @@ get_user_events :: proc(
 			if is_dragging() do continue
 			pt := rl.Vector2{e.x, e.y}
 
+			// Deepest node wins: compute the innermost listener-bearing
+			// node under the pointer, then fire only that node's
+			// listeners. Ancestor click/focus listeners are suppressed.
+			// Hover is multi-fire and stays in its own loop above.
+			winner := deepest_listener_idx(listeners[:], node_rects, pt)
+			if winner < 0 do continue
+
 			for listener in listeners {
 				switch l in listener {
 				case types.ClickListener:
-					if l.node_idx < len(node_rects) &&
-					   rl.CheckCollisionPointRec(pt, node_rects[l.node_idx]) {
-						append(
-							&user_events,
-							types.UserEvent{event = .CLICK, node_idx = l.node_idx},
-						)
+					if l.node_idx == winner {
+						append(&user_events, types.UserEvent{event = .CLICK, node_idx = winner})
 					}
 				case types.FocusListener:
-					if l.node_idx < len(node_rects) &&
-					   rl.CheckCollisionPointRec(pt, node_rects[l.node_idx]) {
-						append(
-							&user_events,
-							types.UserEvent{event = .FOCUS, node_idx = l.node_idx},
-						)
+					if l.node_idx == winner {
+						append(&user_events, types.UserEvent{event = .FOCUS, node_idx = winner})
 					}
 				case types.HoverListener, types.KeyListener, types.ChangeListener,
 				     types.DragListener, types.DropListener, types.Text_Select_Listener:

--- a/test/ui/nested_click_app.fnl
+++ b/test/ui/nested_click_app.fnl
@@ -1,0 +1,47 @@
+;; Nested-listener resolution test. The kitchen-sink pattern: a button
+;; (with :click) inside a hbox (with :draggable). Clicking the button must
+;; fire the click listener, not the ancestor's drag path.
+;;
+;; Layout (no :layout attr): root vbox is full window. The draggable hbox
+;; fills vbox width (anchor_h=0). Inside the hbox, the button has explicit
+;; width=100 and lives at x=0..100, y=0..80. Inner-button center ≈ (50,40).
+;; Click anywhere else at y<80 lands on the hbox background (no click
+;; listener there).
+(local dataflow (require :dataflow))
+(local theme-mod (require :theme))
+
+(theme-mod.set-theme
+  {:surface {:bg [30 30 30]}
+   :drag    {:bg [70 90 70]}
+   :btn     {:bg [120 120 180] :color [240 240 240]}
+   :body    {:font-size 14 :color [220 220 220]}})
+
+(dataflow.init {:last nil :drag-count 0})
+(global redin_get_state (. dataflow :_get-raw-db))
+
+(reg-handler :event/drag-inner-click
+  (fn [db _] (assoc db :last "drag-inner")))
+
+(reg-handler :event/drag-start
+  (fn [db _]
+    (assoc (assoc db :last "drag-start")
+           :drag-count (+ 1 (get db :drag-count 0)))))
+
+(reg-handler :event/reset
+  (fn [db _] (assoc (assoc db :last nil) :drag-count 0)))
+
+(reg-sub :last (fn [db] (get db :last)))
+(reg-sub :drag-count (fn [db] (get db :drag-count 0)))
+
+(global main_view
+  (fn []
+    [:vbox {:aspect :surface}
+     [:hbox {:id :drag-row
+             :aspect :drag
+             :height 80
+             :draggable [:row :event/drag-start 1]}
+      [:button {:id :drag-inner
+                :aspect :btn
+                :width 100 :height 60
+                :click [:event/drag-inner-click]}
+       "DragInner"]]]))

--- a/test/ui/test_nested_click.bb
+++ b/test/ui/test_nested_click.bb
@@ -1,0 +1,30 @@
+(require '[redin-test :refer :all])
+
+;; Deepest-wins hit testing: a button (click listener) inside a hbox
+;; (drag listener). Clicking the button should fire the inner click.
+;; Clicking the draggable background (no inner click) should not fire
+;; any user event — the bare drag listener needs movement to dispatch
+;; and a single injected click has none.
+
+(deftest elements-exist
+  (assert-element {:tag :hbox :id :drag-row})
+  (assert-element {:tag :button :id :drag-inner}))
+
+(deftest click-inner-button-fires-click-not-drag
+  (dispatch ["event/reset"])
+  (wait-ms 100)
+  ;; Button occupies x=0..100 y=0..80 inside the full-width draggable hbox.
+  (click 50 40)
+  (wait-for (state= "last" "drag-inner") {:timeout 1000})
+  (assert-state "drag-count" #(= % 0)
+                "Click on a button inside a draggable must not dispatch drag"))
+
+(deftest click-draggable-background-no-event
+  (dispatch ["event/reset"])
+  (wait-ms 100)
+  ;; x=500 is inside the draggable hbox but outside the button.
+  (click 500 40)
+  (wait-ms 300)
+  (assert-state "last" nil?
+                "Background click on draggable with no movement dispatches nothing")
+  (assert-state "drag-count" #(= % 0)))


### PR DESCRIPTION
## Summary

- Pointer events (`click`, `focus`, `drag` initiation, `drop`) now resolve to the single innermost listener-bearing node under the cursor. Ancestor listeners are suppressed when a descendant is hit.
- Hover stays multi-fire — a hovered card keeps its `#hover` aspect while the pointer moves over any descendant.
- Key/change route to the focused node and are unaffected.

## Motivation

Kitchen-sink's \"remove\" button lives inside a `:draggable` hbox (`examples/kitchen-sink.fnl:198-204`). Before this change, clicking that button also armed the ancestor row's drag listener — `drag_pending` flickered, the `#drag-start` theme briefly applied, and any tiny mouse movement during the press would dispatch the row's drag event alongside the button's click. After this change, the button wins the resolution and the row's drag never initiates.

## Implementation

- Adds `deepest_listener_idx` in `src/host/input/input.odin` — one shared helper that picks the max `node_idx` among listener hits. Nodes are DFS-ordered, so max idx = deepest node. Hover listeners are excluded from the contest.
- `apply.odin` (focus/active), `user_events.odin` (click/focus dispatch), and `drag.odin` (Phase 1 initiation, Phase 3 drop) all call the helper and then only fire listeners whose `node_idx == winner`.

## What this doesn't solve

Same-node drag + click (a node that has both listeners on itself) still needs a gesture arbiter — mouse-down is ambiguous until movement crosses a threshold. Out of scope for this PR; tracked as a follow-up.

## Test plan

- [x] New: `test/ui/nested_click_app.fnl` + `test_nested_click.bb` — button inside draggable hbox, clicking the button fires `:event/drag-inner-click` and `drag-count` stays at 0.
- [x] `odin build src/host -out:build/redin` — clean.
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 122 passing.
- [x] UI suite: 16 apps, 109 tests, all green (smoke, input, button, drag, scroll, scroll_x, modal, popout, canvas, text_select, multiline, line_height, resize, image, shadow, viewport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)