### PR TITLE
fix(devserver): require Bearer auth, drop CORS, check Host (closes #44)

### DIFF
--- a/.claude/skills/redin-dev/SKILL.md
+++ b/.claude/skills/redin-dev/SKILL.md
@@ -168,7 +168,14 @@ canvas.register("my-provider", my_provider)
      :dispatch-later {:ms 1000 :dispatch [:event/timeout]}}))
 ```
 
-## Dev server (--dev mode, port 8800)
+## Dev server (--dev mode, default port 8800)
+
+Authenticated: every non-OPTIONS request needs `Authorization: Bearer <token>`, where the token is written to `./.redin-token` on startup (0600, deleted on shutdown). The `Host` header must also be `localhost:<port>` or `127.0.0.1:<port>`. Bound port is in `./.redin-port`.
+
+```bash
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -H "Authorization: Bearer $TOKEN" http://localhost:$PORT/state
+```
 
 | Method | Path | Description |
 |--------|------|-------------|

--- a/.claude/skills/redin-maintenance/SKILL.md
+++ b/.claude/skills/redin-maintenance/SKILL.md
@@ -42,8 +42,12 @@ Builds redin, then for each pair: starts dev server, runs tests, shuts down. Req
 ```bash
 ./build/redin --dev test/ui/<component>_app.fnl &
 bb test/ui/run.bb test/ui/test_<component>.bb
-curl -s -X POST http://localhost:8800/shutdown
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+     http://localhost:$PORT/shutdown
 ```
+
+Every non-OPTIONS request to the dev server needs `Authorization: Bearer <token>` (token is in `./.redin-token`, 0600, removed on shutdown). `bb test/ui/run.bb` reads the token automatically.
 
 ### Available test suites
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,9 @@ test/*/leak_test
 # Build output
 build/
 
-# Dev server runtime port file (written by --dev mode)
+# Dev server runtime port + auth token files (written by --dev mode)
 .redin-port
+.redin-token
 
 # Integration test working directory
 test/integration/testapp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ These docs are the source of truth. When implementing, follow them exactly.
 
 - **Host/renderer:** Odin + Raylib
 - **Scripting:** LuaJIT (Lua 5.1 API) with Fennel compiled to Lua 5.1 target
-- **AI interface:** localhost HTTP dev server (`--dev` mode). Default port 8800; if busy, walks upward to the next free port. Actual port is written to `./.redin-port` and cleaned up on shutdown. Optional `--profile` flag adds a 5-phase frame-timing ring buffer exposed at `/profile` and an F3-togglable on-screen overlay.
+- **AI interface:** localhost HTTP dev server (`--dev` mode). Default port 8800; if busy, walks upward to the next free port. Bound port is written to `./.redin-port`; a per-run random auth token is written to `./.redin-token` (mode 0600). Both files are removed on shutdown. Every non-`OPTIONS` request must include `Authorization: Bearer <contents of .redin-token>`; the server also rejects requests whose `Host` header isn't `localhost:<port>` or `127.0.0.1:<port>` (DNS-rebinding defence). Optional `--profile` flag adds a 5-phase frame-timing ring buffer exposed at `/profile` and an F3-togglable on-screen overlay.
 
 ## Building
 
@@ -85,7 +85,7 @@ src/runtime/        Fennel runtime (loaded by bridge at startup)
 
 ## Dev server HTTP API
 
-Available when running with `--dev`. Listens on port 8800 by default; walks upward (8801, 8802, ...) if busy, and writes the bound port to `./.redin-port`. Used by UI tests and for interactive debugging.
+Available when running with `--dev`. Listens on port 8800 by default; walks upward (8801, 8802, ...) if busy, and writes the bound port to `./.redin-port`. A per-run random auth token is written to `./.redin-token` (0600). Every non-`OPTIONS` request must carry `Authorization: Bearer <token>`, and the `Host` header must be `localhost:<port>` / `127.0.0.1:<port>`.
 
 | Method | Path | Description |
 |--------|------|-------------|
@@ -100,7 +100,12 @@ Available when running with `--dev`. Listens on port 8800 by default; walks upwa
 | `POST` | `/shutdown` | Request graceful shutdown |
 | `PUT` | `/aspects` | Replace the theme map (JSON body) |
 
-Example: `curl http://localhost:$(cat .redin-port)/state/counter`
+Example:
+
+```bash
+curl -H "Authorization: Bearer $(cat .redin-token)" \
+     http://localhost:$(cat .redin-port)/state/counter
+```
 
 ## Key conventions
 

