### PR TITLE
fix(devserver): harden JSON escape, /state path, /resize (closes #49)

### DIFF
--- a/src/host/bridge/devserver.odin
+++ b/src/host/bridge/devserver.odin
@@ -533,7 +533,7 @@ process_request :: proc(ds: ^Dev_Server, req: ^Pending_Request) {
 			ds.shutdown_requested = true
 			respond_json_ok(ch)
 		} else if req.path == "/resize" {
-			handle_post_resize(ch, req.body)
+			handle_post_resize(ds, ch, req.body)
 		} else if req.path == "/maximize" {
 			rl.MaximizeWindow()
 			respond_json_ok(ch)
@@ -654,13 +654,21 @@ handle_get_state_path :: proc(ds: ^Dev_Server, ch: ^Response_Channel, dot_path: 
 		respond_json_error(ch, 500, `{"error":"lua error"}`)
 		return
 	}
+	// Cap segments and use rawget to skip any __index metamethods —
+	// an app that sets __index on a state table could otherwise be
+	// coaxed into executing Lua via crafted URL paths.
+	MAX_PATH_SEGMENTS :: 32
 	segments := strings.split(dot_path, ".")
 	defer delete(segments)
+	if len(segments) > MAX_PATH_SEGMENTS {
+		lua_pop(L, 1)
+		respond_json_error(ch, 400, `{"error":"path too deep"}`)
+		return
+	}
 	for seg in segments {
 		if lua_istable(L, -1) {
-			s := strings.clone_to_cstring(seg)
-			defer delete(s)
-			lua_getfield(L, -1, s)
+			lua_pushlstring(L, cstring(raw_data(seg)), uint(len(seg)))
+			lua_rawget(L, -2)
 			lua_remove(L, -2)
 		} else {
 			lua_pop(L, 1)
@@ -933,35 +941,35 @@ handle_get_window :: proc(ch: ^Response_Channel) {
 	respond_json(ch, strings.to_string(b))
 }
 
-handle_post_resize :: proc(ch: ^Response_Channel, body: string) {
-	// Parse body without leaving a value on the Lua stack — we only need width/height.
-	width, height := 0, 0
-	{
-		// Minimal hand-parse: { "width": N, "height": M }
-		b := body
-		find_int :: proc(b: string, key: string) -> int {
-			i := strings.index(b, key)
-			if i < 0 do return 0
-			rest := b[i + len(key):]
-			colon := strings.index_byte(rest, ':')
-			if colon < 0 do return 0
-			rest = strings.trim_left_space(rest[colon + 1:])
-			n := 0
-			for j := 0; j < len(rest); j += 1 {
-				c := rest[j]
-				if c >= '0' && c <= '9' {
-					n = n * 10 + int(c - '0')
-				} else if n > 0 {
-					break
-				} else if c != ' ' && c != '\t' {
-					break
-				}
-			}
-			return n
-		}
-		width = find_int(b, "\"width\"")
-		height = find_int(b, "\"height\"")
+handle_post_resize :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	// Proper JSON decode. The previous `strings.index(body, "\"width\"")`
+	// approach parsed `{"widthless":999,"width":150}` as width=999 —
+	// still bounded by the 100..8192 clamp, but fragile enough that a
+	// future caller could be surprised.
+	L := ds.bridge.L
+	pos := 0
+	if !json_decode_value(L, body, &pos) {
+		respond_json_error(ch, 400, `{"error":"invalid JSON"}`)
+		return
 	}
+	defer lua_pop(L, 1)
+	if !lua_istable(L, -1) {
+		respond_json_error(ch, 400, `{"error":"body must be an object"}`)
+		return
+	}
+
+	// lua_rawget reads its key from top-of-stack; after push the table
+	// shifts to -2, so take the absolute index of the table first.
+	table_idx := lua_gettop(L)
+	read_int :: proc(L: ^Lua_State, table_idx: i32, key: string) -> int {
+		lua_pushlstring(L, cstring(raw_data(key)), uint(len(key)))
+		lua_rawget(L, table_idx)
+		defer lua_pop(L, 1)
+		return int(lua_tonumber(L, -1))
+	}
+
+	width := read_int(L, table_idx, "width")
+	height := read_int(L, table_idx, "height")
 	if width < 100 || height < 100 || width > 8192 || height > 8192 {
 		respond_json_error(ch, 400, `{"error":"width and height must be in [100, 8192]"}`)
 		return

--- a/src/host/bridge/json.odin
+++ b/src/host/bridge/json.odin
@@ -266,12 +266,34 @@ json_decode_string :: proc(L: ^Lua_State, s: string, pos: ^int) -> bool {
 			case 't':
 				strings.write_byte(&b, '\t')
 			case 'u':
-				if pos^ + 4 >= len(s) do return false
+				// Need four hex digits at s[pos^+1 .. pos^+5].
+				if pos^ + 5 > len(s) do return false
 				hex := s[pos^ + 1:pos^ + 5]
 				cp, ok := strconv.parse_uint(hex, 16)
 				if !ok do return false
 				pos^ += 4
-				buf, n := utf8.encode_rune(rune(cp))
+
+				// Surrogate pair handling per RFC 8259 §7. A high
+				// surrogate must be followed by `\uYYYY` where YYYY is
+				// a low surrogate; together they encode one codepoint
+				// outside the BMP. A lone low surrogate is invalid.
+				cp32 := u32(cp)
+				switch {
+				case cp32 >= 0xD800 && cp32 <= 0xDBFF:
+					// Need the trailing \uYYYY: 6 chars after current pos^.
+					if pos^ + 7 > len(s) do return false
+					if s[pos^ + 1] != '\\' || s[pos^ + 2] != 'u' do return false
+					lo, ok2 := strconv.parse_uint(s[pos^ + 3:pos^ + 7], 16)
+					if !ok2 do return false
+					lo32 := u32(lo)
+					if lo32 < 0xDC00 || lo32 > 0xDFFF do return false
+					cp32 = 0x10000 + ((cp32 - 0xD800) << 10) + (lo32 - 0xDC00)
+					pos^ += 6 // consume \uYYYY
+				case cp32 >= 0xDC00 && cp32 <= 0xDFFF:
+					// Lone low surrogate.
+					return false
+				}
+				buf, n := utf8.encode_rune(rune(cp32))
 				strings.write_bytes(&b, buf[:n])
 			case:
 				return false

--- a/src/host/bridge/lua_api.odin
+++ b/src/host/bridge/lua_api.odin
@@ -52,6 +52,7 @@ foreign luajit {
 	lua_gettable    :: proc(L: ^Lua_State, index: i32) ---
 	lua_setfield    :: proc(L: ^Lua_State, index: i32, k: cstring) ---
 	lua_getfield    :: proc(L: ^Lua_State, index: i32, k: cstring) ---
+	lua_rawget      :: proc(L: ^Lua_State, index: i32) ---
 	lua_rawgeti     :: proc(L: ^Lua_State, index: i32, n: i32) ---
 	lua_rawseti     :: proc(L: ^Lua_State, index: i32, n: i32) ---
 	lua_next        :: proc(L: ^Lua_State, index: i32) -> i32 ---

--- a/test/ui/input_parsing_app.fnl
+++ b/test/ui/input_parsing_app.fnl
@@ -1,0 +1,34 @@
+;; Test app for dev-server input-parsing hardening (#49).
+;; - Expose state for /state/<path> tests, including a table with an
+;;   __index metatable that would execute Lua if the endpoint still
+;;   went through metamethods.
+;; - Expose state containing a string with surrogate-pair content so
+;;   /state round-tripping through JSON stays correct.
+
+(local dataflow (require :dataflow))
+(local theme-mod (require :theme))
+
+(theme-mod.set-theme {:body {:font-size 14 :color [216 222 233]}})
+
+(dataflow.init {:plain {:leaf "ok"}
+                :tripped false})
+(global redin_get_state (. dataflow :_get-raw-db))
+
+(reg-handler :event/install-metatable
+  ;; Put an __index metatable on db.plain. If /state/<path> routes
+  ;; through lua_getfield, reading plain.absent would call __index
+  ;; and set db.tripped=true. Under lua_rawget, it must NOT.
+  (fn [db _]
+    (let [mt {:__index (fn [t k] (set db.tripped true) "tripped")}]
+      (setmetatable db.plain mt))
+    db))
+
+(reg-handler :event/reset
+  (fn [db _] (setmetatable db.plain nil) (set db.tripped false) db))
+
+(reg-sub :sub/tripped (fn [db] db.tripped))
+
+(global main_view
+  (fn []
+    [:vbox {}
+     [:text {:aspect :body} (.. "tripped=" (tostring (subscribe :sub/tripped)))]]))

--- a/test/ui/test_input_parsing.bb
+++ b/test/ui/test_input_parsing.bb
@@ -1,0 +1,86 @@
+(require '[redin-test :refer :all]
+         '[babashka.http-client :as http]
+         '[cheshire.core :as json]
+         '[clojure.string :as str])
+
+;; Covers #49: dev-server input-parsing hardening.
+;; - M2: JSON \uXXXX surrogate pairs decode correctly, lone surrogates reject.
+;; - M3: /state/<path> uses lua_rawget (no metamethod invocation).
+;; - M4: /resize uses proper JSON parse (can't be confused by substring keys).
+
+(defn- auth-header []
+  (if-let [t (read-token-file)]
+    {"Authorization" (str "Bearer " t)}
+    {}))
+
+(defn- post-raw [path body-str]
+  (http/post (str (base-url) path)
+             {:throw false
+              :headers (merge {"Content-Type" "application/json"} (auth-header))
+              :body body-str}))
+
+;; ---- M2 ---------------------------------------------------------------
+
+(deftest decoder-accepts-surrogate-pair
+  ;; \uD83D\uDE00 (😀) — high + low surrogate must decode to U+1F600.
+  ;; The JSON body is a dispatch payload that won't match any handler,
+  ;; so we expect 500 (not 400: 400 would mean the decoder rejected it).
+  (let [resp (post-raw "/events" "[\"event/does-not-exist\", {\"emoji\":\"\\uD83D\\uDE00\"}]")]
+    (assert (not= 400 (:status resp))
+            (str "Decoder wrongly rejected surrogate pair, got 400"))))
+
+(deftest decoder-rejects-lone-surrogate
+  ;; \uD83D alone (high surrogate, no low) is invalid per RFC 8259 §7.
+  (let [resp (post-raw "/events" "[\"event/x\", {\"bad\":\"\\uD83D\"}]")]
+    (assert (= 400 (:status resp))
+            (str "Expected 400 for lone surrogate, got " (:status resp)))))
+
+;; ---- M3 ---------------------------------------------------------------
+
+(deftest state-path-bypasses-metamethods
+  (dispatch ["event/reset"])
+  (wait-ms 100)
+  (dispatch ["event/install-metatable"])
+  (wait-ms 100)
+  ;; Probe a key not present on db.plain. Under lua_getfield, __index
+  ;; would fire, set tripped=true, and return "tripped". Under
+  ;; lua_rawget, __index is bypassed and the result is nil.
+  (let [resp (http/get (str (base-url) "/state/plain.absent")
+                       {:throw false :headers (auth-header)})]
+    (assert (= 200 (:status resp)))
+    (assert (= "null" (str/trim (:body resp)))
+            (str "Expected null via rawget, got " (:body resp))))
+  ;; And verify __index did NOT run.
+  (let [resp (http/get (str (base-url) "/state/tripped")
+                       {:throw false :headers (auth-header)})]
+    (assert (= "false" (str/trim (:body resp)))
+            (str "Metamethod fired (tripped=true) — /state/<path> must use rawget"))))
+
+(deftest state-path-rejects-over-long-dot-chain
+  ;; 33 segments — over the 32 cap.
+  (let [path (str/join "." (repeat 33 "x"))
+        resp (http/get (str (base-url) "/state/" path)
+                       {:throw false :headers (auth-header)})]
+    (assert (= 400 (:status resp))
+            (str "Expected 400 for 33-segment path, got " (:status resp)))))
+
+;; ---- M4 ---------------------------------------------------------------
+
+(deftest resize-ignores-substring-match
+  ;; `:widthless` would match `strings.index(body, "\"width\"")` under
+  ;; the old parser. The real width field must win.
+  (let [resp (post-raw "/resize"
+              "{\"widthless\":999,\"heightless\":999,\"width\":640,\"height\":480}")]
+    (assert (= 200 (:status resp))
+            (str "Expected 200 resize, got " (:status resp))))
+  ;; Confirm the window is actually 640x480, not 999x999.
+  (wait-ms 200)
+  (let [resp (http/get (str (base-url) "/window")
+                       {:throw false :headers (auth-header)})
+        parsed (json/parse-string (:body resp) true)]
+    (assert (= 640 (:width parsed)) (str "width=" (:width parsed)))
+    (assert (= 480 (:height parsed)) (str "height=" (:height parsed)))))
+
+(deftest resize-rejects-invalid-json
+  (let [resp (post-raw "/resize" "not json")]
+    (assert (= 400 (:status resp)))))


### PR DESCRIPTION
Closes #49 (M2 + M3 + M4 from the security review split of #42).

## M2 — JSON `\uXXXX` escape

`json_decode_string` now:

- Tightens the bounds check to `pos^ + 5 > len(s)` (the `>=` variant still worked but was backwards-rounded).
- Handles surrogate pairs per RFC 8259 §7: a high surrogate (`0xD800..=0xDBFF`) requires a trailing `\uYYYY` low-surrogate sibling; together they decode to one astral-plane codepoint (e.g. `\uD83D\uDE00` → U+1F600 😀).
- Rejects lone surrogates with a parse failure. Previously both re-emitted bytes that form invalid UTF-8 and could round-trip garbage through `/state`.

## M3 — `/state/<dot.path>` traversed metamethods

Switched per-segment lookup from `lua_getfield` to `lua_pushlstring` + `lua_rawget`. An app that attached an `__index` metatable to a state table could previously be coaxed into executing Lua via a crafted URL path; `rawget` bypasses that. Added a **32-segment cap** on the dot chain; over-long paths return `400`.

New FFI binding: `lua_rawget`.

## M4 — `/resize` parsed JSON by substring match

Replaced the hand-rolled `strings.index(body, \"\\\"width\\\"\")` with a real `json_decode_value` into a transient Lua table; `width` / `height` read via `lua_rawget`. Pre-fix, `{\"widthless\":999,\"width\":150}` parsed as `999`; now it's `150`. The 100..8192 clamp stays.

Bug caught during testing: after `lua_pushlstring`, the table's relative index shifts, so `lua_rawget(L, -1)` would use the key as the table and segfault. Fixed by resolving the table's absolute index first.

## Tests

New `test/ui/test_input_parsing.bb` + `input_parsing_app.fnl` — 6 integration tests:

- `decoder-accepts-surrogate-pair` — `\uD83D\uDE00` decodes, not `400`.
- `decoder-rejects-lone-surrogate` — `\uD83D` alone → `400`.
- `state-path-bypasses-metamethods` — with `__index` installed on `db.plain`, `GET /state/plain.absent` returns `null` and `db.tripped` stays `false`.
- `state-path-rejects-over-long-dot-chain` — 33-segment path → `400`.
- `resize-ignores-substring-match` — `{\"widthless\":999,\"heightless\":999,\"width\":640,\"height\":480}` resizes to 640×480 (verified via `/window`).
- `resize-rejects-invalid-json` — bad body → `400`.

## Full regression

- [x] `odin build src/host -out:build/redin` — clean.
- [x] `odin test src/host/bridge` — 5 font-path tests pass.
- [x] 18 UI apps / 118 tests — all green.
- [x] 122 Fennel tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)