### PR TITLE
docs(guide): update views to return frame tree directly (closes #62)

### DIFF
--- a/docs/guide/building-apps.md
+++ b/docs/guide/building-apps.md
@@ -91,27 +91,25 @@ The framework re-records dependencies on every recomputation. No explicit wiring
 
 ## 5. Write the view
 
-A view function returns `{:frame [...] :bind {}}`. It calls `subscribe` to read derived state, then builds the frame tree as nested arrays. Events are declared directly on elements as attributes (`:click`, `:change`, `:key`).
+A view function returns the frame tree directly as nested arrays. It calls `subscribe` to read derived state, then builds the frame tree. Events are declared directly on elements as attributes (`:click`, `:change`, `:key`).
 
 ```fennel
 (global main_view
   (fn []
     (let [items (subscribe :items)
           input-val (subscribe :input-value)]
-      {:frame
-        [:vbox {}
-         [:stack {}
-          [:vbox {:aspect :surface :layout :center}
-           [:text {:aspect :heading :layout :center} "Todo List"]
-           [:input {:aspect :input :width 250 :height 42
-                    :value input-val
-                    :change [:todo/input] :key [:todo/add]}]
-           [:button {:width 250 :height 42 :aspect :button
-                     :click [:todo/add]} "Add"]
-           [:vbox {:overflow :scroll-y :aspect :muted}
-            (icollect [_ item (ipairs (or items []))]
-              [:text {:aspect :body} item.text])]]]]
-       :bind {}})))
+      [:vbox {}
+       [:stack {}
+        [:vbox {:aspect :surface :layout :center}
+         [:text {:aspect :heading :layout :center} "Todo List"]
+         [:input {:aspect :input :width 250 :height 42
+                  :value input-val
+                  :change [:todo/input] :key [:todo/add]}]
+         [:button {:width 250 :height 42 :aspect :button
+                   :click [:todo/add]} "Add"]
+         [:vbox {:overflow :scroll-y :aspect :muted}
+          (icollect [_ item (ipairs (or items []))]
+            [:text {:aspect :body} item.text])]]]])))
 ```
 
 `icollect` returns a list of frames that the framework flattens into the parent's children automatically. No wrapper element needed.

--- a/docs/guide/lua-guide.md
+++ b/docs/guide/lua-guide.md
@@ -62,17 +62,14 @@ end)
 -- 5. Define the view
 function main_view()
   local count = subscribe("sub/counter")
-  return {
-    frame = {"vbox", {aspect = "surface"},
-      {"text", {aspect = "heading"}, tostring(count)},
-      {"button", {aspect = "button", click = {"event/inc"}}, "+1"}},
-    bind = {}
-  }
+  return {"vbox", {aspect = "surface"},
+    {"text", {aspect = "heading"}, tostring(count)},
+    {"button", {aspect = "button", click = {"event/inc"}}, "+1"}}
 end
 ```
 
-The runtime calls `main_view` (the global) on each render tick. The returned table must
-have `frame` and `bind` keys.
+The runtime calls `main_view` (the global) on each render tick. It must return the frame
+tree directly: a Lua table shaped like `{tag, attrs, child1, child2, ...}`.
 
 ---
 
@@ -209,20 +206,17 @@ function main_view()
     table.insert(rows, {"text", {aspect = "body"}, item.text})
   end
 
-  return {
-    frame = {"vbox", {},
-      {"stack", {},
-        {"vbox", {aspect = "surface", layout = "center"},
-          {"text", {aspect = "heading", layout = "center"}, "Todo List"},
-          {"input", {aspect = "input", width = 250, height = 42,
-                     value = input_val,
-                     change = {"todo/input"}, key = {"todo/add"}}},
-          {"button", {width = 250, height = 42, aspect = "button",
-                      click = {"todo/add"}}, "Add"},
-          {"vbox", {overflow = "scroll-y", aspect = "muted"},
-            table.unpack(rows)}}}},
-    bind = {}
-  }
+  return {"vbox", {},
+    {"stack", {},
+      {"vbox", {aspect = "surface", layout = "center"},
+        {"text", {aspect = "heading", layout = "center"}, "Todo List"},
+        {"input", {aspect = "input", width = 250, height = 42,
+                   value = input_val,
+                   change = {"todo/input"}, key = {"todo/add"}}},
+        {"button", {width = 250, height = 42, aspect = "button",
+                    click = {"todo/add"}}, "Add"},
+        {"vbox", {overflow = "scroll-y", aspect = "muted"},
+          table.unpack(rows)}}}}
 end
 ```
 
@@ -242,21 +236,27 @@ Then run your Lua app:
 ./build/redin todo.lua
 ```
 
-Dev mode starts the HTTP dev server on `localhost:8800`:
+Dev mode starts the HTTP dev server (picks port 8800 by default; walks upward if busy):
 
 ```sh
 ./build/redin --dev todo.lua
 ```
 
+The bound port is written to `./.redin-port` and a per-run bearer token to `./.redin-token`:
+
 ```sh
+PORT=$(cat .redin-port)
+TOKEN=$(cat .redin-token)
+AUTH="Authorization: Bearer $TOKEN"
+
 # Inspect live state
-curl localhost:8800/state
+curl -H "$AUTH" localhost:$PORT/state
 
 # Dispatch an event from the terminal
