### PR TITLE
test(input): cover multi-line input in test_input

### DIFF
--- a/test/ui/input_app.fnl
+++ b/test/ui/input_app.fnl
@@ -13,6 +13,7 @@
 
 (dataflow.init
   {:input-value ""
+   :multiline-value ""
    :submitted []
    :last-key nil})
 
@@ -44,11 +45,23 @@
   (fn [db event]
     (assoc db :input-value (or (. event 2) ""))))
 
+;; Multi-line input: no :key handler, so Enter inserts \n in the buffer
+;; (host/input/input.odin:293) and the value comes back via :change.
+(reg-handler :event/multiline-change
+  (fn [db event]
+    (let [ctx (. event 2)]
+      (assoc db :multiline-value (or ctx.value "")))))
+
 (reg-handler :event/reset
   (fn [db event]
-    (assoc (assoc (assoc db :input-value "") :submitted []) :last-key nil)))
+    (-> db
+        (assoc :input-value "")
+        (assoc :multiline-value "")
+        (assoc :submitted [])
+        (assoc :last-key nil))))
 
 (reg-sub :input-value (fn [db] (get db :input-value "")))
+(reg-sub :multiline-value (fn [db] (get db :multiline-value "")))
 (reg-sub :submitted (fn [db] (get db :submitted [])))
 (reg-sub :last-key (fn [db] (get db :last-key)))
 (reg-sub :submitted-count (fn [db] (length (get db :submitted []))))
@@ -56,6 +69,7 @@
 (global main_view
   (fn []
     (let [input-val (subscribe :input-value)
+          multiline-val (subscribe :multiline-value)
           items (subscribe :submitted)
           count (subscribe :submitted-count)
           last-key (subscribe :last-key)]
@@ -68,6 +82,11 @@
        [:text {:id :current-value :aspect :body} (.. "value:" input-val)]
        [:text {:id :submitted-count :aspect :body} (.. "count:" (tostring count))]
        [:text {:id :last-key :aspect :body} (.. "key:" (or last-key ""))]
+       [:input {:id :multiline-input :aspect :input :width 250 :height 80
+                :value multiline-val
+                :placeholder "Multi-line (Enter for new line)..."
+                :change [:event/multiline-change]}]
+       [:text {:id :multiline-current :aspect :body} (.. "ml:" multiline-val)]
        [:vbox {:id :submitted-list}
         (icollect [i item (ipairs (or items []))]
           [:text {:id (.. :item- (tostring i)) :aspect :body} item])]])))

--- a/test/ui/test_input.bb
+++ b/test/ui/test_input.bb
@@ -102,14 +102,65 @@
   (dispatch ["event/set-input" "direct value"])
   (wait-for (state= "input-value" "direct value") {:timeout 2000}))
 
+;; -- Multi-line input --
+;;
+;; The `:multiline-input` has :change but no :key, so Enter inserts a
+;; literal \n in the buffer (host/input/input.odin:293) and the
+;; resulting value arrives via the :change handler. These tests
+;; exercise that path via the dispatch API — no real typing is
+;; possible from the dev-server HTTP surface today.
+
+(deftest multiline-change-preserves-newlines
+  (dispatch ["event/reset"])
+  (wait-ms 200)
+  (dispatch ["event/multiline-change" {:value "line1\nline2"}])
+  (wait-for (state= "multiline-value" "line1\nline2") {:timeout 2000}))
+
+(deftest multiline-change-three-lines
+  (dispatch ["event/reset"])
+  (wait-ms 200)
+  (dispatch ["event/multiline-change" {:value "one\ntwo\nthree"}])
+  (wait-for (state= "multiline-value" "one\ntwo\nthree") {:timeout 2000}))
+
+(deftest multiline-change-renders-in-frame
+  (dispatch ["event/reset"])
+  (wait-ms 200)
+  (dispatch ["event/multiline-change" {:value "alpha\nbeta"}])
+  (wait-ms 200)
+  (let [el (find-element {:tag :input :id :multiline-input})
+        attrs (second el)]
+    (assert (= "alpha\nbeta" (:value attrs))
+            (str "Frame value should carry the newline, got: "
+                 (pr-str (:value attrs))))))
+
+(deftest multiline-change-empty-value
+  (dispatch ["event/reset"])
+  (wait-ms 200)
+  (dispatch ["event/multiline-change" {:value "something\nwith\nnewlines"}])
+  (wait-ms 200)
+  (dispatch ["event/multiline-change" {:value ""}])
+  (wait-for (state= "multiline-value" "") {:timeout 2000}))
+
+(deftest multiline-distinct-from-single-line
+  ;; Writes to one input must not leak into the other.
+  (dispatch ["event/reset"])
+  (wait-ms 200)
+  (dispatch ["event/input-change" {:value "single"}])
+  (dispatch ["event/multiline-change" {:value "multi\nline"}])
+  (wait-ms 200)
+  (assert-state "input-value" #(= % "single"))
+  (assert-state "multiline-value" #(= % "multi\nline")))
+
 ;; -- Reset --
 
 (deftest reset-clears-all
   (dispatch ["event/input-change" {:value "leftover"}])
+  (dispatch ["event/multiline-change" {:value "ml\nleftover"}])
   (wait-ms 100)
   (dispatch ["event/input-key" {:key "enter"}])
   (wait-ms 200)
   (dispatch ["event/reset"])
   (wait-for (state= "input-value" "") {:timeout 2000})
+  (assert-state "multiline-value" #(= % "") "Reset should clear multi-line input")
   (assert-state "submitted" #(= (count %) 0) "Reset should clear submitted list")
   (assert-state "last-key" nil? "Reset should clear last-key"))


### PR DESCRIPTION
## What

Added a second input (`:multiline-input`) to `input_app.fnl` that wires only `:change`, no `:key`. With no key handler to intercept Enter, the host's `insert_char('\n')` path (`src/host/input/input.odin:293`) runs and the resulting value round-trips through state with newlines preserved. The existing `:test-input` keeps its Enter-submits-and-clears behaviour so the original 14 tests still pass.

## New tests (5)

- `multiline-change-preserves-newlines`
- `multiline-change-three-lines`
- `multiline-change-renders-in-frame` — checks `\n` survives the frame tree
- `multiline-change-empty-value`
- `multiline-distinct-from-single-line` — no cross-contamination between inputs
- `reset-clears-all` extended to cover the multi-line buffer too

Total: **19 pass, 0 fail** (was 14).

## Manual check

Dispatched a 3-line value and screenshot'd `input_app`:

- The `:multiline-input` box shows three physical lines.
- The mirrored `:text` node (`ml:first line / second line / third line`) renders correctly.

Framework path is sound end-to-end — the earlier \"doesn't seem to work\" was the pre-existing `:test-input` consuming Enter to submit+clear, which is app behaviour, not a framework bug.

## Caveat

These tests exercise the dispatch API. The dev server has no keystroke-injection endpoint, so actual Enter typing can't be driven from HTTP today. Adding `/type` (or similar) is a separate follow-up if we want to test the raw-keystroke → `\n`-insertion path directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)