### PR TITLE
docs(skills): refresh redin-dev + redin-maintenance for RFC #79 layout

### DIFF
--- a/.claude/skills/redin-dev/SKILL.md
+++ b/.claude/skills/redin-dev/SKILL.md
@@ -10,8 +10,11 @@ Use this skill when building redin apps (Fennel or Lua) or extending the framewo
 ## Architecture
 
 ```
-src/host/           Odin host (renderer, bridge, input)
-  main.odin         Entry point, main loop
+src/cmd/redin/      Thin CLI entry (package main)
+  main.odin         Arg parsing, --track-mem setup, calls redin.run
+src/redin/          Importable framework (package redin)
+  runtime.odin      Public API: set_window/set_size/set_title, on_init/
+                    on_input/on_frame/on_shutdown hooks, run, request_shutdown
   render.odin       Raylib renderer, layout (draw_box, draw_text, viewport)
   bridge/           Lua/Fennel bridge
     bridge.odin     Host callbacks, Lua<->Odin conversion, canvas draw execution
@@ -213,22 +216,22 @@ Uses `redin-test` framework: `get-frame`, `get-state`, `dispatch`, `find-element
 
 ### Build check
 ```bash
-odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 ```
 
 ## Adding a new node type (framework development)
 
-1. `src/host/types/view_tree.odin` — add struct + union variant
-2. `src/host/bridge/bridge.odin` — add parsing case in `lua_read_node`
-3. `src/host/render.odin` — add rendering case in `render_node`
-4. `src/host/render.odin` — add `node_preferred_width` / `node_preferred_height` cases
+1. `src/redin/types/view_tree.odin` — add struct + union variant
+2. `src/redin/bridge/bridge.odin` — add parsing case in `lua_read_node`
+3. `src/redin/render.odin` — add rendering case in `render_node`
+4. `src/redin/render.odin` — add `node_preferred_width` / `node_preferred_height` cases
 5. `src/runtime/theme.fnl` — add to consumption table if it uses aspects
 6. `test/ui/<component>_app.fnl` + `test/ui/test_<component>.bb` — UI test
 
 ## Adding a host function (framework development)
 
-1. `src/host/bridge/bridge.odin` — write `proc "c" (L: ^Lua_State) -> i32` callback with `context = g_context`
-2. `src/host/bridge/bridge.odin` — register with `register_cfunc(b.L, "name", callback)` in `init` proc
+1. `src/redin/bridge/bridge.odin` — write `proc "c" (L: ^Lua_State) -> i32` callback with `context = g_context`
+2. `src/redin/bridge/bridge.odin` — register with `register_cfunc(b.L, "name", callback)` in `init` proc
 3. Call from Fennel: `(redin.name ...)` or from Lua: `redin.name(...)`
 
 ## redin-cli
@@ -237,14 +240,15 @@ Project manager for redin. Install: `curl -sL https://raw.githubusercontent.com/
 
 | Command | Description |
 |---|---|
-| `redin-cli new-fnl <name>` | Scaffold Fennel project (main.fnl, flsproject.fnl, .redin/, .claude/skills/) |
-| `redin-cli new-lua <name>` | Scaffold Lua project (main.lua, .luarc.json, .redin/, .claude/skills/) |
-| `redin-cli upgrade-to-native` | Copy Odin host source into native/ for custom canvas providers |
-| `redin-cli update [version]` | Update redin binary + runtime in .redin/ |
+| `redin-cli new-fnl [--native] <name>` | Scaffold Fennel project (main.fnl, flsproject.fnl, .redin/, .claude/skills/). With `--native`, also drops `app.odin` + `build.sh` at project root for native Odin development. |
+| `redin-cli new-lua [--native] <name>` | Scaffold Lua project. `--native` same as above. |
+| `redin-cli update [version]` | Update redin binary + runtime in .redin/. Also refreshes .claude/skills/. |
 | `redin-cli latest` | Print latest available version |
 | `redin-cli help` | Show all commands, project structure, dev server endpoints |
 
-### Project structure (after new-fnl/new-lua)
+`upgrade-to-native` is a deprecated alias for `new-fnl --native .` (or `new-lua --native .`); will be removed in a future release.
+
+### Project structure (after new-fnl/new-lua, no `--native`)
 
 ```
 my-app/
@@ -256,17 +260,55 @@ my-app/
   .gitignore       # ignores .redin/
 ```
 
-### Native upgrade (after upgrade-to-native)
+### Project structure (after new-fnl --native / new-lua --native)
+
+The `--native` flag adds two user-owned files at project root and pulls
+the redin source into `.redin/src/redin/` so `app.odin` can import it.
 
 ```
 my-app/
