### PR TITLE
RFC #79 PR 2: bridge API publication (cfuncs, dispatch, marshaller)

### DIFF
--- a/.claude/skills/redin-dev/SKILL.md
+++ b/.claude/skills/redin-dev/SKILL.md
@@ -228,11 +228,50 @@ odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -o
 5. `src/runtime/theme.fnl` — add to consumption table if it uses aspects
 6. `test/ui/<component>_app.fnl` + `test/ui/test_<component>.bb` — UI test
 
-## Adding a host function (framework development)
+## Adding a host function
+
+### From user code (preferred — `--native` projects)
+
+In `app.odin`, register before or after `redin.run`:
+
+```odin
+my_cfunc :: proc(L: ^bridge.Lua_State) -> i32 {
+    // No `proc "c"`, no manual context. The bridge's trampoline already
+    // set `context = bridge.host_context()` before calling.
+    n := lua_tointeger(L, 1)
+    // ...
+    return 0  // number of return values pushed onto the stack
+}
+
+main :: proc() {
+    bridge.register_cfunc("my_cfunc", my_cfunc)
+    // ...
+    redin.run(cfg)
+}
+```
+
+Pre-`redin.run` registrations are buffered and flushed inside `bridge.init`. From Fennel: `(redin.my_cfunc ...)`. From Lua: `redin.my_cfunc(...)`.
+
+For `proc "c"` cfuncs (escape hatch — usually not needed), use `bridge.register_cfunc_raw` and call `context = bridge.host_context()` yourself at entry.
+
+### From the framework (in-tree contributors only)
 
 1. `src/redin/bridge/bridge.odin` — write `proc "c" (L: ^Lua_State) -> i32` callback with `context = g_context`
-2. `src/redin/bridge/bridge.odin` — register with `register_cfunc(b.L, "name", callback)` in `init` proc
+2. `src/redin/bridge/bridge.odin` — add `register_cfunc_init(b.L, "name", callback)` line inside the `init` proc, between `lua_newtable(b.L)` and `lua_setglobal(b.L, "redin")`
 3. Call from Fennel: `(redin.name ...)` or from Lua: `redin.name(...)`
+
+## Bridge API for native code
+
+`package bridge` (importable from user `app.odin`) exposes:
+
+| Proc | Use |
+|---|---|
+| `bridge.register_cfunc(name, fn: proc(L) -> i32)` | Register a Lua cfunc with a regular Odin proc. Trampoline auto-sets context. Safe before or after `bridge.init`. |
+| `bridge.register_cfunc_raw(name, fn: Lua_CFunction)` | Same but takes `proc "c"` directly. Caller manages context. |
+| `bridge.host_context() -> runtime.Context` | The runtime context the bridge captured at init. Only needed by `register_cfunc_raw` callers. |
+| `bridge.push(L, value: any)` | Marshaller: Odin → Lua. Supports primitives, slices, arrays, dynamic arrays, maps, structs, unions, pointers, enums, any. Bails at depth 32 on cycles. |
+| `bridge.dispatch(event, payload: any) -> (ok, err)` | Marshal payload + push to Fennel as `[:dispatch [:event-name payload]]`. Calls the matching `reg-handler`. |
+| `bridge.dispatch_tos(L, event) -> (ok, err)` | Zero-copy: caller already pushed payload onto the stack (hot path, e.g. per-frame state). |
 
 ## redin-cli
 

--- a/.claude/skills/redin-maintenance/SKILL.md
+++ b/.claude/skills/redin-maintenance/SKILL.md
@@ -98,6 +98,7 @@ The public docs and the in-tree skills are part of the contract and ship to down
 | `docs/reference/elements.md` | Per-element attribute reference | New element, new/renamed attribute |
 | `docs/reference/theme.md` | Theme struct + consumption matrix | New theme property, new consumer |
 | `docs/reference/effects.md`, `canvas.md`, `dev-server.md` | Topic reference | When that topic changes |
+| `docs/reference/native-bridge.md` | Public bridge API for `--native` projects: `register_cfunc`, `register_cfunc_raw`, `host_context`, `push`, `dispatch`, `dispatch_tos` | Any change to the public bridge surface in `src/redin/bridge/api.odin` |
 | `docs/guide/*.md` | Quickstart, cheatsheet, lua-guide, building-apps | When a guide example would mislead a reader |
 | `.claude/skills/redin-dev/SKILL.md` | Architecture overview, node types, frame format, canvas API, theme, testing | Node types, frame format, canvas/theme API, top-level workflows |
 | `.claude/skills/redin-maintenance/SKILL.md` | Verification + release workflow (this file) | New test suite, new verification step, changed release process |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Active development on `reboot` branch. Core rendering, bridge, input, and runtim
 
 - [docs/core-api.md](docs/core-api.md) -- Frame format, events, host functions, interaction model, dev server
 - [docs/app-api.md](docs/app-api.md) -- Dataflow, tracked state accessors, subscriptions, effect system
