### PR TITLE
perf(text_select): hit-testing reuses Text_Line[] cache (closes #39)

### DIFF
--- a/src/host/input/text_select.odin
+++ b/src/host/input/text_select.odin
@@ -44,7 +44,7 @@ process_text_selection :: proc(
 			text_node, is_text := nodes[tl.node_idx].(types.NodeText)
 			if !is_text do continue
 
-			offset := node_byte_offset_at(text_node, node_rects[tl.node_idx], pt, theme)
+			offset := node_byte_offset_at(tl.node_idx, text_node, node_rects[tl.node_idx], pt, theme)
 
 			// Shift-click extends the existing selection to the new offset within
 			// the same node. The anchor remains at its original byte.
@@ -89,13 +89,24 @@ process_text_selection :: proc(
 				lo = prev_word(content_bytes, offset)
 				hi = next_word(content_bytes, offset)
 			case 3:
-				// Whole wrapped line at this offset.
+				// Whole wrapped line at this offset. Reuse the cached
+				// wrap from layout/draw — same (idx, width) key.
 				f := resolve_font(text_node, theme)
 				fs := resolve_font_size(text_node, theme)
-				lines := text_pkg.compute_lines(text_node.content, f, fs, 0, node_rects[tl.node_idx].width)
-				defer delete(lines)
+				width := node_rects[tl.node_idx].width
+				lines: []text_pkg.Text_Line
+				fresh: [dynamic]text_pkg.Text_Line
+				owns := false
+				if cached, ok := text_pkg.lookup_lines(tl.node_idx, width); ok {
+					lines = cached
+				} else {
+					fresh = text_pkg.compute_lines(text_node.content, f, fs, 0, width)
+					lines = fresh[:]
+					owns = true
+				}
+				defer if owns do delete(fresh)
 				if len(lines) > 0 {
-					line_idx, _ := text_pkg.cursor_to_line(lines[:], offset)
+					line_idx, _ := text_pkg.cursor_to_line(lines, offset)
 					lo = lines[line_idx].start
 					hi = lines[line_idx].end
 				}
@@ -132,7 +143,7 @@ process_text_selection :: proc(
 			if is_text {
 				mouse := rl.GetMousePosition()
 				rect := node_rects[idx]
-				offset := node_byte_offset_at(text_node, rect, mouse, theme)
+				offset := node_byte_offset_at(idx, text_node, rect, mouse, theme)
 				if offset == gesture.anchor_offset {
 					// Collapsed to a caret; drop the selection range.
 					state.selection_start = -1
@@ -158,6 +169,7 @@ process_text_selection :: proc(
 // Uses the same font/size resolution as render.
 @(private)
 node_byte_offset_at :: proc(
+	node_idx: int,
 	n: types.NodeText,
 	rect: rl.Rectangle,
 	pt: rl.Vector2,
@@ -176,8 +188,18 @@ node_byte_offset_at :: proc(
 	}
 	lh := text_pkg.line_height(font_size, lh_ratio)
 
-	lines := text_pkg.compute_lines(n.content, f, font_size, spacing, rect.width)
-	defer delete(lines)
+	// Prefer the cache populated by layout/draw at the same (idx, width).
+	lines: []text_pkg.Text_Line
+	fresh: [dynamic]text_pkg.Text_Line
+	owns := false
+	if cached, ok := text_pkg.lookup_lines(node_idx, rect.width); ok {
+		lines = cached
+	} else {
+		fresh = text_pkg.compute_lines(n.content, f, font_size, spacing, rect.width)
+		lines = fresh[:]
+		owns = true
+	}
+	defer if owns do delete(fresh)
 
 	rel_y := pt.y - rect.y
 	line_idx := int(rel_y / lh)


### PR DESCRIPTION
Closes #39.

## What

Three text-selection gestures still computed wraps from scratch even though layout/draw already held the same wrap in `intrinsic_cache` under the same `(idx, width)` key:

- Triple-click \"whole wrapped line\" (`text_select.odin:95`).
- Click-to-cursor on mouse-down and drag-extend (`node_byte_offset_at`).

Both now go through `text_pkg.lookup_lines(idx, rect.width)` and only call `compute_lines` on miss (e.g. width mismatch, or the node idx not yet seen by layout).

`node_byte_offset_at` grew a `node_idx` parameter — the two call sites in `text_select` already had the index available (`tl.node_idx` / `idx`), so it's a tiny signature change.

## Perf note

These paths fire on click / drag, not per frame, so the saved computation is small per user interaction. The real value is consistency — this was the last NodeText compute_lines caller outside the cache, leaving #40 (NodeInput) as the only remaining gap.

## Regression

- [x] `odin build src/host -out:build/redin` — clean.
- [x] `test_text_select` — 4/4 pass.
- [x] UI suite: 19 apps / 124 tests — all green.
- [x] 122 Fennel + bridge (5) + parser (26) unit tests — all green.
- [x] `src/host/input` tests: pre-existing flakiness (1–2 failures on repeated runs) observed both with and without this change; not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)