-  native/          # full Odin host source + providers.odin
-    build.sh       # odin build native/ -out:build/redin
-    providers.odin # user's custom canvas providers (package host)
-    main.odin      # copied from .redin/, init_providers() injected
-    ...            # rest of host source
+  app.odin         # USER-OWNED: package main, calls redin.run(cfg)
+  build.sh         # USER-OWNED: odin build . -collection:lib=.redin/lib ...
   build/           # native build output (gitignored)
+  .redin/          # binary + runtime + source + docs (gitignored)
+    src/redin/     # framework source — overwritten by `redin-cli update`
+    lib/           # odin-http
+    vendor/luajit/ # libluajit-5.1.a
+    redin          # prebuilt binary fallback
+  .claude/skills/
   redinw           # updated: prefers build/redin over .redin/redin
+  main.fnl         # app code
+```
+
+The user owns `app.odin`. The framework lives in `.redin/` and is
+overwritten by `redin-cli update` with no merge conflicts. Customize
+the window, register canvas providers / Lua cfuncs / per-frame hooks
+in `app.odin` before the call to `redin.run`:
+
+```odin
+package main
+
+import "core:os"
+import redin "./.redin/src/redin"
+import "./.redin/src/redin/canvas"
+
+main :: proc() {
+    redin.set_window(1920, 1080, "my game", {.WINDOW_RESIZABLE})
+
+    canvas.register("my-bg", my_bg_provider)
+    redin.on_frame(per_frame_tick)
+
+    cfg: redin.Config
+    cfg.app = "main.fnl"
+    for arg in os.args[1:] {
+        switch arg {
+        case "--dev":     cfg.dev = true
+        case "--profile": cfg.profile = true
+        case:             cfg.app = arg
+        }
+    }
+    redin.run(cfg)
+}
 ```
 
 ### Running
@@ -275,6 +317,7 @@ my-app/
 ./redinw --dev main.fnl          # dev server + hot reload
 ./redinw main.fnl                # normal mode
 ./redinw --track-mem main.fnl    # memory leak tracking
+./build.sh                        # (--native only) rebuild after editing app.odin
 ```
 
 ## Key conventions

--- a/.claude/skills/redin-maintenance/SKILL.md
+++ b/.claude/skills/redin-maintenance/SKILL.md
@@ -10,8 +10,10 @@ Use this skill to verify changes to the redin framework before committing.
 ## Build
 
 ```bash
-odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 ```
+
+`src/cmd/redin/` is the thin CLI entry point (`package main`, arg parsing + memory tracking + `redin.run` call). The framework itself lives in `src/redin/` (`package redin`).
 
 Requires: `libssl-dev`, `libraylib-dev`, and the `lib/odin-http` git submodule (`git submodule update --init`).
 
@@ -78,7 +80,7 @@ To run all integration tests with memory tracking:
 
 After changes to the framework, verify in this order:
 
-1. **Build** — `odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin`
+1. **Build** — `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin`
 2. **Runtime tests** — `luajit test/lua/runner.lua test/lua/test_*.fnl`
 3. **Integration tests** — `bash test/ui/run-all.sh`
 4. **Visual check** — for rendering changes, take a screenshot via `GET /screenshot` on the dev server and inspect
@@ -115,11 +117,14 @@ If a contract was described incorrectly (not just incompletely), fix the doc eve
 | Change area | Build | Runtime tests | UI tests | Memory check |
 |---|---|---|---|---|
 | `src/runtime/` (Fennel) | - | Yes | Yes | - |
-| `src/host/render.odin` | Yes | - | Yes (visual) | - |
-| `src/host/bridge/` | Yes | - | Yes | Yes |
-| `src/host/input/` | Yes | - | Yes | - |
-| `src/host/types/` | Yes | - | Yes | - |
-| `src/host/text/` | Yes | - | Yes (multiline) | - |
+| `src/redin/runtime.odin` (public API, run loop) | Yes | - | Yes | - |
+| `src/redin/render.odin` | Yes | - | Yes (visual) | - |
+| `src/redin/bridge/` | Yes | - | Yes | Yes |
+| `src/redin/input/` | Yes | - | Yes | - |
+| `src/redin/types/` | Yes | - | Yes | - |
+| `src/redin/text/` | Yes | - | Yes (multiline) | - |
+| `src/redin/canvas/` | Yes | - | Yes (canvas) | - |
+| `src/cmd/redin/` (CLI flags, --track-mem) | Yes | - | - | Yes |
 
 ## Cutting a release
 