+- [docs/reference/native-bridge.md](docs/reference/native-bridge.md) -- Public bridge API for `--native` projects (`register_cfunc`, `dispatch`, `push`)
 
 These docs are the source of truth. When implementing, follow them exactly.
 

--- a/docs/core-api.md
+++ b/docs/core-api.md
@@ -333,6 +333,8 @@ Checks: color format, enum membership (`font`, `weight`, `align`), opacity range
 
 Functions Odin exposes to the Lua VM under the `redin` global table. Available from any Fennel or Lua code.
 
+> Extending this table from user Odin code (in `--native` projects) is documented separately in [`reference/native-bridge.md`](reference/native-bridge.md). Use `bridge.register_cfunc(name, fn)` to add `redin.<name>` entries at runtime without forking framework files.
+
 ### `redin.log(...)`
 
 Print to stdout. Variadic, joins arguments with tabs.

--- a/docs/guide/lua-guide.md
+++ b/docs/guide/lua-guide.md
@@ -227,7 +227,7 @@ end
 Build the host binary once:
 
 ```sh
-odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 ```
 
 Then run your Lua app:

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -11,7 +11,7 @@ Get from zero to a running counter app in 5 minutes.
 ## Build the host
 
 ```sh
-odin build src/host -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 ```
 
 This produces the `build/redin` binary: the Odin/Raylib host that embeds LuaJIT and runs your Fennel scripts.