-curl -X POST localhost:8800/events \
-  -H 'Content-Type: application/json' \
-  -d '{"event": ["todo/add"]}'
+curl -X POST -H "$AUTH" -H 'Content-Type: application/json' \
+  -d '["todo/add"]' \
+  localhost:$PORT/events
 ```
 
-See [core-api.md](../core-api.md) and [app-api.md](../app-api.md) for the full API
-reference.
+See [core-api.md](../core-api.md), [app-api.md](../app-api.md), and
+[dev-server.md](../reference/dev-server.md) for the full API reference.

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -49,11 +49,9 @@ This produces the `build/redin` binary: the Odin/Raylib host that embeds LuaJIT 
 (global main_view
   (fn []
     (let [count (subscribe :sub/counter)]
-      {:frame
-       [:vbox {:aspect :surface}
-         [:text {:aspect :heading} (tostring count)]
-         [:button {:aspect :button :click [:event/inc]} "+1"]]
-       :bind {}})))
+      [:vbox {:aspect :surface}
+        [:text {:aspect :heading} (tostring count)]
+        [:button {:aspect :button :click [:event/inc]} "+1"]])))
 ```
 
 ### What each piece does
@@ -66,7 +64,7 @@ This produces the `build/redin` binary: the Odin/Raylib host that embeds LuaJIT 
 | `dataflow.init` | Seed `app-db` with `{:counter 0}` |
 | `reg-handler` | Register `:event/inc`; handler receives `db` and returns updated `db` |
 | `reg-sub` | Register `:sub/counter`; recomputes only when `:counter` changes |
-| `main_view` | Global the runtime calls each frame; returns `{:frame ... :bind {}}` |
+| `main_view` | Global the runtime calls each frame; returns the frame tree directly |
 
 ### How events work
 
@@ -95,20 +93,26 @@ The window opens. Click the button -- the counter increments.
 ./build/redin --dev counter.fnl
 ```
 
-`--dev` enables the HTTP dev server on `localhost:8800`.
+`--dev` enables the HTTP dev server. It picks port 8800 by default (walks upward if busy) and writes the bound port to `./.redin-port` plus a per-run bearer token to `./.redin-token`.
 
 ```sh
+PORT=$(cat .redin-port)
+TOKEN=$(cat .redin-token)
+AUTH="Authorization: Bearer $TOKEN"
+
 # Inspect live state
-curl localhost:8800/state
+curl -H "$AUTH" localhost:$PORT/state
 
 # Inspect the current frame tree
-curl localhost:8800/frames
+curl -H "$AUTH" localhost:$PORT/frames
 
 # Dispatch an event from the terminal
-curl -X POST localhost:8800/events \
-  -H 'Content-Type: application/json' \
-  -d '{"event": ["event/inc"]}'
+curl -X POST -H "$AUTH" -H 'Content-Type: application/json' \
+  -d '["event/inc"]' \
+  localhost:$PORT/events
 ```
+
+See [dev-server.md](../reference/dev-server.md) for the full endpoint list and auth details.
 
 ## Next steps
 

--- a/docs/guide/re-frame-quickstart.md
+++ b/docs/guide/re-frame-quickstart.md
@@ -31,7 +31,7 @@ A translation guide for developers who know re-frame. The programming model is t
 
 **State variants use `#`.** Theme keys like `:button#hover` and `:input#focus` use `#` as the separator between the base aspect and the state variant.
 
-**Events are inline on elements.** Instead of a separate binding table, event handlers are declared directly as element attributes: `:click`, `:change`, `:key`. The view returns `{:frame [...] :bind {}}` with an empty bind map.
+**Events are inline on elements.** Instead of a separate binding table, event handlers are declared directly as element attributes: `:click`, `:change`, `:key`. The view returns the frame tree directly.
 
 ## Translation recipe
 
@@ -79,11 +79,9 @@ A translation guide for developers who know re-frame. The programming model is t
 (global main_view
   (fn []
     (let [count (subscribe :sub/counter)]
-      {:frame
-       [:vbox {:padding [24 24 24 24]}
-         [:text {:aspect :heading} (tostring count)]
-         [:button {:aspect :button :click [:event/increment]} "+1"]]
-       :bind {}})))
+      [:vbox {:padding [24 24 24 24]}
+        [:text {:aspect :heading} (tostring count)]
+        [:button {:aspect :button :click [:event/increment]} "+1"]])))
 ```
 
 ### Inline events replace binding tables


### PR DESCRIPTION
## Summary
- `main_view` previously returned `{:frame [...] :bind {}}`; it now returns the frame tree directly. Updated re-frame-quickstart, quickstart, building-apps, and lua-guide.
- Fixed stale `curl` examples in quickstart + lua-guide: added `Authorization: Bearer $(cat .redin-token)` and corrected `/events` body from `{"event": [...]}` to just `[...]`.
- Swept `.claude/skills/` and `CLAUDE.md` — no lingering references.

Closes #62.

## Test plan
- [x] `grep -rn ':frame|:bind|\{:frame' docs/ .claude/skills/ CLAUDE.md` — no matches
- [x] `grep -rn 'localhost:8800' docs/guide/` — no bare URLs in examples
- [x] Examples in docs match actual `main_view` usage in `examples/kitchen-sink.fnl` and `examples/perf-10k.fnl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)