### PR TITLE
fix(test): sidecar *_app.flags for per-app host flags (closes #66)

### DIFF
--- a/test/ui/profile_app.flags
+++ b/test/ui/profile_app.flags
@@ -1,0 +1,1 @@
+--profile

--- a/test/ui/run-all.sh
+++ b/test/ui/run-all.sh
@@ -54,9 +54,17 @@ for test_file in "$SCRIPT_DIR"/test_*.bb; do
 
   echo "=== $name ==="
 
+  # Optional sidecar: <app>_app.flags — whitespace-split extra host flags.
+  flags_file="$SCRIPT_DIR/${app_name}_app.flags"
+  extra_flags=()
+  if [ -f "$flags_file" ]; then
+    # shellcheck disable=SC2207
+    extra_flags=( $(cat "$flags_file") )
+  fi
+
   # Start dev server in background
   rm -f "$PORT_FILE"
-  "$BINARY" --dev "$app_file" &
+  "$BINARY" --dev "${extra_flags[@]}" "$app_file" &
   SERVER_PID=$!
 
   if ! wait_for_server; then


### PR DESCRIPTION
## Summary
- Add optional `<app>_app.flags` sidecar next to each test app. `run-all.sh` reads it and splices the whitespace-separated contents into the launch command.
- Add `test/ui/profile_app.flags` containing `--profile` so `test_profile` can hit `/profile`.
- No change to any existing test app (no sidecar → empty flags → same `--dev` launch as before).

## Why
Per #66: `/profile` is gated on `--profile`, but `run-all.sh` always launched with just `--dev`, so `test_profile` got 404. Option 1 from the issue (sidecar file) scales to future flag needs (e.g. `--track-mem` for leak-specific suites) without hardcoding app names into the script.

## Test plan
- [x] `bash test/ui/run-all.sh` — reports *"All test suites passed"* (previously *"1 test suite(s) had failures"* on `test_profile`).

Closes #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)