### PR TITLE
fix(json): depth cap + cycle detection in codec (closes #46)

### DIFF
--- a/src/host/bridge/json.odin
+++ b/src/host/bridge/json.odin
@@ -68,7 +68,36 @@ json_key :: proc(b: ^strings.Builder, key: string) {
 // Lua value -> JSON
 // ---------------------------------------------------------------------------
 
+// Shared depth cap for encoder and decoder. 128 is well clear of any
+// legitimate data structure and far below the host's native stack
+// limit, so going deeper is either a cycle (encoder) or adversarial
+// input (decoder). Both sides bail with `null` / parse-failure rather
+// than recurse forever.
+MAX_JSON_DEPTH :: 128
+
+@(private = "file")
+Json_Encode_Ctx :: struct {
+	// Tables currently on the recursion path, by lua_topointer. A
+	// "path" set rather than a "seen" set — a DAG where the same
+	// sub-table appears under multiple keys should serialize each
+	// occurrence in full. Only cycles back into an ancestor are
+	// replaced with `null`.
+	path:  map[rawptr]bool,
+	depth: int,
+}
+
 lua_value_to_json :: proc(b: ^strings.Builder, L: ^Lua_State, index: i32) {
+	ctx: Json_Encode_Ctx
+	defer delete(ctx.path)
+	lua_value_to_json_inner(b, L, index, &ctx)
+}
+
+@(private = "file")
+lua_value_to_json_inner :: proc(b: ^strings.Builder, L: ^Lua_State, index: i32, ctx: ^Json_Encode_Ctx) {
+	if ctx.depth >= MAX_JSON_DEPTH {
+		json_null(b)
+		return
+	}
 	abs_idx := index < 0 ? lua_gettop(L) + index + 1 : index
 	t := lua_type(L, abs_idx)
 	switch t {
@@ -81,6 +110,19 @@ lua_value_to_json :: proc(b: ^strings.Builder, L: ^Lua_State, index: i32) {
 	case LUA_TSTRING:
 		json_string(b, string(lua_tostring_raw(L, abs_idx)))
 	case LUA_TTABLE:
+		ptr := lua_topointer(L, abs_idx)
+		if ptr in ctx.path {
+			// Cycle back to an ancestor — emit null and stop.
+			json_null(b)
+			return
+		}
+		ctx.path[ptr] = true
+		ctx.depth += 1
+		defer {
+			delete_key(&ctx.path, ptr)
+			ctx.depth -= 1
+		}
+
 		lua_rawgeti(L, abs_idx, 1)
 		is_array := !lua_isnil(L, -1)
 		lua_pop(L, 1)
@@ -91,7 +133,7 @@ lua_value_to_json :: proc(b: ^strings.Builder, L: ^Lua_State, index: i32) {
 			for i: i32 = 1; i <= n; i += 1 {
 				if i > 1 do json_comma(b)
 				lua_rawgeti(L, abs_idx, i)
-				lua_value_to_json(b, L, -1)
+				lua_value_to_json_inner(b, L, -1, ctx)
 				lua_pop(L, 1)
 			}
 			json_end_array(b)
@@ -104,7 +146,7 @@ lua_value_to_json :: proc(b: ^strings.Builder, L: ^Lua_State, index: i32) {
 					if !first do json_comma(b)
 					first = false
 					json_key(b, string(lua_tostring_raw(L, -2)))
-					lua_value_to_json(b, L, -1)
+					lua_value_to_json_inner(b, L, -1, ctx)
 				}
 				lua_pop(L, 1)
 			}
@@ -160,6 +202,12 @@ json_skip_ws :: proc(s: string, pos: ^int) {
 }
 
 json_decode_value :: proc(L: ^Lua_State, s: string, pos: ^int) -> bool {
+	return json_decode_value_at(L, s, pos, 0)
+}
+
+@(private = "file")
+json_decode_value_at :: proc(L: ^Lua_State, s: string, pos: ^int, depth: int) -> bool {
+	if depth > MAX_JSON_DEPTH do return false
 	json_skip_ws(s, pos)
 	if pos^ >= len(s) do return false
 	c := s[pos^]
@@ -167,9 +215,9 @@ json_decode_value :: proc(L: ^Lua_State, s: string, pos: ^int) -> bool {
 	case '"':
 		return json_decode_string(L, s, pos)
 	case '{':
-		return json_decode_object(L, s, pos)
+		return json_decode_object(L, s, pos, depth)
 	case '[':
-		return json_decode_array(L, s, pos)
+		return json_decode_array(L, s, pos, depth)
 	case 't':
 		return json_decode_literal(L, s, pos, "true")
 	case 'f':
@@ -274,7 +322,7 @@ json_decode_literal :: proc(L: ^Lua_State, s: string, pos: ^int, lit: string) ->
 }
 
 @(private = "file")
-json_decode_object :: proc(L: ^Lua_State, s: string, pos: ^int) -> bool {
+json_decode_object :: proc(L: ^Lua_State, s: string, pos: ^int, depth: int) -> bool {
 	if s[pos^] != '{' do return false
 	pos^ += 1
 	lua_newtable(L)
@@ -290,7 +338,7 @@ json_decode_object :: proc(L: ^Lua_State, s: string, pos: ^int) -> bool {
 		json_skip_ws(s, pos)
 		if pos^ >= len(s) || s[pos^] != ':' {lua_pop(L, 2);return false}
 		pos^ += 1
-		if !json_decode_value(L, s, pos) {lua_pop(L, 2);return false}
+		if !json_decode_value_at(L, s, pos, depth + 1) {lua_pop(L, 2);return false}
 		lua_settable(L, -3)
 		json_skip_ws(s, pos)
 		if pos^ >= len(s) {lua_pop(L, 1);return false}
@@ -304,7 +352,7 @@ json_decode_object :: proc(L: ^Lua_State, s: string, pos: ^int) -> bool {
 }
 
 @(private = "file")
-json_decode_array :: proc(L: ^Lua_State, s: string, pos: ^int) -> bool {
+json_decode_array :: proc(L: ^Lua_State, s: string, pos: ^int, depth: int) -> bool {
 	if s[pos^] != '[' do return false
 	pos^ += 1
 	lua_newtable(L)
@@ -315,7 +363,7 @@ json_decode_array :: proc(L: ^Lua_State, s: string, pos: ^int) -> bool {
 	}
 	idx: i32 = 1
 	for {
-		if !json_decode_value(L, s, pos) {lua_pop(L, 1);return false}
+		if !json_decode_value_at(L, s, pos, depth + 1) {lua_pop(L, 1);return false}
 		lua_rawseti(L, -2, idx)
 		idx += 1
 		json_skip_ws(s, pos)

--- a/src/host/bridge/lua_api.odin
+++ b/src/host/bridge/lua_api.odin
@@ -45,6 +45,7 @@ foreign luajit {
 	lua_tointeger :: proc(L: ^Lua_State, index: i32) -> i64 ---
 	lua_toboolean :: proc(L: ^Lua_State, index: i32) -> i32 ---
 	lua_tolstring :: proc(L: ^Lua_State, index: i32, len: ^uint) -> cstring ---
+	lua_topointer :: proc(L: ^Lua_State, index: i32) -> rawptr ---
 
 	lua_createtable :: proc(L: ^Lua_State, narr: i32, nrec: i32) ---
 	lua_settable    :: proc(L: ^Lua_State, index: i32) ---

--- a/test/ui/json_limits_app.fnl
+++ b/test/ui/json_limits_app.fnl
@@ -1,0 +1,27 @@
+;; Exercises JSON codec depth + cycle limits from #46.
+;; - /state is exposed so the encoder runs on our db.
+;; - :event/install-cycle replaces the db with a table that points
+;;   back to itself, which would previously blow the host stack.
+(local dataflow (require :dataflow))
+(local theme-mod (require :theme))
+
+(theme-mod.set-theme
+  {:body {:font-size 14 :color [216 222 233]}})
+
+(dataflow.init {:counter 0})
+(global redin_get_state (. dataflow :_get-raw-db))
+
+(reg-handler :event/install-cycle
+  (fn [db _]
+    (set db.self db)
+    db))
+
+(reg-handler :event/reset
+  (fn [db _] (dataflow.set-db {:counter 0}) {:counter 0}))
+
+(reg-sub :sub/counter (fn [db] (or db.counter 0)))
+
+(global main_view
+  (fn []
+    [:vbox {}
+     [:text {:aspect :body} (.. "counter=" (tostring (subscribe :sub/counter)))]]))

--- a/test/ui/test_json_limits.bb
+++ b/test/ui/test_json_limits.bb
@@ -1,0 +1,58 @@
+(require '[redin-test :refer :all]
+         '[babashka.http-client :as http]
+         '[cheshire.core :as json]
+         '[clojure.string :as str])
+
+;; Verifies the JSON codec depth cap + cycle detection land from #46:
+;;   - Deeply-nested request bodies must not crash the host (H1).
+;;   - Cyclic Lua tables must not crash the host on /state readback (H2).
+;; Uses the smoke app — which exposes redin_get_state — so /state is live.
+
+(defn- auth-header []
+  (if-let [t (read-token-file)]
+    {"Authorization" (str "Bearer " t)}
+    {}))
+
+(defn- post-raw [path body-str]
+  (http/post (str (base-url) path)
+             {:throw false
+              :headers (merge {"Content-Type" "application/json"} (auth-header))
+              :body body-str}))
+
+(deftest deeply-nested-request-body-rejected-not-crash
+  ;; 1000 nested arrays — pre-fix this blew the native stack. After
+  ;; #46, the decoder caps at MAX_JSON_DEPTH (128) and /events
+  ;; returns 400.
+  (let [deep (str (str/join (repeat 1000 "["))
+                  (str/join (repeat 1000 "]")))
+        resp (post-raw "/events" deep)]
+    (assert (= 400 (:status resp))
+            (str "Expected 400 for over-deep body, got " (:status resp))))
+  ;; Server must still be responsive after the rejection.
+  (let [resp (http/get (str (base-url) "/state")
+                       {:throw false :headers (auth-header)})]
+    (assert (= 200 (:status resp))
+            (str "Server unreachable after deeply-nested POST, got " (:status resp)))))
+
+(deftest decoder-accepts-depth-at-cap
+  ;; Depth exactly 128 should still decode — cap is inclusive.
+  (let [shallow (str (str/join (repeat 128 "["))
+                     (str/join (repeat 128 "]")))
+        resp (post-raw "/events" shallow)]
+    ;; Either 200 (if an event/1000-level-deep handler exists, which
+    ;; it doesn't) or 500 (handler not registered) — but never 400,
+    ;; since 400 means the decoder rejected it.
+    (assert (not= 400 (:status resp))
+            (str "Depth-128 body wrongly rejected by decoder, got 400"))))
+
+(deftest cyclic-lua-table-does-not-crash-state-encoding
+  ;; Ask Fennel to install a cyclic table as the app db. `_get-raw-db`
+  ;; returns the db; dataflow.set-db replaces it.
+  (dispatch ["event/install-cycle"])
+  (wait-ms 200)
+  ;; /state must return 200 and valid JSON (cycles → null).
+  (let [resp (http/get (str (base-url) "/state")
+                       {:throw false :headers (auth-header)})]
+    (assert (= 200 (:status resp)))
+    (assert (json/parse-string (:body resp) true)
+            "Response body should parse as JSON")))


### PR DESCRIPTION
Closes #46 (H1 + H2 from the security review split of #42).

## What changes

Shared `MAX_JSON_DEPTH = 128` used by both codec sides.

### Decoder (H1)

`json_decode_value` now delegates to a private `json_decode_value_at` that carries a depth counter. Objects and arrays recurse with `depth + 1`; beyond the cap the decoder returns `false`, which `handle_post_events` surfaces as a `400 \"invalid JSON\"`. Previously a ~500k-deep `[[[...]]]` body (well under the 1 MiB body cap) blew the native stack.

### Encoder (H2)

`lua_value_to_json` now owns a `Json_Encode_Ctx` with:
- `path: map[rawptr]bool` — tables currently on the recursion path, keyed by `lua_topointer` (identity).
- `depth: int` — belt-and-suspenders against any path-set bug.

On entering a table: if its pointer is already on the path, emit `null` and stop; otherwise mark it, recurse, unmark on return. A DAG where the same sub-table appears under multiple keys still serializes each occurrence in full — only true cycles back into an ancestor are cut.

Added one-line `lua_topointer` FFI binding.

## Tests

New `test/ui/test_json_limits.bb` + `json_limits_app.fnl`:
- **`deeply-nested-request-body-rejected-not-crash`** — POST 1000-deep array to `/events` → `400`, then `/state` still returns `200`. Verifies no crash.
- **`decoder-accepts-depth-at-cap`** — POST 128-deep array → not `400`. Verifies the cap doesn't reject legitimate data.
- **`cyclic-lua-table-does-not-crash-state-encoding`** — dispatch `event/install-cycle` to set `db.self = db`, then `GET /state` → `200` with parseable JSON.

## Full regression

- [x] `odin build src/host -out:build/redin` — clean
- [x] 17 UI apps / 112 tests — all green
- [x] 122 Fennel unit tests — all green
- [x] New `json_limits` suite — 3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)