### PR TITLE
fix(theme): validate font-face paths before LoadFont (closes #48)

### DIFF
--- a/docs/reference/theme.md
+++ b/docs/reference/theme.md
@@ -56,6 +56,8 @@ Register custom fonts via a `:font-face` block in the theme. Each font name maps
 
 `:font-face` is not an aspect -- it's processed separately to load font files before the theme is applied. Font files are loaded via Raylib's `LoadFont`.
 
+Paths are validated before load: they must be relative (no leading `/`), contain no `..` segments, and no NUL bytes. Rejected paths are logged but don't abort the theme — the rest still applies. This matters because themes can come from `PUT /aspects` as well as Fennel code; the check keeps arbitrary filesystem paths out of the font loader regardless of source.
+
 ### Bundled fonts
 
 Three font families are bundled in the binary and available without `:font-face`:

--- a/src/host/bridge/bridge.odin
+++ b/src/host/bridge/bridge.odin
@@ -1114,6 +1114,28 @@ lua_read_node :: proc(L: ^Lua_State, tag: string, attrs_idx: i32, text_content: 
 	return types.NodeStack{}
 }
 
+// Reject any font-face path that could reach outside the project
+// directory. `rl.LoadFont` opens and parses the file immediately, so
+// an unvalidated path lets a theme source (including PUT /aspects)
+// pick any file on disk the redin user can read. Allowed shape:
+// relative path, no leading `/`, no `..` segments, no NUL bytes.
+// Resolution of the final path is still CWD-relative, matching the
+// documented `assets/Font.ttf` pattern in docs/reference/theme.md.
+@(private)
+validate_font_path :: proc(path: string) -> bool {
+	if len(path) == 0 do return false
+	if strings.contains_rune(path, 0) do return false
+	if path[0] == '/' do return false
+	// Segment-wise check so "foo..bar" (a legit filename that happens
+	// to contain two dots) doesn't trip the guard, but "../etc/passwd"
+	// does. Split on '/' only — Windows support would also need '\\'.
+	segments := strings.split(path, "/", context.temp_allocator)
+	for seg in segments {
+		if seg == ".." do return false
+	}
+	return true
+}
+
 load_font_faces :: proc(L: ^Lua_State, index: i32) {
 	lua_pushnil(L)
 	for lua_next(L, index) != 0 {
@@ -1131,6 +1153,11 @@ load_font_faces :: proc(L: ^Lua_State, index: i32) {
 				lua_getfield(L, variants_idx, sk.key)
 				if lua_isstring(L, -1) {
 					path := string(lua_tostring_raw(L, -1))
+					if !validate_font_path(path) {
+						fmt.eprintfln("Rejected font path (must be relative, no ..): %s", path)
+						lua_pop(L, 1)
+						continue
+					}
 					cpath := strings.clone_to_cstring(path, context.temp_allocator)
 					loaded := rl.LoadFont(cpath)
 					if loaded.texture.id > 0 {

--- a/src/host/bridge/font_path_test.odin
+++ b/src/host/bridge/font_path_test.odin
@@ -1,0 +1,39 @@
+package bridge
+
+import "core:testing"
+
+@(test)
+test_validate_font_path_accepts_relative :: proc(t: ^testing.T) {
+	testing.expect(t, validate_font_path("assets/Font.ttf"))
+	testing.expect(t, validate_font_path("Font.ttf"))
+	testing.expect(t, validate_font_path("a/b/c/Font.ttf"))
+	testing.expect(t, validate_font_path("fonts/MyFont-Bold.ttf"))
+}
+
+@(test)
+test_validate_font_path_rejects_absolute :: proc(t: ^testing.T) {
+	testing.expect(t, !validate_font_path("/etc/passwd"))
+	testing.expect(t, !validate_font_path("/tmp/x.ttf"))
+	testing.expect(t, !validate_font_path("/"))
+}
+
+@(test)
+test_validate_font_path_rejects_parent_segments :: proc(t: ^testing.T) {
+	testing.expect(t, !validate_font_path("../Font.ttf"))
+	testing.expect(t, !validate_font_path("a/../b/Font.ttf"))
+	testing.expect(t, !validate_font_path("fonts/../../etc/passwd"))
+}
+
+@(test)
+test_validate_font_path_allows_embedded_dots :: proc(t: ^testing.T) {
+	// Filenames with dots that aren't a `..` segment must pass.
+	testing.expect(t, validate_font_path("foo..bar/Font.ttf"))
+	testing.expect(t, validate_font_path("assets/My.Font.ttf"))
+	testing.expect(t, validate_font_path(".hidden/Font.ttf"))
+}
+
+@(test)
+test_validate_font_path_rejects_empty_and_nul :: proc(t: ^testing.T) {
+	testing.expect(t, !validate_font_path(""))
+	testing.expect(t, !validate_font_path("a\x00b/Font.ttf"))
+}


### PR DESCRIPTION
Closes #48 (M1 from the security review split of #42).

## Problem

`load_font_faces` handed any caller-supplied string straight to `rl.LoadFont`, which opens and parses the file immediately. A theme source — either Fennel code fetched over the network, or `PUT /aspects` (authenticated but arbitrary payload) — could use this to open arbitrary files on disk and exercise font-parser bugs on whatever was found there.

## Fix

New `validate_font_path` helper rejects:

- empty strings / paths containing NUL bytes
- absolute paths (leading `/`)
- any path with a `..` segment (split on `/`, exact segment match — so `My.Font.ttf` and `foo..bar/x.ttf` still pass)

Resolution of a valid path stays CWD-relative, matching the documented `assets/Font.ttf` pattern in `docs/reference/theme.md`. Rejected paths are logged but don't abort the theme swap — the rest of the theme still applies, mirroring the existing \"Failed to load font\" handling for missing files.

## Tests

New `src/host/bridge/font_path_test.odin` — 5 `@(test)` cases:

- accepts typical relative paths (`assets/Font.ttf`, `Font.ttf`, `.hidden/Font.ttf`)
- rejects absolute paths (`/etc/passwd`, `/`)
- rejects `..` segments anywhere (`../Font.ttf`, `a/../b`, `fonts/../../etc/passwd`)
- allows filenames with embedded dots (`My.Font.ttf`, `foo..bar/x.ttf`)
- rejects empty strings and NUL bytes

Run with `odin test src/host/bridge`.

Manual verification via `PUT /aspects`:

| body | outcome |
|---|---|
| `{\"font-face\":{\"test\":{\"regular\":\"/etc/passwd\"}}}` | rejected, logged |
| `{\"font-face\":{\"test\":{\"regular\":\"../../etc/passwd\"}}}` | rejected, logged |
| `{\"font-face\":{\"test\":{\"regular\":\"assets/X.ttf\"}}}` | accepted (rl.LoadFont then fails normally if file is absent) |

## Full regression

- [x] `odin build src/host -out:build/redin` — clean.
- [x] `odin test src/host/bridge` — 5 tests pass.
- [x] 17 UI apps / 112 tests — all green.
- [x] 122 Fennel + `json_limits` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)