### PR TITLE
fix(devserver): encode screenshot PNG in memory (closes #45)

### DIFF
--- a/src/host/bridge/devserver.odin
+++ b/src/host/bridge/devserver.odin
@@ -955,16 +955,23 @@ handle_put_aspects :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string)
 // --- Screenshot ---
 
 handle_screenshot :: proc(ch: ^Response_Channel) {
+	// Encode PNG in-memory (no temp file). Avoids the fixed-path
+	// TOCTOU where a local attacker could symlink-swap a predictable
+	// /tmp path between export and readback. Raylib returns a buffer
+	// we own via MemFree. respond_binary blocks until the response
+	// has been sent, so the buffer stays valid across the send and
+	// we free exactly once on return.
 	image := rl.LoadImageFromScreen()
 	defer rl.UnloadImage(image)
-	tmp_path: cstring = "/tmp/redin_screenshot.png"
-	rl.ExportImage(image, tmp_path)
-	data, read_err := os.read_entire_file_from_path("/tmp/redin_screenshot.png", context.allocator)
-	if read_err != nil {
+
+	size: i32 = 0
+	ptr := rl.ExportImageToMemory(image, ".png", &size)
+	if ptr == nil || size <= 0 {
 		respond_text(ch, 500, "Failed to capture screenshot")
 		return
 	}
-	defer delete(data)
+	defer rl.MemFree(ptr)
+
+	data := ([^]u8)(ptr)[:int(size)]
 	respond_binary(ch, "image/png", data)
-	os.remove("/tmp/redin_screenshot.png")
 }


### PR DESCRIPTION
Closes #45 (Critical C2 from the security review, split from #42).
Also subsumes #50's L6 (orphaned temp file on read failure).

## Problem

`handle_screenshot` exported the image to a fixed path `/tmp/redin_screenshot.png` and read it back. Two TOCTOU races against a local attacker:

1. Pre-create `/tmp/redin_screenshot.png` as a symlink → Raylib's write clobbers whatever file the symlink targets.
2. Race-swap the symlink between `ExportImage` and `read_entire_file_from_path` → the HTTP reply returns arbitrary file bytes.

Combined with cross-origin access (pre-#44), the latter let a webpage exfiltrate local files by firing `/screenshot` while a parallel process flipped the symlink.

## Fix

Use `rl.ExportImageToMemory(image, ".png", &size)` — Raylib encodes the PNG into a buffer it owns. Slice into `[]u8`, pass to `respond_binary` (which blocks until sent), then `rl.MemFree` on return. The filesystem is not touched at all.

## Verification

- [x] `odin build src/host -out:build/redin` — clean.
- [x] `curl -H \"Authorization: Bearer $TOKEN\" /screenshot -o shot.png` returns a valid 1280x800 PNG; `file` confirms.
- [x] `/tmp/redin_screenshot.png` is never created during the request.
- [x] Screenshot-using tests pass: `test_line_height`, `test_resize`, `test_shadow`.
- [x] Full UI suite: 17 apps / 112 tests — all green.
- [x] 122 Fennel tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)