### PR TITLE
fix(build): bundle lib/ and vendor/luajit for native builds (closes #68)

### DIFF
--- a/.claude/skills/redin-dev/SKILL.md
+++ b/.claude/skills/redin-dev/SKILL.md
@@ -209,7 +209,7 @@ Uses `redin-test` framework: `get-frame`, `get-state`, `dispatch`, `find-element
 
 ### Build check
 ```bash
-odin build src/host -collection:lib=lib -out:build/redin
+odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 ```
 
 ## Adding a new node type (framework development)

--- a/.claude/skills/redin-maintenance/SKILL.md
+++ b/.claude/skills/redin-maintenance/SKILL.md
@@ -10,7 +10,7 @@ Use this skill to verify changes to the redin framework before committing.
 ## Build
 
 ```bash
-odin build src/host -collection:lib=lib -out:build/redin
+odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 ```
 
 Requires: `libssl-dev`, `libraylib-dev`, and the `lib/odin-http` git submodule (`git submodule update --init`).
@@ -75,7 +75,7 @@ To run all integration tests with memory tracking:
 
 After changes to the framework, verify in this order:
 
-1. **Build** — `odin build src/host -collection:lib=lib -out:build/redin`
+1. **Build** — `odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin`
 2. **Runtime tests** — `luajit test/lua/runner.lua test/lua/test_*.fnl`
 3. **Integration tests** — `bash test/ui/run-all.sh`
 4. **Visual check** — for rendering changes, take a screenshot via `GET /screenshot` on the dev server and inspect

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,10 @@ jobs:
         run: |
           luajit test/lua/runner.lua test/lua/test_*.fnl
           mkdir -p build
-          odin build src/host -collection:lib=lib -out:build/redin
+          odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 
       - name: Build release binary
-        run: odin build src/host -collection:lib=lib -out:build/redin -o:speed
+        run: odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin -o:speed
 
       - name: AOT compile Fennel runtime
         run: |
@@ -62,8 +62,12 @@ jobs:
           VERSION: ${{ steps.version.outputs.tag }}
         run: |
           cp build/redin dist/
+          mkdir -p dist/lib/odin-http
+          rsync -a --exclude=openssl/includes --exclude=docs --exclude=examples --exclude=comparisons --exclude=old_nbio lib/odin-http/ dist/lib/odin-http/
           mkdir -p dist/vendor/fennel
           cp vendor/fennel/fennel.lua dist/vendor/fennel/
+          mkdir -p dist/vendor/luajit/lib
+          cp vendor/luajit/lib/libluajit-5.1.a dist/vendor/luajit/lib/
           mkdir -p dist/docs/guide dist/docs/reference
           cp docs/core-api.md docs/app-api.md dist/docs/
           cp docs/guide/*.md dist/docs/guide/ 2>/dev/null || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Build host
         run: |
           mkdir -p build
-          odin build src/host -collection:lib=lib -out:build/redin
+          odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ These docs are the source of truth. When implementing, follow them exactly.
 ## Building
 
 ```bash
-odin build src/host -collection:lib=lib -out:build/redin
+odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 ```
 
 ## Running
@@ -43,7 +43,7 @@ luajit test/lua/runner.lua test/lua/test_*.fnl
 bb test/ui/run.bb test/ui/test_<name>.bb
 
 # Build check
-odin build src/host -collection:lib=lib -out:build/redin
+odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 ```
 
 ### UI test convention

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The CLI downloads a pinned redin binary into `.redin/` — no build tools needed
 sudo apt-get install -y luajit libluajit-5.1-dev libssl-dev
 
 # Build
-odin build src/host -collection:lib=lib -out:build/redin
+odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 
 # Run
 ./build/redin --dev examples/kitchen-sink.fnl
@@ -61,7 +61,7 @@ odin build src/host -collection:lib=lib -out:build/redin
 luajit test/lua/runner.lua test/lua/test_*.fnl
 
 # Build check
-odin build src/host -collection:lib=lib -out:build/redin
+odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 ```
 
 ## Project structure

--- a/docs/guide/lua-guide.md
+++ b/docs/guide/lua-guide.md
@@ -227,7 +227,7 @@ end
 Build the host binary once:
 
 ```sh
-odin build src/host -collection:lib=lib -out:build/redin
+odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 ```
 
 Then run your Lua app:

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -11,7 +11,7 @@ Get from zero to a running counter app in 5 minutes.
 ## Build the host
 
 ```sh
-odin build src/host -collection:lib=lib -out:build/redin
+odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 ```
 
 This produces the `build/redin` binary: the Odin/Raylib host that embeds LuaJIT and runs your Fennel scripts.

--- a/release.sh
+++ b/release.sh
@@ -7,12 +7,12 @@ NAME="redin-${VERSION}-${PLATFORM}"
 DIST="dist/${NAME}"
 
 echo "Building redin ${VERSION}..."
-odin build src/host -collection:lib=lib -out:build/redin
+odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 echo "  Binary built: build/redin"
 
 echo "Packaging ${NAME}.tar.gz..."
 rm -rf dist
-mkdir -p "${DIST}/docs/guide" "${DIST}/docs/reference" "${DIST}/src/runtime" "${DIST}/vendor" "${DIST}/.claude/skills/redin-dev"
+mkdir -p "${DIST}/docs/guide" "${DIST}/docs/reference" "${DIST}/src/runtime" "${DIST}/vendor" "${DIST}/lib" "${DIST}/.claude/skills/redin-dev"
 
 # Binary
 cp build/redin "${DIST}/redin"
@@ -23,6 +23,16 @@ cp src/runtime/*.fnl "${DIST}/src/runtime/"
 # Vendor (fennel + luajit)
 cp -r vendor/fennel "${DIST}/vendor/fennel"
 cp -r vendor/luajit "${DIST}/vendor/luajit"
+
+# Lib (odin-http submodule, for upgrade-to-native builds).
+# Exclude Windows-only static libs and non-source dirs to keep the tarball small.
+rsync -a \
+  --exclude='openssl/includes' \
+  --exclude='docs' \
+  --exclude='examples' \
+  --exclude='comparisons' \
+  --exclude='old_nbio' \
+  lib/odin-http/ "${DIST}/lib/odin-http/"
 
 # Docs — API docs
 cp docs/core-api.md "${DIST}/docs/"

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,7 @@ git submodule update --init --recursive
 echo ""
 echo "Building redin..."
 mkdir -p build
-odin build src/host -collection:lib=lib -out:build/redin
+odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 
 echo ""
 echo "=== Setup complete ==="

--- a/src/host/bridge/lua_api.odin
+++ b/src/host/bridge/lua_api.odin
@@ -1,6 +1,6 @@
 package bridge
 
-foreign import luajit "../../../vendor/luajit/lib/libluajit-5.1.a"
+foreign import luajit "luajit:lib/libluajit-5.1.a"
 
 Lua_State :: distinct rawptr
 Lua_CFunction :: #type proc "c" (L: ^Lua_State) -> i32

--- a/test/ui/run-all.sh
+++ b/test/ui/run-all.sh
@@ -18,7 +18,7 @@ TOTAL_FAILED=0
 
 # Build
 echo "=== Building redin ==="
-odin build "$ROOT_DIR/src/host" -collection:lib="$ROOT_DIR/lib" -out:"$BINARY"
+odin build "$ROOT_DIR/src/host" -collection:lib="$ROOT_DIR/lib" -collection:luajit="$ROOT_DIR/vendor/luajit" -out:"$BINARY"
 echo ""
 
 wait_for_server() {


### PR DESCRIPTION
## Summary
Two gaps exposed by #68 that broke `redin-cli upgrade-to-native`:

1. **luajit link path**: `src/host/bridge/lua_api.odin` foreign-imported `../../../vendor/luajit/lib/libluajit-5.1.a` — the same relative-path problem the odin-http import had before v0.1.10. Switched to `foreign import luajit "luajit:lib/libluajit-5.1.a"` with a new `-collection:luajit=vendor/luajit` flag.

2. **Empty `lib/` in the release tarball**: `lib/odin-http` is a git submodule, so GitHub's auto-generated source tarball (used by `upgrade-to-native`) has an empty `lib/`. Added both `lib/odin-http` and `vendor/luajit/lib/libluajit-5.1.a` to the release tarball (`release.sh` and `.github/workflows/release.yml`). The odin-http copy strips `openssl/includes` (Windows-only `.lib` blobs; Linux uses system OpenSSL) plus `docs/`, `examples/`, `comparisons/`, `old_nbio/` — trimmed from 55 MB to ~230 KB.

Threaded `-collection:luajit=vendor/luajit` through every `odin build` invocation — CI (`test.yml`, `release.yml`), scripts (`release.sh`, `setup.sh`, `test/ui/run-all.sh`), docs (README, CLAUDE.md, quickstart, lua-guide), and both skill files.

## redin-cli follow-up (separate repo)
- `cmd-upgrade-to-native` must copy `.redin/lib/` → `native/lib/` and `.redin/vendor/luajit/` → `native/vendor/luajit/`.
- The generated `native/build.sh` must pass both `-collection:lib=\"$SCRIPT_DIR/lib\"` and `-collection:luajit=\"$SCRIPT_DIR/vendor/luajit\"`.

That change is ready locally but needs this release out first to have a tarball that bundles the dependencies.

## Test plan
- [x] `odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin` — clean build
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 122/122 pass
- [x] `bash test/ui/run-all.sh` — *"All test suites passed"*
- [x] Built a local v0.1.11-test tarball, manually replayed `upgrade-to-native`'s output (copy src/host → native/, copy lib+vendor/luajit from .redin/ → native/, stamp new build.sh), ran `./build.sh` — produced a working 5.8 MB native binary

Closes #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)