--- a/docs/reference/dev-server.md
+++ b/docs/reference/dev-server.md
@@ -10,7 +10,7 @@ Starts when the app is launched with `--dev`. Listens on `localhost:8800` (walks
 
 Read endpoints reflect the last state pushed to the host. Write endpoints queue events into the main input channel as if they came from real user input.
 
-Implementation: `src/host/bridge/devserver.odin`.
+Implementation: `src/redin/bridge/devserver.odin`.
 
 ### Authentication
 

--- a/docs/reference/native-bridge.md
+++ b/docs/reference/native-bridge.md
@@ -1,0 +1,125 @@
+# Native bridge API
+
+Public Odin API for `--native` projects. Lets user code in `app.odin` register Lua cfuncs, dispatch events into the Fennel re-frame pipeline, and marshal Odin values to Lua — all without forking framework files.
+
+Import from your `app.odin`:
+
+```odin
+import "./.redin/src/redin/bridge"
+```
+
+## Cfunc registration
+
+### `bridge.register_cfunc(name: cstring, fn: proc(L: ^Lua_State) -> i32)`
+
+Registers a Lua-callable function under `redin.<name>`. Pass a regular Odin proc — **not** `proc "c"`. The bridge wraps it in a static trampoline that sets `context = bridge.host_context()` and dispatches via a Lua upvalue.
+
+```odin
+my_signal :: proc(L: ^bridge.Lua_State) -> i32 {
+    // Context is already set; tracking allocator is live; no ceremony.
+    n := lua_tointeger(L, 1)
+    fmt.eprintfln("got signal %d", n)
+    return 0  // number of return values pushed onto the stack
+}
+
+main :: proc() {
+    bridge.register_cfunc("my_signal", my_signal)
+    redin.run({app = "main.fnl", dev = true})
+}
+```
+
+From Fennel: `(redin.my_signal 42)`. From Lua: `redin.my_signal(42)`.
+
+**Timing:** safe before *or* after `bridge.init`. Registrations made before `redin.run` (which is when `bridge.init` runs) are buffered and flushed inside init, after the `redin` Lua global is created.
+
+**Duplicate names:** silent replace. In dev mode (`Config.dev == true`), logs a stderr warning before replacing — same policy as `canvas.register`.
+
+### `bridge.register_cfunc_raw(name: cstring, fn: Lua_CFunction)`
+
+Escape hatch for raw `proc "c"` cfuncs. The caller is responsible for `context = bridge.host_context()` at entry. Use only when you genuinely need the raw C calling convention (e.g. integrating with another C library).
+
+### `bridge.host_context() -> runtime.Context`
+
+Returns the runtime context the bridge captured during `init`. Only needed by `register_cfunc_raw` callers — `register_cfunc`'s trampoline sets it for you.
+
+## Marshalling
+
+### `bridge.push(L: ^Lua_State, value: any)`
+
+Pushes one Odin value onto the Lua stack. Reflection-based; supported types:
+
+| Odin type | Lua representation |
+|---|---|
+| `nil`, nil pointer | Lua nil |
+| `bool` | Lua boolean |
+| integer (`i8..i64`, `u8..u64`), enum | Lua number |
+| `f32`, `f64` | Lua number |
+| `string`, `cstring` | Lua string |
+| `[]T`, `[N]T`, `[dynamic]T` | Lua array table (1-indexed) |
+| `map[string]T` (and other key types) | Lua keyed table |
+| `struct` | Lua keyed table; field names → keys |
+| `union` | active variant pushed; `nil` if unset |
+| `^T` | dereferences and recurses; `nil` if pointer is nil |
+| `any` | recurses on the wrapped value |
+
+Unsupported types push `nil` and log a stderr warning. Bails at recursion depth 32 with a warning to guard against cycles.
+
+```odin
+Combat_State :: struct {
+    player_hp: i32,
+    enemy_hp:  i32,
+    items:     []string,
+}
+
+bridge.push(L, Combat_State{player_hp = 100, enemy_hp = 50, items = []string{"sword", "shield"}})
+// Lua sees: {player_hp = 100, enemy_hp = 50, items = {"sword", "shield"}}
+```
+
+## Dispatch (native → Fennel)
+
+`redin_events` is the Fennel-side dispatch channel (`view.deliver-events`). Both verbs below append `["dispatch", [event_name, payload]]` to a one-element events array and call it.
+
+### `bridge.dispatch(event: string, payload: any) -> (ok: bool, err: string)`
+
+High-level: marshal the payload via `push` and dispatch.
+
+```odin
+ok, err := bridge.dispatch("combat/push", combat_state)
+if !ok do fmt.eprintfln("dispatch failed: %s", err)
+```
+
+Fennel side:
+
+```fennel
+(reg-handler :combat/push
+  (fn [db event]
+    (let [payload (. event 2)]
+      (assoc db :combat payload))))
+```
+
+### `bridge.dispatch_tos(L: ^Lua_State, event: string) -> (ok: bool, err: string)`
+
+Zero-copy hot-path variant: the caller has already pushed the payload onto the top of the Lua stack using raw `lua_*` helpers. Use this for per-frame state pushes where reflection cost matters.
+
+The payload is consumed regardless of success.
+
+```odin
+// Caller built a custom Lua table on the stack already.
+build_combat_table_on_stack(L, &combat)
+ok, err := bridge.dispatch_tos(L, "combat/push")
+```
+
+## Calling conventions and context
+
+| Convention | Context propagates? | When you write it |
+|---|---|---|
+| `proc()` (Odin default) | yes | `on_init`, `on_input`, `on_frame`, `on_shutdown`, `register_cfunc` callbacks |
+| `proc "c"` | no — must `context = ...` explicitly | `register_cfunc_raw` callbacks only |
+
+Hooks registered via `redin.on_*` are called from inside `redin.run`, which already has `host_context()` set, so context inherits naturally. User cfuncs registered via `register_cfunc` go through the trampoline. The only place `proc "c"` discipline applies is `register_cfunc_raw`.
+
+## See also
+
+- [Canvas providers](canvas.md) — symmetric callback model for visual native work
+- [Effects](effects.md) — the Fennel-facing dispatch interface
+- [`docs/core-api.md`](../core-api.md) — built-in `redin.*` host functions exposed by the framework

--- a/docs/reference/theme.md
+++ b/docs/reference/theme.md
@@ -81,7 +81,7 @@ If a requested font or style isn't found, the system falls back:
 
 ## Theme struct
 
-The host-side `Theme` struct (in `src/host/types/theme.odin`) defines the properties available per aspect:
+The host-side `Theme` struct (in `src/redin/types/theme.odin`) defines the properties available per aspect:
 
 | Property | Type | Notes |
 | -------- | ---- | ----- |

--- a/src/redin/bridge/api.odin
+++ b/src/redin/bridge/api.odin
@@ -1,0 +1,412 @@
+// Public API: published bridge primitives for user-owned `app.odin` code
+// to extend redin without forking framework files. RFC #79 PR 2.
+package bridge
+
+import "base:runtime"
+import "core:fmt"
+import "core:reflect"
+import "core:strings"
+
+// ---------------------------------------------------------------------------
+// Context propagation
+// ---------------------------------------------------------------------------
+
+// Returns the runtime context the bridge captured during init. User cfuncs
+// registered via register_cfunc_raw (the proc "c" escape hatch) need to set
+// `context = bridge.host_context()` at entry to restore the tracking
+// allocator and other context-bound state. register_cfunc handles this
+// automatically via the trampoline.
+host_context :: proc "contextless" () -> runtime.Context {
+	return g_context
+}
+
+// ---------------------------------------------------------------------------
+// Lua cfunc registration (works before or after bridge.init)
+// ---------------------------------------------------------------------------
+//
+// User code typically calls register_cfunc before redin.run (which is
+// when bridge.init runs). Registrations made before init are buffered
+// and flushed by flush_pending_cfuncs() at the end of init, after the
+// `redin` Lua global has been created.
+//
+// Post-init, registrations apply immediately by looking up the redin
+// table via lua_getglobal.
+
+@(private = "file")
+Pending_Cfunc :: struct {
+	name:   cstring,
+	fn:     proc(L: ^Lua_State) -> i32, // used when is_raw == false
+	raw:    Lua_CFunction,                // used when is_raw == true
+	is_raw: bool,
+}
+
+@(private = "file")
+g_pending_cfuncs: [dynamic]Pending_Cfunc
+
+// Internal: called from bridge.init after the redin Lua global exists,
+// to apply any registrations that were buffered before init.
+flush_pending_cfuncs :: proc() {
+	if len(g_pending_cfuncs) == 0 do return
+	for p in g_pending_cfuncs {
+		if p.is_raw {
+			apply_register_cfunc_raw(p.name, p.raw)
+		} else {
+			apply_register_cfunc(p.name, p.fn)
+		}
+	}
+	delete(g_pending_cfuncs)
+	g_pending_cfuncs = nil
+}
+
+// Register a Lua cfunc using a regular Odin proc (default calling
+// convention). The bridge wraps it in a static `proc "c"` trampoline that
+// sets context = host_context() and dispatches via a Lua upvalue holding
+// the user proc pointer — so user code never types `proc "c"` and never
+// calls host_context() directly.
+//
+// Safe to call before bridge.init (registrations are buffered) or after
+// (applied immediately).
+//
+// Duplicate name: silent replace. In dev mode, logs a stderr warning before
+// replacing (matches canvas.register's policy).
+register_cfunc :: proc(name: cstring, fn: proc(L: ^Lua_State) -> i32) {
+	if g_bridge == nil {
+		append(&g_pending_cfuncs, Pending_Cfunc{name = name, fn = fn})
+		return
+	}
+	apply_register_cfunc(name, fn)
+}
+
+// Register a raw `proc "c"` cfunc directly. Caller is responsible for
+// `context = bridge.host_context()` inside the proc body. Use this only
+// when you genuinely need the raw C calling convention (e.g. integration
+// with another C library that already provides a proc "c"); otherwise
+// prefer register_cfunc.
+//
+// Safe to call before or after bridge.init.
+register_cfunc_raw :: proc(name: cstring, fn: Lua_CFunction) {
+	if g_bridge == nil {
+		append(&g_pending_cfuncs, Pending_Cfunc{name = name, raw = fn, is_raw = true})
+		return
+	}
+	apply_register_cfunc_raw(name, fn)
+}
+
+@(private = "file")
+apply_register_cfunc :: proc(name: cstring, fn: proc(L: ^Lua_State) -> i32) {
+	L := g_bridge.L
+	if !get_redin_table(L, "register_cfunc", name) do return
+
+	if g_bridge.dev_mode && field_is_set(L, name) {
+		fmt.eprintfln("redin: warn: bridge.register_cfunc(%q) replaces an existing binding", name)
+	}
+
+	// Push the user proc pointer as a lightuserdata upvalue, then build a
+	// closure of `cfunc_trampoline` that captures it. The trampoline pulls
+	// the pointer back out at call time via lua_upvalueindex(1).
+	lua_pushlightuserdata(L, rawptr(fn))
+	lua_pushcclosure(L, cfunc_trampoline, 1)
+	lua_setfield(L, -2, name)
+
+	lua_pop(L, 1) // pop redin table
+}
+
+@(private = "file")
+apply_register_cfunc_raw :: proc(name: cstring, fn: Lua_CFunction) {
+	L := g_bridge.L
+	if !get_redin_table(L, "register_cfunc_raw", name) do return
+
+	if g_bridge.dev_mode && field_is_set(L, name) {
+		fmt.eprintfln("redin: warn: bridge.register_cfunc_raw(%q) replaces an existing binding", name)
+	}
+
+	lua_pushcfunction(L, fn)
+	lua_setfield(L, -2, name)
+	lua_pop(L, 1)
+}
+
+@(private = "file")
+get_redin_table :: proc(L: ^Lua_State, caller: string, name: cstring) -> bool {
+	lua_getglobal(L, "redin")
+	if !lua_istable(L, -1) {
+		lua_pop(L, 1)
+		fmt.eprintfln(
+			"redin: error: bridge.%s(%s) called before bridge.init created the redin global",
+			caller, name,
+		)
+		return false
+	}
+	return true
+}
+
+@(private = "file")
+field_is_set :: proc(L: ^Lua_State, name: cstring) -> bool {
+	lua_getfield(L, -1, name)
+	exists := !lua_isnil(L, -1)
+	lua_pop(L, 1)
+	return exists
+}
+
+// Static trampoline shared by all register_cfunc registrations. The user
+// proc pointer is recovered from upvalue 1, context is set, then the user
+// proc runs with full Odin defaults (auto-propagated context, allocator).
+@(private = "file")
+cfunc_trampoline :: proc "c" (L: ^Lua_State) -> i32 {
+	context = g_context
+
+	user_fn_ptr := lua_touserdata(L, lua_upvalueindex(1))
+	if user_fn_ptr == nil {
+		fmt.eprintln("redin: error: cfunc trampoline upvalue is nil — corrupt registration?")
+		return 0
+	}
+	user_fn := cast(proc(L: ^Lua_State) -> i32)user_fn_ptr
+	return user_fn(L)
+}
+
+// ---------------------------------------------------------------------------
+// Odin → Lua marshaller
+// ---------------------------------------------------------------------------
+
+@(private = "file")
+MAX_PUSH_DEPTH :: 32
+
+// Push one Odin value onto the Lua stack. Supported types:
+//   nil                                   → Lua nil
+//   bool                                  → Lua boolean
+//   integer (i8..i64, u8..u64), enum     → Lua number
+//   f32, f64                              → Lua number
+//   string, cstring                       → Lua string
+//   []T, [N]T                             → Lua array table (1-indexed)
+//   map[string]T (or any string-keyed)    → Lua keyed table
+//   struct                                → Lua keyed table (field name → value)
+//   union                                 → active variant pushed; nil if unset
+//   ^T                                    → deref and recurse; nil if pointer is nil
+//   any                                   → recurse on the wrapped value
+// Unsupported types push nil and log a warning.
+// Bails at recursion depth MAX_PUSH_DEPTH (cycle guard); pushes nil + warns.
+push :: proc(L: ^Lua_State, value: any) {
+	push_at_depth(L, value, 0)
+}
+
+@(private = "file")
+push_at_depth :: proc(L: ^Lua_State, value: any, depth: int) {
+	if depth >= MAX_PUSH_DEPTH {
+		fmt.eprintfln("redin: warn: bridge.push bailed at depth %d (circular reference?)", depth)
+		lua_pushnil(L)
+		return
+	}
+
+	if value.data == nil || value.id == nil {
+		lua_pushnil(L)
+		return
+	}
+
+	ti := runtime.type_info_base(type_info_of(value.id))
+
+	#partial switch v in ti.variant {
+	case runtime.Type_Info_Boolean:
+		b, ok := reflect.as_bool(value)
+		if ok {
+			lua_pushboolean(L, b ? 1 : 0)
+		} else {
+			lua_pushnil(L)
+		}
+
+	case runtime.Type_Info_Integer:
+		// Keep precision: use i64 path for signed, u64 for unsigned.
+		if v.signed {
+			n, ok := reflect.as_i64(value)
+			if ok { lua_pushinteger(L, n) } else { lua_pushnil(L) }
+		} else {
+			n, ok := reflect.as_u64(value)
+			if ok { lua_pushinteger(L, i64(n)) } else { lua_pushnil(L) }
+		}
+
+	case runtime.Type_Info_Float:
+		n, ok := reflect.as_f64(value)
+		if ok { lua_pushnumber(L, n) } else { lua_pushnil(L) }
+
+	case runtime.Type_Info_Enum:
+		// Push as integer using the underlying base type.
+		base_value := any{data = value.data, id = v.base.id}
+		push_at_depth(L, base_value, depth + 1)
+
+	case runtime.Type_Info_String:
+		s, ok := reflect.as_string(value)
+		if ok {
+			cs := strings.clone_to_cstring(s, context.temp_allocator)
+			lua_pushstring(L, cs)
+		} else {
+			lua_pushnil(L)
+		}
+
+	case runtime.Type_Info_Pointer:
+		ptr := (^rawptr)(value.data)^
+		if ptr == nil {
+			lua_pushnil(L)
+		} else {
+			elem := any{data = ptr, id = v.elem.id}
+			push_at_depth(L, elem, depth + 1)
+		}
+
+	case runtime.Type_Info_Slice:
+		slice := (^runtime.Raw_Slice)(value.data)^
+		push_array(L, slice.data, slice.len, v.elem, v.elem_size, depth)
+
+	case runtime.Type_Info_Array:
+		push_array(L, value.data, v.count, v.elem, v.elem_size, depth)
+
+	case runtime.Type_Info_Dynamic_Array:
+		da := (^runtime.Raw_Dynamic_Array)(value.data)^
+		push_array(L, da.data, da.len, v.elem, v.elem_size, depth)
+
+	case runtime.Type_Info_Map:
+		push_map(L, value, v, depth)
+
+	case runtime.Type_Info_Struct:
+		push_struct(L, value, v, depth)
+
+	case runtime.Type_Info_Union:
+		push_union(L, value, v, depth)
+
+	case runtime.Type_Info_Any:
+		// `any` wraps another any. Recurse on the wrapped value.
+		inner := (^any)(value.data)^
+		push_at_depth(L, inner, depth + 1)
+
+	case:
+		fmt.eprintfln("redin: warn: bridge.push: unsupported type %v", value.id)
+		lua_pushnil(L)
+	}
+}
+
+@(private = "file")
+push_array :: proc(L: ^Lua_State, data: rawptr, count: int, elem: ^runtime.Type_Info, elem_size: int, depth: int) {
+	lua_createtable(L, i32(count), 0)
+	for i in 0 ..< count {
+		item_data := rawptr(uintptr(data) + uintptr(i * elem_size))
+		item := any{data = item_data, id = elem.id}
+		push_at_depth(L, item, depth + 1)
+		lua_rawseti(L, -2, i32(i + 1)) // Lua arrays are 1-indexed
+	}
+}
+
+@(private = "file")
+push_struct :: proc(L: ^Lua_State, value: any, info: runtime.Type_Info_Struct, depth: int) {
+	lua_createtable(L, 0, info.field_count)
+	for i in 0 ..< int(info.field_count) {
+		field_data := rawptr(uintptr(value.data) + info.offsets[i])
+		field_value := any{data = field_data, id = info.types[i].id}
+		push_at_depth(L, field_value, depth + 1)
+		// Stack: [..., table, field_value]
+		name := strings.clone_to_cstring(info.names[i], context.temp_allocator)
+		lua_setfield(L, -2, name)
+	}
+}
+
+@(private = "file")
+push_union :: proc(L: ^Lua_State, value: any, info: runtime.Type_Info_Union, depth: int) {
+	tag_ptr := rawptr(uintptr(value.data) + info.tag_offset)
+	tag: i64
+	switch info.tag_type.size {
+	case 1: tag = i64((^i8)(tag_ptr)^)
+	case 2: tag = i64((^i16)(tag_ptr)^)
+	case 4: tag = i64((^i32)(tag_ptr)^)
+	case 8: tag = (^i64)(tag_ptr)^
+	case:   tag = 0
+	}
+	if tag == 0 {
+		lua_pushnil(L)
+		return
+	}
+	variant := info.variants[tag - 1]
+	inner := any{data = value.data, id = variant.id}
+	push_at_depth(L, inner, depth + 1)
+}
+
+@(private = "file")
+push_map :: proc(L: ^Lua_State, value: any, info: runtime.Type_Info_Map, depth: int) {
+	lua_createtable(L, 0, 0)
+
+	it: int
+	for k, val in reflect.iterate_map(value, &it) {
+		// Push key. We accept any type that the marshaller would push as a
+		// Lua scalar — string is the common case (map[string]T) and works
+		// the cleanest. Numbers, bools, etc. also work via push_at_depth.
+		push_at_depth(L, k, depth + 1)
+		push_at_depth(L, val, depth + 1)
+		lua_settable(L, -3)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Native → Fennel dispatch
+// ---------------------------------------------------------------------------
+//
+// `redin_events` is a Fennel-side function (view.deliver-events) registered
+// as a Lua global at runtime startup. It expects an array of entries where
+// each entry has the shape ["dispatch", [event_name, payload?]].
+
+// Zero-copy variant: the caller has already pushed the payload onto the
+// top of the Lua stack. Wraps it in ["dispatch", [event, payload]],
+// appends to a one-element events array, and calls redin_events. The
+// payload is consumed regardless of success.
+//
+// Use this in hot paths (per-frame state push) where the caller can
+// avoid the reflection cost by building the payload directly with
+// lua_push* helpers. See `dispatch` for the high-level variant.
+dispatch_tos :: proc(L: ^Lua_State, event: string) -> (ok: bool, err: string) {
+	// Stack on entry: [..., payload]
+	lua_getglobal(L, "redin_events")
+	if lua_isnil(L, -1) {
+		lua_pop(L, 2) // pop nil redin_events + payload
+		return false, "redin_events is not registered (Fennel runtime not loaded)"
+	}
+	// Stack: [..., payload, redin_events]
+	// payload is at -2; we need it copied into the events array below.
+
+	// events[1] = ["dispatch", [event, payload]]
+	lua_createtable(L, 1, 0) // events
+	lua_createtable(L, 2, 0) // wrapper
+	lua_pushstring(L, "dispatch")
+	lua_rawseti(L, -2, 1) // wrapper[1] = "dispatch"
+
+	lua_createtable(L, 2, 0) // inner
+	ev_cs := strings.clone_to_cstring(event, context.temp_allocator)
+	lua_pushstring(L, ev_cs)
+	lua_rawseti(L, -2, 1) // inner[1] = event_name
+
+	// Stack now: [..., payload, redin_events, events, wrapper, inner]
+	// Original payload sits at index -5. Copy it as inner[2].
+	lua_pushvalue(L, -5)
+	lua_rawseti(L, -2, 2) // inner[2] = payload (pops the copy)
+
+	lua_rawseti(L, -2, 2) // wrapper[2] = inner
+	lua_rawseti(L, -2, 1) // events[1] = wrapper
+
+	// Stack: [..., payload, redin_events, events]
+	// pcall consumes redin_events + events; payload is left dangling and
+	// we pop it ourselves at the end (regardless of success/failure).
+	if lua_pcall(L, 1, 0, 0) != 0 {
+		msg := lua_tostring_raw(L, -1)
+		err_owned := strings.clone_from_cstring(msg, context.temp_allocator)
+		lua_pop(L, 2) // error msg + original payload
+		return false, err_owned
+	}
+
+	lua_pop(L, 1) // original payload
+	return true, ""
+}
+
+// Dispatch an event with an Odin-side payload. Marshals the payload via
+// `push` (reflection-based), wraps in ["dispatch", [event, payload]],
+// and appends to redin_events. Suitable for non-hot-path callers; for
+// per-frame pushes prefer building the payload directly and using
+// dispatch_tos.
+dispatch :: proc(event: string, payload: any) -> (ok: bool, err: string) {
+	if g_bridge == nil {
+		return false, "bridge.dispatch called before bridge.init"
+	}
+	push(g_bridge.L, payload)
+	return dispatch_tos(g_bridge.L, event)
+}

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -48,19 +48,19 @@ init :: proc(b: ^Bridge, dev_mode: bool) {
 
 	// Create redin global table with host functions
 	lua_newtable(b.L)
-	register_cfunc(b.L, "push", redin_push)
-	register_cfunc(b.L, "set_theme", redin_set_theme)
-	register_cfunc(b.L, "log", redin_log)
-	register_cfunc(b.L, "now", redin_now)
-	register_cfunc(b.L, "measure_text", redin_measure_text)
-	register_cfunc(b.L, "http", redin_http)
-	register_cfunc(b.L, "json_encode", redin_json_encode)
-	register_cfunc(b.L, "json_decode", redin_json_decode)
-	register_cfunc(b.L, "canvas_register", redin_canvas_register)
-	register_cfunc(b.L, "canvas_unregister", redin_canvas_unregister)
-	register_cfunc(b.L, "key_down", redin_key_down)
-	register_cfunc(b.L, "key_pressed", redin_key_pressed)
-	register_cfunc(b.L, "shell", redin_shell)
+	register_cfunc_init(b.L, "push", redin_push)
+	register_cfunc_init(b.L, "set_theme", redin_set_theme)
+	register_cfunc_init(b.L, "log", redin_log)
+	register_cfunc_init(b.L, "now", redin_now)
+	register_cfunc_init(b.L, "measure_text", redin_measure_text)
+	register_cfunc_init(b.L, "http", redin_http)
+	register_cfunc_init(b.L, "json_encode", redin_json_encode)
+	register_cfunc_init(b.L, "json_decode", redin_json_decode)
+	register_cfunc_init(b.L, "canvas_register", redin_canvas_register)
+	register_cfunc_init(b.L, "canvas_unregister", redin_canvas_unregister)
+	register_cfunc_init(b.L, "key_down", redin_key_down)
+	register_cfunc_init(b.L, "key_pressed", redin_key_pressed)
+	register_cfunc_init(b.L, "shell", redin_shell)
 	lua_setglobal(b.L, "redin")
 
 	// Also expose flat globals for the effect system
@@ -68,6 +68,11 @@ init :: proc(b: ^Bridge, dev_mode: bool) {
 	lua_setglobal(b.L, "redin_http")
 	lua_pushcfunction(b.L, redin_shell)
 	lua_setglobal(b.L, "redin_shell")
+
+	// Apply any user cfunc registrations made before bridge.init (the
+	// natural pattern: app.odin calls bridge.register_cfunc before
+	// redin.run, which is when bridge.init runs).
+	flush_pending_cfuncs()
 
 	load_fennel(b.L)
 	load_runtime(b.L)
@@ -1645,7 +1650,13 @@ parse_fraction :: proc(s: string) -> types.ViewportValue {
 // Helpers
 // ---------------------------------------------------------------------------
 
-register_cfunc :: proc(L: ^Lua_State, name: cstring, f: Lua_CFunction) {
+// Init-only helper: assumes the redin table is at stack -2 and adds a
+// cfield to it. The public, post-init API for adding cfuncs to the redin
+// table lives in api.odin (`register_cfunc` / `register_cfunc_raw`); that
+// version locates the redin table via lua_getglobal so it works after init
+// returns.
+@(private)
+register_cfunc_init :: proc(L: ^Lua_State, name: cstring, f: Lua_CFunction) {
 	lua_pushcfunction(L, f)
 	lua_setfield(L, -2, name)
 }

--- a/src/redin/bridge/lua_api.odin
+++ b/src/redin/bridge/lua_api.odin
@@ -40,12 +40,14 @@ foreign luajit {
 	lua_pushstring    :: proc(L: ^Lua_State, s: cstring) ---
 	lua_pushboolean   :: proc(L: ^Lua_State, b: i32) ---
 	lua_pushcclosure  :: proc(L: ^Lua_State, f: Lua_CFunction, n: i32) ---
+	lua_pushlightuserdata :: proc(L: ^Lua_State, p: rawptr) ---
 
-	lua_tonumber  :: proc(L: ^Lua_State, index: i32) -> f64 ---
-	lua_tointeger :: proc(L: ^Lua_State, index: i32) -> i64 ---
-	lua_toboolean :: proc(L: ^Lua_State, index: i32) -> i32 ---
-	lua_tolstring :: proc(L: ^Lua_State, index: i32, len: ^uint) -> cstring ---
-	lua_topointer :: proc(L: ^Lua_State, index: i32) -> rawptr ---
+	lua_tonumber   :: proc(L: ^Lua_State, index: i32) -> f64 ---
+	lua_tointeger  :: proc(L: ^Lua_State, index: i32) -> i64 ---
+	lua_toboolean  :: proc(L: ^Lua_State, index: i32) -> i32 ---
+	lua_tolstring  :: proc(L: ^Lua_State, index: i32, len: ^uint) -> cstring ---
+	lua_topointer  :: proc(L: ^Lua_State, index: i32) -> rawptr ---
+	lua_touserdata :: proc(L: ^Lua_State, index: i32) -> rawptr ---
 
 	lua_createtable :: proc(L: ^Lua_State, narr: i32, nrec: i32) ---
 	lua_settable    :: proc(L: ^Lua_State, index: i32) ---
@@ -102,6 +104,13 @@ lua_isstring :: #force_inline proc "contextless" (L: ^Lua_State, index: i32) -> 
 
 lua_isnumber :: #force_inline proc "contextless" (L: ^Lua_State, index: i32) -> bool {
 	return lua_type(L, index) == LUA_TNUMBER
+}
+
+// Lua 5.1 / LuaJIT: upvalue indices are encoded as offsets from
+// LUA_GLOBALSINDEX. Used by closure-based cfuncs to access values
+// captured at lua_pushcclosure time.
+lua_upvalueindex :: #force_inline proc "contextless" (i: i32) -> i32 {
+	return LUA_GLOBALSINDEX - i
 }
 
 luaL_dofile :: proc(L: ^Lua_State, filename: cstring) -> i32 {


### PR DESCRIPTION
Second of three PRs implementing #79. Closes #74 and #75; unblocks user-space implementation for #76.

## What this changes

New file `src/redin/bridge/api.odin` exposes a small public API on top of existing internals. No behavior change for Fennel-only projects — this is strictly additive.

### Cfunc registration (with auto-context trampoline)

```odin
my_cfunc :: proc(L: ^bridge.Lua_State) -> i32 {
    // No `proc "c"`, no manual `context = ...`.
    return 0
}

bridge.register_cfunc("my_cfunc", my_cfunc)   // safe before or after bridge.init
```

The bridge stores the user proc pointer as a Lua **upvalue** (lightuserdata) and registers a single static `cfunc_trampoline :: proc "c"` as the actual cfunc. The trampoline pulls the pointer back via `lua_upvalueindex(1)`, sets `context = host_context()`, and calls the user proc. End result: 99% of native code never types `"c"` and never touches `host_context()` directly.

Pre-`bridge.init` registrations are buffered in `g_pending_cfuncs` and flushed inside `bridge.init`, after the `redin` Lua global is created. Post-init they apply immediately via `lua_getglobal`.

`register_cfunc_raw(name, fn: Lua_CFunction)` is the escape hatch for raw `proc "c"` callers (advanced; must call `context = bridge.host_context()` themselves).

### Marshaller

```odin
bridge.push :: proc(L: ^Lua_State, value: any)
```

Supports: `nil`, `bool`, integer (i8..i64, u8..u64), enum (via base type), `f32`, `f64`, `string`, `cstring`, `[]T`, `[N]T`, `[dynamic]T`, map (string-keyed common case), struct (field name → value), union (active variant), pointer (deref or nil), `any` (recurse). Bails at recursion depth 32 with a stderr warning to guard cycles. Unsupported types push nil and warn.

Uses `base:runtime` + `core:reflect` for type-info dispatch.

### Dispatch

```odin
bridge.dispatch     :: proc(event: string, payload: any)               -> (ok, err)
bridge.dispatch_tos :: proc(L: ^Lua_State, event: string)               -> (ok, err)
```

`dispatch` is `push` + `dispatch_tos` under the hood. `dispatch_tos` is the zero-copy hot-path primitive — caller has already pushed the payload onto top of stack (the per-frame state-push pattern from #75).

### Plumbing

- Existing init-only helper `register_cfunc(L, name, f)` renamed to `register_cfunc_init` so the public name is free for the post-init variant.
- `bridge.init` calls `flush_pending_cfuncs()` after `lua_setglobal "redin"` and before `load_runtime`, so user pre-init registrations are visible to Fennel from the moment the runtime starts.
- Added FFI bindings: `lua_pushlightuserdata`, `lua_touserdata`. Added inline helper `lua_upvalueindex(i: i32) -> i32` returning `LUA_GLOBALSINDEX - i` (the Lua 5.1 / LuaJIT convention).

### Skill update

- `redin-dev/SKILL.md` "Adding a host function" now leads with the **user-side** workflow (preferred for `--native` projects) and keeps the framework-side workflow as a secondary path for upstream contributors.
- New "Bridge API for native code" table documents `push`, `dispatch`, `dispatch_tos`, `register_cfunc`, `register_cfunc_raw`, `host_context`.

## Test plan

- [x] `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin` → green
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` → 122/122
- [x] `odin test src/redin/parser` → 26/26
- [x] End-to-end smoke (project-root `app.odin` against the renamed redin):
   - `register_cfunc("my_signal", ...)` called **before** `redin.run`. From Fennel `(redin.my_signal)` triggers the user proc; trampoline auto-sets context. ✓
   - `on_frame` hook calls `bridge.dispatch("combat/push", state)` where state is a struct with `i32`/`i64` fields. `/state/combat` returns `{"enemy_hp":50,"player_hp":100,"turn":360}` — proves the struct marshaller, the dispatch wrap, and the Fennel `(reg-handler :combat/push ...)` path. ✓
   - Calling `redin.my_signal()` via the dev server's `POST /events` triggers the user cfunc; signal-count subscription updates. ✓

Closes sstoehrm/redin#74, sstoehrm/redin#75. sstoehrm/redin#76 stays open as the tracker for the user-space-proven topic-routed signal channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)