--- a/docs/core-api.md
+++ b/docs/core-api.md
@@ -428,6 +428,8 @@ Providers register in Odin via `canvas.register(name, provider)`. See the [canva
 
 Runs on `localhost:8800` when started with `--dev` flag. All responses are JSON unless noted.
 
+**Authentication.** Every non-`OPTIONS` request must include `Authorization: Bearer <token>`, where the token is read from `./.redin-token` (generated on startup, mode 0600, removed on shutdown). The server also verifies the `Host` header is `localhost:<port>` or `127.0.0.1:<port>` (DNS-rebinding defence). Missing token → `401`, bad Host → `403`, `OPTIONS` → `405` (CORS preflight not served — the endpoint is for local tools, not browsers). See [dev-server reference](../reference/dev-server.md) for usage examples.
+
 ### Frames
 
 | Method | Path      | Body | Response                             |

--- a/docs/reference/dev-server.md
+++ b/docs/reference/dev-server.md
@@ -6,11 +6,29 @@ HTTP server for inspecting and driving redin apps from external tools.
 
 ## Overview
 
-Starts when the app is launched with `--dev`. Listens on `localhost:8800`. All responses are JSON unless noted. CORS headers are included on all responses.
+Starts when the app is launched with `--dev`. Listens on `localhost:8800` (walks upward if busy).
 
 Read endpoints reflect the last state pushed to the host. Write endpoints queue events into the main input channel as if they came from real user input.
 
 Implementation: `src/host/bridge/devserver.odin`.
+
+### Authentication
+
+On startup the server generates a random 256-bit token and writes it to `./.redin-token` (mode 0600, removed on shutdown). Every non-OPTIONS request must include:
+
+```
+Authorization: Bearer <contents of .redin-token>
+```
+
+The server also verifies the `Host` header matches `localhost:<port>` or `127.0.0.1:<port>` to blunt DNS-rebinding attacks. CORS preflight is not served — the endpoint is intended for local tools, not browsers. Missing token → `401`; bad Host → `403`; OPTIONS → `405`.
+
+All examples below assume:
+
+```bash
+PORT=$(cat .redin-port)
+TOKEN=$(cat .redin-token)
+AUTH="Authorization: Bearer $TOKEN"
+```
 
 ---
 
@@ -19,7 +37,7 @@ Implementation: `src/host/bridge/devserver.odin`.
 ### `GET /frames` -- full frame tree
 
 ```bash
-curl http://localhost:8800/frames
+curl -H "$AUTH" http://localhost:$PORT/frames
 ```
 
 Response: the full frame tree as JSON. Calls `view.get-last-push` in Lua to retrieve the last rendered frame.
@@ -27,7 +45,7 @@ Response: the full frame tree as JSON. Calls `view.get-last-push` in Lua to retr
 ### `GET /state` -- full app-db
 
 ```bash
-curl http://localhost:8800/state
+curl -H "$AUTH" http://localhost:$PORT/state
 ```
 
 Response: JSON-serialized Lua state table.
@@ -37,13 +55,13 @@ Response: JSON-serialized Lua state table.
 Dot-separated path. Segments are string keys into the Lua state table.
 
 ```bash
-curl http://localhost:8800/state/items.text
+curl -H "$AUTH" http://localhost:$PORT/state/items.text
 ```
 
 ### `GET /aspects` -- theme table
 
 ```bash
-curl http://localhost:8800/aspects
+curl -H "$AUTH" http://localhost:$PORT/aspects
 ```
 
 Response: full theme as JSON object (serialized from host-side `Theme` structs).
@@ -80,7 +98,7 @@ The sum of `phase_us` may be less than `total_us` because glue code between phas
 ### `GET /screenshot` -- PNG capture
 
 ```bash
-curl http://localhost:8800/screenshot -o screenshot.png
+curl -H "$AUTH" http://localhost:$PORT/screenshot -o screenshot.png
 ```
 
 Returns binary PNG. Content-Type: `image/png`. Captures the current Raylib window.
@@ -92,7 +110,7 @@ Returns binary PNG. Content-Type: `image/png`. Captures the current Raylib windo
 ### `POST /events` -- dispatch an event
 
 ```bash
-curl -X POST http://localhost:8800/events \
+curl -X POST -H "$AUTH" http://localhost:$PORT/events \
   -H 'Content-Type: application/json' \
   -d '{"event": ["event/increment"]}'
 ```
@@ -106,7 +124,7 @@ The JSON body is decoded into a Lua value and passed to the event system.
 Hit-tests at the given pixel coordinate and dispatches through input handling.
 
 ```bash
-curl -X POST http://localhost:8800/click \
+curl -X POST -H "$AUTH" http://localhost:$PORT/click \
   -H 'Content-Type: application/json' \
   -d '{"x": 400, "y": 300}'
 ```
@@ -118,7 +136,7 @@ Queues a `MouseEvent` with `button = LEFT` into the input event queue.
 ### `POST /shutdown` -- graceful shutdown
 
 ```bash
-curl -X POST http://localhost:8800/shutdown
+curl -X POST -H "$AUTH" http://localhost:$PORT/shutdown
 ```
 
 Response: `{"ok": true}`
@@ -128,7 +146,7 @@ Sets `shutdown_requested = true` on the dev server.
 ### `PUT /aspects` -- replace theme
 
 ```bash
-curl -X PUT http://localhost:8800/aspects \
+curl -X PUT -H "$AUTH" http://localhost:$PORT/aspects \
   -H 'Content-Type: application/json' \
   -d '{"button": {"bg": [76, 86, 106], "radius": 6}}'
 ```

--- a/src/host/bridge/devserver.odin
+++ b/src/host/bridge/devserver.odin
@@ -1,6 +1,8 @@
 package bridge
 
 import "core:container/queue"
+import "core:crypto"
+import "core:encoding/hex"
 import "core:fmt"
 import "core:net"
 import "core:os"
@@ -39,6 +41,9 @@ Dev_Server :: struct {
 	bridge:             ^Bridge,
 	tcp_sock:           net.TCP_Socket,
 	port:               int,
+	auth_token:         string, // 64-char hex, required as Bearer on every non-OPTIONS request
+	expected_host_v4:   string, // "127.0.0.1:<port>"
+	expected_host_name: string, // "localhost:<port>"
 	server_thread:      ^thread.Thread,
 	incoming:           Sync_Queue,
 	event_queue:        [dynamic]types.InputEvent,
@@ -46,9 +51,14 @@ Dev_Server :: struct {
 	shutdown_requested: bool,
 }
 
-PORT_FILE :: ".redin-port"
-PORT_BASE :: 8800
+PORT_FILE  :: ".redin-port"
+TOKEN_FILE :: ".redin-token"
+PORT_BASE  :: 8800
 PORT_RANGE :: 100
+
+// Number of bytes of entropy for the auth token. 32 bytes (256 bits)
+// hex-encoded yields a 64-char token.
+AUTH_TOKEN_BYTES :: 32
 
 // --- Sync queue ---
 
@@ -97,13 +107,31 @@ devserver_init :: proc(ds: ^Dev_Server, b: ^Bridge) {
 	ds.tcp_sock = sock
 	ds.port = bound_port
 
+	// Generate a per-run auth token. Written to .redin-token with mode
+	// 0600 so only the running user can read it. Required as a Bearer
+	// header on every non-OPTIONS request — see should_authorize().
+	{
+		raw: [AUTH_TOKEN_BYTES]u8
+		crypto.rand_bytes(raw[:])
+		enc, _ := hex.encode(raw[:])
+		ds.auth_token = string(enc)
+	}
+
+	ds.expected_host_v4   = fmt.aprintf("127.0.0.1:%d", bound_port)
+	ds.expected_host_name = fmt.aprintf("localhost:%d", bound_port)
+
 	port_str := fmt.tprintf("%d", bound_port)
 	if err := os.write_entire_file(PORT_FILE, port_str); err != nil {
 		fmt.eprintfln("Warning: could not write %s: %v", PORT_FILE, err)
 	}
+	// 0600 — owner read+write only.
+	private_perm := os.Permissions{.Read_User, .Write_User}
+	if err := os.write_entire_file(TOKEN_FILE, transmute([]u8)ds.auth_token, private_perm); err != nil {
+		fmt.eprintfln("Warning: could not write %s: %v", TOKEN_FILE, err)
+	}
 
 	ds.server_thread = thread.create_and_start_with_poly_data(ds, server_thread_proc, context)
-	fmt.printfln("Dev server listening on http://localhost:%d", bound_port)
+	fmt.printfln("Dev server listening on http://localhost:%d (auth token in %s)", bound_port, TOKEN_FILE)
 }
 
 devserver_destroy :: proc(ds: ^Dev_Server) {
@@ -119,7 +147,11 @@ devserver_destroy :: proc(ds: ^Dev_Server) {
 		}
 		net.close(ds.tcp_sock)
 		os.remove(PORT_FILE)
+		os.remove(TOKEN_FILE)
 	}
+	if len(ds.auth_token) > 0 do delete(ds.auth_token)
+	if len(ds.expected_host_v4) > 0 do delete(ds.expected_host_v4)
+	if len(ds.expected_host_name) > 0 do delete(ds.expected_host_name)
 	queue.destroy(&ds.incoming.q)
 	delete(ds.event_queue)
 }
@@ -189,7 +221,7 @@ server_thread_proc :: proc(ds: ^Dev_Server) {
 		}
 
 		if too_large {
-			resp := "HTTP/1.1 413 Payload Too Large\r\n" + CORS_HEADERS + "\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+			resp := "HTTP/1.1 413 Payload Too Large\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
 			net.send_tcp(client, transmute([]u8)resp)
 			net.close(client)
 			continue
@@ -224,19 +256,47 @@ server_thread_proc :: proc(ds: ^Dev_Server) {
 			path = rest[:sp2] if sp2 >= 0 else rest
 		}
 
-		// Extract body (after double CRLF)
+		// Split headers / body. Headers are everything up to the first
+		// "\r\n\r\n" — the request line is included, which is fine:
+		// header lookup works with any leading line, and the second
+		// line onward are real headers.
+		headers := req_str
 		body := ""
 		if header_end := strings.index(req_str, "\r\n\r\n"); header_end >= 0 {
+			headers = req_str[:header_end]
 			body_start := header_end + 4
 			if body_start < total {
 				body = req_str[body_start:]
 			}
 		}
 
-		// Handle OPTIONS directly
+		// DNS-rebinding defence: require Host: localhost:<port> or
+		// 127.0.0.1:<port>. A malicious site resolving an attacker
+		// hostname to 127.0.0.1 would send a different Host header,
+		// so the request is rejected before the auth check runs.
+		host_ok := check_host_header(headers, ds.expected_host_v4, ds.expected_host_name)
+		if !host_ok {
+			deny := "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+			net.send_tcp(client, transmute([]u8)deny)
+			net.close(client)
+			continue
+		}
+
+		// OPTIONS: reject — we don't serve CORS preflight. With auth
+		// required and no Access-Control-Allow-Origin emitted, browsers
+		// can't make cross-origin calls regardless, so OPTIONS has no
+		// legitimate use here.
 		if method == "OPTIONS" {
-			options_resp := "HTTP/1.1 204 No Content\r\n" + CORS_HEADERS + "\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
-			net.send_tcp(client, transmute([]u8)options_resp)
+			deny := "HTTP/1.1 405 Method Not Allowed\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+			net.send_tcp(client, transmute([]u8)deny)
+			net.close(client)
+			continue
+		}
+
+		// Require a matching Bearer token on every non-OPTIONS request.
+		if !check_bearer_token(headers, ds.auth_token) {
+			deny := "HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: Bearer\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+			net.send_tcp(client, transmute([]u8)deny)
 			net.close(client)
 			continue
 		}
@@ -261,8 +321,6 @@ server_thread_proc :: proc(ds: ^Dev_Server) {
 		// Send header line by line (no allocator needed)
 		send_str(client, "HTTP/1.1 ")
 		send_str(client, status_line)
-		send_str(client, "\r\n")
-		send_str(client, CORS_HEADERS)
 		send_str(client, "\r\nContent-Type: ")
 		send_str(client, ct)
 		send_str(client, "\r\nContent-Length: ")
@@ -305,7 +363,57 @@ int_to_str :: proc(buf: []u8, val: int) -> string {
 	return string(buf[i:])
 }
 
-CORS_HEADERS :: "Access-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: GET, POST, PUT, OPTIONS\r\nAccess-Control-Allow-Headers: Content-Type"
+// Case-insensitive lookup for a header value. Returns the trimmed
+// value, or "" if the header is absent.
+find_header_value :: proc(headers: string, name_lower: string) -> string {
+	lower := strings.to_lower(headers, context.temp_allocator)
+	needle := strings.concatenate({name_lower, ":"}, context.temp_allocator)
+	idx := strings.index(lower, needle)
+	if idx < 0 do return ""
+	// Require the header to start at a line boundary (or the very
+	// start of the buffer) so a body substring can't be mistaken for
+	// a header.
+	if idx > 0 && lower[idx - 1] != '\n' do return ""
+	rest := headers[idx + len(needle):]
+	end := strings.index_any(rest, "\r\n")
+	if end < 0 do end = len(rest)
+	return strings.trim_space(rest[:end])
+}
+
+// Verify the request's Host header matches one of the expected bound
+// values. Blocks DNS-rebinding attacks where a remote attacker has
+// their hostname resolve to 127.0.0.1.
+check_host_header :: proc(headers: string, expected_v4: string, expected_name: string) -> bool {
+	host := find_header_value(headers, "host")
+	if len(host) == 0 do return false
+	return host == expected_v4 || host == expected_name
+}
+
+// Constant-time compare of the Authorization bearer token against
+// the per-run secret. Returns true on exact match.
+check_bearer_token :: proc(headers: string, expected: string) -> bool {
+	if len(expected) == 0 do return false
+	auth := find_header_value(headers, "authorization")
+	prefix := "Bearer "
+	if !strings.has_prefix(auth, prefix) {
+		// Tolerate lowercase prefix (some clients).
+		if !strings.has_prefix(auth, "bearer ") do return false
+	}
+	got := auth[len(prefix):]
+	return constant_time_eq(got, expected)
+}
+
+// Length-independent equality check to avoid leaking token length via
+// timing. For 64-char hex this is overkill, but trivial to get right.
+@(private)
+constant_time_eq :: proc(a: string, b: string) -> bool {
+	if len(a) != len(b) do return false
+	diff: u8 = 0
+	for i in 0 ..< len(a) {
+		diff |= a[i] ~ b[i]
+	}
+	return diff == 0
+}
 
 find_content_length :: proc(headers: string) -> int {
 	lower := strings.to_lower(headers, context.temp_allocator)
@@ -331,6 +439,7 @@ status_text :: proc(code: int) -> string {
 	case 200: return "200 OK"
 	case 204: return "204 No Content"
 	case 400: return "400 Bad Request"
+	case 401: return "401 Unauthorized"
 	case 403: return "403 Forbidden"
 	case 404: return "404 Not Found"
 	case 405: return "405 Method Not Allowed"

--- a/test/ui/redin_test.bb
+++ b/test/ui/redin_test.bb
@@ -14,6 +14,12 @@
   (let [f (clojure.java.io/file ".redin-port")]
     (when (.isFile f) (some-> (slurp f) str/trim parse-long))))
 
+(defn read-token-file
+  "Read the dev server auth token from ./.redin-token if it exists."
+  []
+  (let [f (clojure.java.io/file ".redin-token")]
+    (when (.isFile f) (some-> (slurp f) str/trim))))
+
 ;; ---------------------------------------------------------------------------
 ;; Connection state
 ;; ---------------------------------------------------------------------------
@@ -23,18 +29,25 @@
 (defn- base-url []
   (or (:base-url @conn) "http://localhost:8800"))
 
+(defn- auth-headers []
+  (if-let [t (:token @conn)]
+    {"Authorization" (str "Bearer " t)}
+    {}))
+
 ;; ---------------------------------------------------------------------------
 ;; Connection management
 ;; ---------------------------------------------------------------------------
 
 (defn connect!
   "Open HTTP connection to the dev server.
-   Port defaults to ./.redin-port if present, else 8800."
+   Port defaults to ./.redin-port if present, else 8800.
+   Token defaults to ./.redin-token if present."
   ([] (connect! {}))
-  ([{:keys [host port] :or {host "localhost"}}]
+  ([{:keys [host port token] :or {host "localhost"}}]
    (let [port (or port (read-port-file) 8800)
+         token (or token (read-token-file))
          base (str "http://" host ":" port)]
-     (reset! conn {:base-url base})
+     (reset! conn {:base-url base :token token})
      @conn)))
 
 (defn disconnect!
@@ -48,20 +61,23 @@
 
 (defn- get-json [path]
   (let [resp (http/get (str (base-url) path)
-                       {:headers {"Accept" "application/json"}})]
+                       {:headers (merge {"Accept" "application/json"}
+                                        (auth-headers))})]
     (json/parse-string (:body resp) true)))
 
 (defn- post-json [path body]
   (let [resp (http/post (str (base-url) path)
-                        {:headers {"Content-Type" "application/json"
-                                   "Accept" "application/json"}
+                        {:headers (merge {"Content-Type" "application/json"
+                                          "Accept" "application/json"}
+                                         (auth-headers))
                          :body (json/generate-string body)})]
     (json/parse-string (:body resp) true)))
 
 (defn- put-json [path body]
   (let [resp (http/put (str (base-url) path)
-                       {:headers {"Content-Type" "application/json"
-                                  "Accept" "application/json"}
+                       {:headers (merge {"Content-Type" "application/json"
+                                         "Accept" "application/json"}
+                                        (auth-headers))
                         :body (json/generate-string body)})]
     (json/parse-string (:body resp) true)))
 
@@ -340,7 +356,8 @@
   "Save a screenshot to the given path."
   ([] (screenshot nil))
   ([path]
-   (let [resp (http/get (str (base-url) "/screenshot") {:as :bytes})]
+   (let [resp (http/get (str (base-url) "/screenshot")
+                        {:as :bytes :headers (auth-headers)})]
      (when path
        (with-open [out (java.io.FileOutputStream. path)]
          (.write out ^bytes (:body resp))))

--- a/test/ui/run-all.sh
+++ b/test/ui/run-all.sh
@@ -10,7 +10,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 BINARY="$ROOT_DIR/build/redin"
 PORT_FILE="$ROOT_DIR/.redin-port"
+TOKEN_FILE="$ROOT_DIR/.redin-token"
 PORT=""
+TOKEN=""
 TOTAL_PASSED=0
 TOTAL_FAILED=0
 
@@ -23,9 +25,12 @@ wait_for_server() {
   local timeout=10
   local start=$SECONDS
   while true; do
-    if [ -f "$PORT_FILE" ]; then
+    if [ -f "$PORT_FILE" ] && [ -f "$TOKEN_FILE" ]; then
       PORT="$(cat "$PORT_FILE")"
-      if [ -n "$PORT" ] && curl -s "http://localhost:$PORT/frames" >/dev/null 2>&1; then
+      TOKEN="$(cat "$TOKEN_FILE")"
+      if [ -n "$PORT" ] && [ -n "$TOKEN" ] \
+         && curl -s -H "Authorization: Bearer $TOKEN" \
+                 "http://localhost:$PORT/frames" >/dev/null 2>&1; then
         return 0
       fi
     fi
@@ -70,7 +75,8 @@ for test_file in "$SCRIPT_DIR"/test_*.bb; do
   fi
 
   # Shutdown
-  curl -s -X POST "http://localhost:$PORT/shutdown" >/dev/null 2>&1 || true
+  curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+       "http://localhost:$PORT/shutdown" >/dev/null 2>&1 || true
   wait "$SERVER_PID" 2>/dev/null || true
   echo ""
 done

--- a/test/ui/run.bb
+++ b/test/ui/run.bb
@@ -12,6 +12,8 @@
 (def port (or (some->> cli-args (partition 2 1) (filter #(= (first %) "--port")) first second parse-long)
               (read-port-file)
               8800))
+(def token (or (some->> cli-args (partition 2 1) (filter #(= (first %) "--token")) first second)
+               (read-token-file)))
 
 (def test-files
   (or (seq (filter #(and (str/ends-with? % ".bb") (not (str/starts-with? % "--")))
@@ -30,7 +32,9 @@
 (flush)
 (try
   (http/get (str "http://" host ":" port "/frames")
-            {:headers {"Accept" "application/json"} :timeout 2000})
+            {:headers (merge {"Accept" "application/json"}
+                             (when token {"Authorization" (str "Bearer " token)}))
+             :timeout 2000})
   (println "OK")
   (catch Exception _
     (println "FAILED")
@@ -38,7 +42,7 @@
     (println "Start redin with --dev first.")
     (System/exit 2)))
 
-(connect! {:host host :port port})
+(connect! {:host host :port port :token token})
 
 (def total-passed (atom 0))
 (def total-failed (atom 0))

--- a/test/ui/test_profile.bb
+++ b/test/ui/test_profile.bb
@@ -4,8 +4,10 @@
 
 (defn get-profile []
   (let [port (slurp ".redin-port")
+        token (read-token-file)
         resp (http/get (str "http://localhost:" (clojure.string/trim port) "/profile")
-                       {:throw false})]
+                       {:throw false
+                        :headers (when token {"Authorization" (str "Bearer " token)})})]
     {:status (:status resp)
      :body   (when (= 200 (:status resp)) (json/parse-string (:body resp) true))}))
 

--- a/test/ui/test_text_select.bb
+++ b/test/ui/test_text_select.bb
@@ -8,8 +8,10 @@
 ;; ---------------------------------------------------------------------------
 
 (defn get-selection []
-  (let [resp (http/get (str (base-url) "/selection")
-                       {:headers {"Accept" "application/json"}
+  (let [token (read-token-file)
+        resp (http/get (str (base-url) "/selection")
+                       {:headers (merge {"Accept" "application/json"}
+                                        (when token {"Authorization" (str "Bearer " token)}))
                         :throw false})]
     (when (= 200 (:status resp))
       (json/parse-string (:body resp) true))))


### PR DESCRIPTION
Closes #44 (Critical C1 from the security review, split from #42).

## What changes

- **Auth token** — on startup the dev server generates a 256-bit token (`crypto.rand_bytes` → 64-char hex) and writes it to `./.redin-token` with mode `0600`. Removed on shutdown alongside `.redin-port`.
- **Bearer check** — every non-`OPTIONS` request must carry `Authorization: Bearer <token>`. Constant-time compare. Missing/wrong → `401` with `WWW-Authenticate: Bearer`.
- **Host check** — rejects requests whose `Host` header isn't `localhost:<port>` or `127.0.0.1:<port>`. Defuses DNS rebinding. Bad Host → `403`.
- **CORS removed** — `Access-Control-Allow-Origin: *` and friends are gone from all response paths. `OPTIONS` returns `405` because CORS preflight isn't served (the endpoint is for local tools, not browsers).

## Client-side updates

- `test/ui/redin_test.bb`: `read-token-file`, `connect!` accepts `:token`, all helpers merge an `Authorization` header. Screenshot helper carries auth.
- `test/ui/run.bb`: reads `.redin-token`, threads it through the health-check and `connect!`.
- `test/ui/run-all.sh`: reads both port + token, adds `Authorization: Bearer` to the `wait_for_server` probe and to the shutdown `curl`.
- `test/ui/test_profile.bb`, `test/ui/test_text_select.bb`: direct `http/get` calls updated.
- `docs/reference/dev-server.md`, `docs/core-api.md`, `CLAUDE.md`: document the new auth model; all curl examples now show the header.
- `.gitignore`: ignore `.redin-token`.

## Manual verification

```
curl http://localhost:$PORT/frames                                      → 401
curl -H \"Authorization: Bearer $(cat .redin-token)\" .../frames          → 200
curl -H \"Host: evil.com:$PORT\" -H \"Authorization: Bearer ...\" .../frames → 403
curl -X OPTIONS .../events                                              → 405
ls -la .redin-token                                                     → -rw------- (0600)
```

## Automated verification

- [x] `odin build src/host -out:build/redin` — clean
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 122 passing
- [x] UI suite: 17 apps, 112 tests, all green
- [x] `test_profile` — 3 passing (direct http/get with auth works)

## Deferred

The token file location (CWD) will be revisited in #50 (L1) — eventually `\$XDG_RUNTIME_DIR/redin/<pid>.token`. CWD is fine for now since the file is `0600` and both files are cleaned up on shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)