@@ -145,7 +150,13 @@ The workflow's `release` job runs only when `version` is non-empty, so an empty 
 
 ## Pre-publish native-build smoke check
 
-The release workflow runs `scripts/smoke-native.sh <tarball>` after packaging and before publishing. It extracts the tarball into a temp project, replays what `redin-cli upgrade-to-native` would do (copy src/host + lib/ + vendor/luajit/ into `native/`), runs `./native/build.sh`, launches the resulting binary under `--dev`, and asserts `/frames` contains a sentinel string from `main.fnl`. The sentinel check is what catches broken runtime lookup — just polling `/state` returns 200 even when Fennel fails to load.
+The release workflow runs `scripts/smoke-native.sh <tarball>` after packaging and before publishing. It exercises the new RFC #79 native flow against the freshly-built tarball:
+
+1. Extract the binary tarball into `<tmp>/.redin/`.
+2. Copy the local checkout's `src/redin/.` into `<tmp>/.redin/src/redin/` (simulates redin-cli's `fetch-source`).
+3. Drop a project-root `app.odin` (with `import redin "./.redin/src/redin"`) and `build.sh`.
+4. Run `./build.sh` from project root (uses `-collection:lib=.redin/lib -collection:luajit=.redin/vendor/luajit`).
+5. Launch the resulting binary under `--dev`, assert `/frames` contains a sentinel string from `main.fnl`. The sentinel check is what catches broken runtime lookup — just polling `/state` returns 200 even when Fennel fails to load.
 
 Run it locally before a release:
 
@@ -154,4 +165,4 @@ Run it locally before a release:
 bash scripts/smoke-native.sh dist/redin-v0.1.X-test-linux-amd64.tar.gz
 ```
 
-Note: keep the `build.sh` template in the smoke script aligned with redin-cli's `build-sh` constant in `redin-cli/redin-cli`. Whenever one changes, update the other in the same PR.
+Note: keep the `app.odin` and `build.sh` templates inline in the smoke script aligned with redin-cli's `app-odin-fnl` and `build-sh-native` constants in `redin-cli/redin-cli`. Whenever one changes, update the other in the same PR (or in a coordinated pair of PRs).


### PR DESCRIPTION
v0.2.0 shipped with stale `.claude/skills/redin-dev/SKILL.md` referencing `src/host/`, the dead `upgrade-to-native` flow, and the legacy `native/` + `providers.odin` layout. This PR brings both skills back in sync with RFC #79.

## What changes

**`redin-dev/SKILL.md`** (this is the one bundled into release tarballs and pulled into every project's `.claude/skills/redin-dev/` by `redin-cli`):

- Architecture diagram: shows the `src/cmd/redin/` (CLI) + `src/redin/` (framework) split. `runtime.odin` highlighted as the public API entry (\`set_window\`/\`set_size\`/\`set_title\`, \`on_init\`/\`on_input\`/\`on_frame\`/\`on_shutdown\`, \`run\`, \`request_shutdown\`).
- Build command updated to `odin build src/cmd/redin ...`.
- \"Adding a new node type\" / \"Adding a host function\" walkthroughs use `src/redin` paths.
- redin-cli command table adds `--native`; `upgrade-to-native` noted as deprecated alias.
- Native section rewritten: project-root `app.odin` + `build.sh` layout, with a worked example showing `redin.set_window`, `canvas.register`, `redin.on_frame`, and arg-parsing inside main.

**`redin-maintenance/SKILL.md`** (internal-only, not bundled):

- Build commands updated.
- \"When to run what\" table refreshed with `src/redin` paths plus `runtime.odin` and `src/cmd/redin/` rows.
- Pre-publish smoke prose now describes what `scripts/smoke-native.sh` actually does (project-root `app.odin` importing redin from `./.redin/src/redin`) instead of the legacy `cp src/host → native/`.

## Recovery for users on v0.2.0

`redin-cli` runs `refresh-claude-skills` on every `update` invocation (sstoehrm/redin#73), so once a coordinated `v0.2.1` patch is tagged with this fix, any existing user running `redin-cli update` self-heals to the corrected skill.

## Test plan

- [x] `grep -n 'src/host\|upgrade-to-native\|package host\|init_providers' .claude/skills/*/SKILL.md` only returns the intentional one-line deprecation note explaining the `upgrade-to-native` alias mapping.
- [x] All build commands match `setup.sh`, `release.sh`, `CLAUDE.md`, and `README.md`.
- [x] Native walkthrough mirrors the `app-odin-fnl` template in `redin-cli` (sstoehrm/redin-cli#4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)