### PR TITLE
chore(setup): add clang and xvfb to apt install line

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -11,7 +11,7 @@ echo ""
 echo "Installing system packages..."
 if command -v apt-get &>/dev/null; then
   sudo apt-get update -qq
-  sudo apt-get install -y luajit libluajit-5.1-dev libssl-dev
+  sudo apt-get install -y luajit libluajit-5.1-dev libssl-dev clang xvfb
 elif command -v dnf &>/dev/null; then
   sudo dnf install -y luajit luajit-devel openssl-devel
 elif command -v pacman &>/dev/null; then


### PR DESCRIPTION
## Summary

- `clang` is required by recent Odin nightlies for both `odin build` and `odin test` (the toolchain's default linker driver). Without it, builds fail with `sh: 1: clang: not found`.
- `xvfb` supports the `test/ui/run-all.sh --headless` path documented in `.claude/skills/redin-maintenance/SKILL.md`.
- Only the `apt-get` branch is updated; `dnf`/`pacman` branches are untouched because equivalent package names there weren't validated in this change.

## Test plan

- [ ] Fresh apt-based VM: `bash setup.sh && odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin` succeeds
- [ ] `bash test/ui/run-all.sh --headless` passes on a machine without a display

🤖 Generated with [Claude Code](https://claude.com/claude-code)