### PR TITLE
fix(http): use -collection for odin-http import (closes #64)

### DIFF
--- a/.claude/skills/redin-dev/SKILL.md
+++ b/.claude/skills/redin-dev/SKILL.md
@@ -209,7 +209,7 @@ Uses `redin-test` framework: `get-frame`, `get-state`, `dispatch`, `find-element
 
 ### Build check
 ```bash
-odin build src/host -out:build/redin
+odin build src/host -collection:lib=lib -out:build/redin
 ```
 
 ## Adding a new node type (framework development)

--- a/.claude/skills/redin-maintenance/SKILL.md
+++ b/.claude/skills/redin-maintenance/SKILL.md
@@ -10,7 +10,7 @@ Use this skill to verify changes to the redin framework before committing.
 ## Build
 
 ```bash
-odin build src/host -out:build/redin
+odin build src/host -collection:lib=lib -out:build/redin
 ```
 
 Requires: `libssl-dev`, `libraylib-dev`, and the `lib/odin-http` git submodule (`git submodule update --init`).
@@ -75,7 +75,7 @@ To run all integration tests with memory tracking:
 
 After changes to the framework, verify in this order:
 
-1. **Build** — `odin build src/host -out:build/redin`
+1. **Build** — `odin build src/host -collection:lib=lib -out:build/redin`
 2. **Runtime tests** — `luajit test/lua/runner.lua test/lua/test_*.fnl`
 3. **Integration tests** — `bash test/ui/run-all.sh`
 4. **Visual check** — for rendering changes, take a screenshot via `GET /screenshot` on the dev server and inspect

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,10 @@ jobs:
         run: |
           luajit test/lua/runner.lua test/lua/test_*.fnl
           mkdir -p build
-          odin build src/host -out:build/redin
+          odin build src/host -collection:lib=lib -out:build/redin
 
       - name: Build release binary
-        run: odin build src/host -out:build/redin -o:speed
+        run: odin build src/host -collection:lib=lib -out:build/redin -o:speed
 
       - name: AOT compile Fennel runtime
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Build host
         run: |
           mkdir -p build
-          odin build src/host -out:build/redin
+          odin build src/host -collection:lib=lib -out:build/redin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ These docs are the source of truth. When implementing, follow them exactly.
 ## Building
 
 ```bash
-odin build src/host -out:build/redin
+odin build src/host -collection:lib=lib -out:build/redin
 ```
 
 ## Running
@@ -43,7 +43,7 @@ luajit test/lua/runner.lua test/lua/test_*.fnl
 bb test/ui/run.bb test/ui/test_<name>.bb
 
 # Build check
-odin build src/host -out:build/redin
+odin build src/host -collection:lib=lib -out:build/redin
 ```
 
 ### UI test convention

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The CLI downloads a pinned redin binary into `.redin/` — no build tools needed
 sudo apt-get install -y luajit libluajit-5.1-dev libssl-dev
 
 # Build
-odin build src/host -out:build/redin
+odin build src/host -collection:lib=lib -out:build/redin
 
 # Run
 ./build/redin --dev examples/kitchen-sink.fnl
@@ -61,7 +61,7 @@ odin build src/host -out:build/redin
 luajit test/lua/runner.lua test/lua/test_*.fnl
 
 # Build check
-odin build src/host -out:build/redin
+odin build src/host -collection:lib=lib -out:build/redin
 ```
 
 ## Project structure

--- a/docs/guide/lua-guide.md
+++ b/docs/guide/lua-guide.md
@@ -227,7 +227,7 @@ end
 Build the host binary once:
 
 ```sh
-odin build src/host -out:build/redin
+odin build src/host -collection:lib=lib -out:build/redin
 ```
 
 Then run your Lua app:

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -11,7 +11,7 @@ Get from zero to a running counter app in 5 minutes.
 ## Build the host
 
 ```sh
-odin build src/host -out:build/redin
+odin build src/host -collection:lib=lib -out:build/redin
 ```
 
 This produces the `build/redin` binary: the Odin/Raylib host that embeds LuaJIT and runs your Fennel scripts.

--- a/release.sh
+++ b/release.sh
@@ -7,7 +7,7 @@ NAME="redin-${VERSION}-${PLATFORM}"
 DIST="dist/${NAME}"
 
 echo "Building redin ${VERSION}..."
-odin build src/host -out:build/redin
+odin build src/host -collection:lib=lib -out:build/redin
 echo "  Binary built: build/redin"
 
 echo "Packaging ${NAME}.tar.gz..."

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,7 @@ git submodule update --init --recursive
 echo ""
 echo "Building redin..."
 mkdir -p build
-odin build src/host -out:build/redin
+odin build src/host -collection:lib=lib -out:build/redin
 
 echo ""
 echo "=== Setup complete ==="

--- a/src/host/bridge/http_client.odin
+++ b/src/host/bridge/http_client.odin
@@ -5,8 +5,8 @@ import "core:fmt"
 import "core:strings"
 import "core:sync"
 import "core:thread"
-import http "../../../lib/odin-http"
-import http_client "../../../lib/odin-http/client"
+import http "lib:odin-http"
+import http_client "lib:odin-http/client"
 
 Http_Request :: struct {
 	id:      string,

--- a/test/ui/run-all.sh
+++ b/test/ui/run-all.sh
@@ -18,7 +18,7 @@ TOTAL_FAILED=0
 
 # Build
 echo "=== Building redin ==="
-odin build "$ROOT_DIR/src/host" -out:"$BINARY"
+odin build "$ROOT_DIR/src/host" -collection:lib="$ROOT_DIR/lib" -out:"$BINARY"
 echo ""
 
 wait_for_server() {


### PR DESCRIPTION
## Summary
- Switch `src/host/bridge/http_client.odin` from `import "../../../lib/odin-http"` (+ `/client`) to `import "lib:odin-http"` (+ `/client`).
- Thread `-collection:lib=lib` through every `odin build src/host` invocation: CI (`test.yml`, `release.yml`), scripts (`release.sh`, `setup.sh`, `test/ui/run-all.sh`), docs (README, CLAUDE.md, quickstart, lua-guide), and the two skill files.
- Makes the import location-independent so `redin-cli upgrade-to-native` doesn't have to replicate the source-repo directory depth.

## Why
Per #64: `redin-cli upgrade-to-native` copies `src/` + `vendor/` into `native/` but not `lib/`, and even if it did, the relative import `../../../lib/odin-http` assumes the source-repo layout (`src/host/bridge/` → `lib/`). After `upgrade-to-native` the host source lives one level shallower so the same relative path would resolve wrong. A collection import sidesteps both problems — downstream only needs to copy `lib/` and pass `-collection:lib=lib` (or an absolute path) on the build.

## redin-cli follow-up (separate repo)
redin-cli still needs a paired change — `cmd-upgrade-to-native` must copy `lib/`, and the generated `native/build.sh` must pass `-collection:lib=lib` (or an absolute path). Not touched here.

## Test plan
- [x] `odin build src/host -collection:lib=lib -out:build/redin` — clean build succeeds
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 122/122 pass
- [x] `bash test/ui/run-all.sh` — all suites pass except `test_profile` (pre-existing failure on main; unrelated — run-all.sh doesn't pass `--profile`, so `/profile` returns 404)
- [x] `grep -rn 'odin build src/host' .` — every tracked invocation carries the new flag

Closes #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)