### PR TITLE
fix(devserver,shell): L1/L2/L3/L4/L5 hardening grab bag (closes #50)

### DIFF
--- a/docs/reference/dev-server.md
+++ b/docs/reference/dev-server.md
@@ -30,6 +30,12 @@ TOKEN=$(cat .redin-token)
 AUTH="Authorization: Bearer $TOKEN"
 ```
 
+### Runtime caveats
+
+**`--dev` trusts its filesystem.** The hot-reload watcher re-requires `src/runtime/*.fnl` whenever their mtimes advance. Anyone who can write to `src/runtime` gets code execution in the running process on the next tick. Don't run `--dev` from a world-writable directory, and don't leave `--dev` enabled in production.
+
+**The bearer token is a capability.** Any holder can dispatch events, which means any app-registered `:shell` or `:http` effect is one authenticated POST away from arbitrary shell execution or network access in the user's context. The token is 0600 and per-run, so this only matters if the token leaks — but plan accordingly when wiring `:shell` handlers.
+
 ---
 
 ## Read endpoints

--- a/src/host/bridge/devserver.odin
+++ b/src/host/bridge/devserver.odin
@@ -121,12 +121,15 @@ devserver_init :: proc(ds: ^Dev_Server, b: ^Bridge) {
 	ds.expected_host_v4   = fmt.aprintf("127.0.0.1:%d", bound_port)
 	ds.expected_host_name = fmt.aprintf("localhost:%d", bound_port)
 
+	// 0600 — owner read+write only. Previously .redin-port was 0644
+	// which leaked the bound port to anyone who could list the CWD.
+	// Testing helpers run as the same user, so 0600 doesn't regress
+	// them.
+	private_perm := os.Permissions{.Read_User, .Write_User}
 	port_str := fmt.tprintf("%d", bound_port)
-	if err := os.write_entire_file(PORT_FILE, port_str); err != nil {
+	if err := os.write_entire_file(PORT_FILE, transmute([]u8)port_str, private_perm); err != nil {
 		fmt.eprintfln("Warning: could not write %s: %v", PORT_FILE, err)
 	}
-	// 0600 — owner read+write only.
-	private_perm := os.Permissions{.Read_User, .Write_User}
 	if err := os.write_entire_file(TOKEN_FILE, transmute([]u8)ds.auth_token, private_perm); err != nil {
 		fmt.eprintfln("Warning: could not write %s: %v", TOKEN_FILE, err)
 	}
@@ -459,7 +462,9 @@ find_content_length :: proc(headers: string) -> int {
 	lower := strings.to_lower(headers, context.temp_allocator)
 	idx := strings.index(lower, "content-length:")
 	if idx < 0 do return 0
-	rest := strings.trim_left_space(headers[idx + len("content-length:"):])
+	// Trim from `lower` (same index) so lookup and extraction don't
+	// reference different case representations of the header block.
+	rest := strings.trim_left_space(lower[idx + len("content-length:"):])
 	end := strings.index_any(rest, "\r\n")
 	if end < 0 do end = len(rest)
 	val := strings.trim_space(rest[:end])

--- a/src/host/bridge/shell.odin
+++ b/src/host/bridge/shell.odin
@@ -170,43 +170,29 @@ execute_shell :: proc(req: Shell_Request) -> Shell_Response {
 	read_buf: [4096]u8
 	stdout_done, stderr_done: bool
 
+	// Blocking reads on child pipes. The previous version gated each
+	// read on os.pipe_has_data and fell through to os.read in both
+	// branches — same behaviour, extra syscall, and on macOS/BSD the
+	// has_data probe could false-negative and turn a quick command
+	// into a hang (the `else` branch still called os.read after the
+	// probe said "nothing there"). Direct blocking reads are simpler
+	// and work on all platforms: when the child exits and closes its
+	// pipe, os.read returns 0 / error and we mark that side done.
 	for !stdout_done || !stderr_done {
 		if !stdout_done {
-			has_data, _ := os.pipe_has_data(stdout_r)
-			if has_data {
-				n, err := os.read(stdout_r, read_buf[:])
-				if err == nil && n > 0 {
-					append(&stdout_buf, ..read_buf[:n])
-				} else {
-					stdout_done = true
-				}
+			n, err := os.read(stdout_r, read_buf[:])
+			if err != nil || n <= 0 {
+				stdout_done = true
 			} else {
-				// Check if pipe is closed (EOF)
-				n, err := os.read(stdout_r, read_buf[:])
-				if err != nil || n == 0 {
-					stdout_done = true
-				} else {
-					append(&stdout_buf, ..read_buf[:n])
-				}
+				append(&stdout_buf, ..read_buf[:n])
 			}
 		}
-
 		if !stderr_done {
-			has_data, _ := os.pipe_has_data(stderr_r)
-			if has_data {
-				n, err := os.read(stderr_r, read_buf[:])
-				if err == nil && n > 0 {
-					append(&stderr_buf, ..read_buf[:n])
-				} else {
-					stderr_done = true
-				}
+			n, err := os.read(stderr_r, read_buf[:])
+			if err != nil || n <= 0 {
+				stderr_done = true
 			} else {
-				n, err := os.read(stderr_r, read_buf[:])
-				if err != nil || n == 0 {
-					stderr_done = true
-				} else {
-					append(&stderr_buf, ..read_buf[:n])
-				}
+				append(&stderr_buf, ..read_buf[:n])
 			}
 		}
 	}


### PR DESCRIPTION
Closes #50 (low-priority grab bag from the security review split of #42).

L6 was already subsumed by #45 (PR #52) — the screenshot endpoint no longer writes a temp file, so there's nothing to clean up on read failure.

## L1 — `.redin-port` mode 0644 → 0600

Matches `.redin-token`: write with `Permissions{Read_User, Write_User}`. Same-user test harness still reads it; other users on the box can no longer see the bound port via the shared directory. (Full `$XDG_RUNTIME_DIR/redin/<pid>.port` relocation is deliberately skipped — it would break the CWD contract the test harness and docs depend on, and the mode fix closes the actual leak.)

## L2 — shell IO loop redundancy

`process_shell_command` probed `os.pipe_has_data` and then fell through to `os.read` in *both* branches — the probe added a syscall for nothing, and on macOS/BSD where `pipe_has_data` can false-negative, a quick command's output went down the else branch that still called `os.read` and blocked.

Collapsed to direct blocking reads; EOF (`n == 0` or error) marks that stream done. Same behaviour on happy paths, no false-negative hang on other platforms.

## L3 — `find_content_length` case split

Lookup indexed into `lower` (via `strings.to_lower`), but extraction sliced the original `headers`. Only worked because the values were ASCII digits. Now extraction slices `lower` at the same index, so lookup and parse agree on the buffer.

## L4 + L5 — runtime caveats in docs

Added a \"Runtime caveats\" block to `docs/reference/dev-server.md`:

- **Hot-reload**: `src/runtime/*.fnl` auto-reloads on mtime change. Don't run `--dev` from a world-writable directory; don't leave `--dev` on in production.
- **Bearer-token capability**: any holder can dispatch events, which means any app-registered `:shell` / `:http` effect is one authenticated POST away from arbitrary shell execution or network access.

No code change for L4/L5 — they were informational findings.

## Verification

```
$ ls -la .redin-port .redin-token
-rw------- .redin-port
-rw------- .redin-token
```

Hand-sent request with lowercase `content-length: 17` still parses (`POST /events` returns 200). Full regression — 19 UI apps / 124 tests + 122 Fennel + 5 Odin bridge unit tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)