### PR TITLE
fix(devserver): refuse to follow symlinks on token/port writes (#78 M1)

### DIFF
--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -8,6 +8,7 @@ import "core:net"
 import "core:os"
 import "core:strings"
 import "core:sync"
+import "core:sys/linux"
 import "core:thread"
 import "core:time"
 import "../input"
@@ -81,6 +82,41 @@ sync_queue_drain :: proc(sq: ^Sync_Queue, out: ^[dynamic]^Pending_Request) {
 
 // --- Init/Destroy ---
 
+// Write `data` to `path` with mode 0600, refusing to follow symlinks
+// or to open any non-regular file. Used for .redin-port and .redin-token
+// — see issue #78 finding M1. Without O_NOFOLLOW, an attacker (or a
+// stale symlink in CWD) could redirect the write to an arbitrary file
+// owned by the user (e.g. ~/.ssh/authorized_keys).
+//
+// On EEXIST we lstat the path and only retry after unlinking when the
+// existing entry is a regular file — handles the legitimate case where
+// a previous --dev run crashed without cleaning up. Symlinks raise
+// ELOOP under O_NOFOLLOW, FIFOs/sockets/devices fall through without
+// retry, so neither path can be hijacked.
+write_private_no_follow :: proc(path: string, data: []u8) -> bool {
+	cpath := strings.clone_to_cstring(path, context.temp_allocator)
+	flags := linux.Open_Flags{.WRONLY, .CREAT, .EXCL, .TRUNC, .NOFOLLOW, .CLOEXEC}
+	mode  := linux.Mode{.IRUSR, .IWUSR}
+
+	fd, err := linux.open(cpath, flags, mode)
+	if err == .EEXIST {
+		// O_NOFOLLOW + O_EXCL: symlinks surface as EEXIST rather than
+		// ELOOP. lstat (NOT stat) so we inspect the entry itself, not
+		// what a symlink points at.
+		st: linux.Stat
+		if linux.lstat(cpath, &st) != .NONE do return false
+		if (transmute(u32) st.mode) & 0o170000 != 0o100000 do return false
+		if linux.unlink(cpath) != .NONE do return false
+		fd, err = linux.open(cpath, flags, mode)
+	}
+	if err != .NONE do return false
+	defer linux.close(fd)
+
+	written, werr := linux.write(fd, data)
+	if werr != .NONE || written != len(data) do return false
+	return true
+}
+
 devserver_init :: proc(ds: ^Dev_Server, b: ^Bridge) {
 	ds.bridge = b
 	ds.running = true
@@ -125,13 +161,17 @@ devserver_init :: proc(ds: ^Dev_Server, b: ^Bridge) {
 	// which leaked the bound port to anyone who could list the CWD.
 	// Testing helpers run as the same user, so 0600 doesn't regress
 	// them.
-	private_perm := os.Permissions{.Read_User, .Write_User}
+	//
+	// write_private_no_follow refuses to write through a symlink — see
+	// issue #78 finding M1. If a stale symlink in CWD points at a
+	// sensitive file, the dev server logs and continues without writing
+	// rather than overwriting the link target.
 	port_str := fmt.tprintf("%d", bound_port)
-	if err := os.write_entire_file(PORT_FILE, transmute([]u8)port_str, private_perm); err != nil {
-		fmt.eprintfln("Warning: could not write %s: %v", PORT_FILE, err)
+	if !write_private_no_follow(PORT_FILE, transmute([]u8)port_str) {
+		fmt.eprintfln("Warning: could not write %s (refused to follow non-regular path)", PORT_FILE)
 	}
-	if err := os.write_entire_file(TOKEN_FILE, transmute([]u8)ds.auth_token, private_perm); err != nil {
-		fmt.eprintfln("Warning: could not write %s: %v", TOKEN_FILE, err)
+	if !write_private_no_follow(TOKEN_FILE, transmute([]u8)ds.auth_token) {
+		fmt.eprintfln("Warning: could not write %s (refused to follow non-regular path)", TOKEN_FILE)
 	}
 
 	ds.server_thread = thread.create_and_start_with_poly_data(ds, server_thread_proc, context)

--- a/src/redin/bridge/devserver_write_test.odin
+++ b/src/redin/bridge/devserver_write_test.odin
@@ -1,0 +1,97 @@
+package bridge
+
+// Regression tests for issue #78 finding M1: the dev server's writes to
+// .redin-port and .redin-token must not follow symlinks. Without
+// O_NOFOLLOW, an attacker (or a stale symlink in CWD) could redirect
+// the write to an arbitrary file owned by the user (e.g. ~/.ssh/authorized_keys).
+
+import "core:fmt"
+import "core:os"
+import "core:strings"
+import "core:sys/linux"
+import "core:testing"
+
+@(private = "file")
+make_tmp_path :: proc(suffix: string) -> string {
+	dir, derr := os.temp_directory(context.temp_allocator)
+	if derr != nil {
+		dir = "/tmp"
+	}
+	pid := linux.getpid()
+	return fmt.aprintf("%s/redin_test_%d_%s", dir, i32(pid), suffix)
+}
+
+@(private = "file")
+read_all :: proc(path: string) -> (string, bool) {
+	data, err := os.read_entire_file_from_path(path, context.allocator)
+	if err != nil do return "", false
+	return string(data), true
+}
+
+@(test)
+test_write_private_no_follow_creates_new_file :: proc(t: ^testing.T) {
+	path := make_tmp_path("new")
+	defer delete(path)
+	defer os.remove(path)
+
+	payload := "hello"
+	testing.expect(t, write_private_no_follow(path, transmute([]u8)payload))
+
+	got, ok := read_all(path)
+	defer if ok do delete(got)
+	testing.expect(t, ok, "expected file to be readable after write")
+	testing.expect_value(t, got, payload)
+}
+
+@(test)
+test_write_private_no_follow_refuses_symlink :: proc(t: ^testing.T) {
+	target := make_tmp_path("symlink_target")
+	link   := make_tmp_path("symlink_link")
+	defer delete(target)
+	defer delete(link)
+	defer os.remove(target)
+	defer os.remove(link)
+
+	// Plant a regular file with sentinel content, then a symlink
+	// pointing at it. If the helper follows the link, the sentinel
+	// content gets overwritten — the bug under test.
+	sentinel := "PROTECTED\n"
+	_ = os.write_entire_file(target, transmute([]u8)sentinel)
+
+	ctarget := strings.clone_to_cstring(target, context.temp_allocator)
+	clink   := strings.clone_to_cstring(link,   context.temp_allocator)
+	if errno := linux.symlink(ctarget, clink); errno != .NONE {
+		testing.fail_now(t, fmt.tprintf("symlink setup failed: %v", errno))
+	}
+
+	payload := "ATTACKER_OVERWRITE"
+	ok := write_private_no_follow(link, transmute([]u8)payload)
+	testing.expect(t, !ok, "write_private_no_follow must refuse to write through a symlink")
+
+	got, read_ok := read_all(target)
+	defer if read_ok do delete(got)
+	testing.expect(t, read_ok, "symlink target should still be readable")
+	testing.expect_value(t, got, sentinel)
+}
+
+@(test)
+test_write_private_no_follow_replaces_stale_regular_file :: proc(t: ^testing.T) {
+	// A previous --dev run that crashed leaves .redin-token behind as a
+	// regular file with mode 0600. The next run must be able to replace
+	// it (otherwise dev mode breaks after any crash). The replacement
+	// must NOT preserve any prior content.
+	path := make_tmp_path("stale")
+	defer delete(path)
+	defer os.remove(path)
+
+	stale := "leftover_from_previous_run"
+	_ = os.write_entire_file(path, transmute([]u8)stale)
+
+	fresh := "new_token_value"
+	testing.expect(t, write_private_no_follow(path, transmute([]u8)fresh))
+
+	got, ok := read_all(path)
+	defer if ok do delete(got)
+	testing.expect(t, ok)
+	testing.expect_value(t, got, fresh)
+}


### PR DESCRIPTION
## Summary

- `os.write_entire_file` follows symlinks. A stale or attacker-planted symlink at `./.redin-token` or `./.redin-port` could redirect the dev server's startup writes onto an arbitrary file owned by the user. Content is attacker-uncontrolled (random hex token / decimal port) so this is a file-destruction primitive, not write-what-where, but still a local DoS / data-loss vector.
- New helper `write_private_no_follow` opens with `O_CREAT|O_WRONLY|O_TRUNC|O_EXCL|O_NOFOLLOW|O_CLOEXEC` at mode 0600. On `EEXIST` it `lstat`s the path and only retries after `unlink` when the entry is a regular file — handles the legitimate "previous `--dev` run crashed" case while refusing symlinks, directories, FIFOs, sockets, and devices.
- Addresses finding **M1** from #78.

## Test plan

- [x] New unit tests `test_write_private_no_follow_{creates_new_file,refuses_symlink,replaces_stale_regular_file}` — 3/3 pass
- [x] Red-green-revert verified: swapping `lstat` for `stat` in the helper makes the symlink-refusal test fail
- [x] `odin test src/redin/bridge ...` — 8/8 pass
- [x] `odin build src/cmd/redin ...` — exit 0
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 122/122 pass
- [x] `bash test/ui/run-all.sh --headless` — all suites pass
- [x] `--track-mem` smoke run with graceful shutdown — no leak / outstanding reports
- [x] `examples/perf-10k.fnl` under `--dev --profile` — 9.5–10.7 ms/frame, phases stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)