### PR TITLE
fix(devserver): header lookup boundary + /click range check (#78 L1, L2)

### DIFF
--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -4,6 +4,7 @@ import "core:container/queue"
 import "core:crypto"
 import "core:encoding/hex"
 import "core:fmt"
+import "core:math"
 import "core:net"
 import "core:os"
 import "core:strings"
@@ -408,19 +409,36 @@ int_to_str :: proc(buf: []u8, val: int) -> string {
 
 // Case-insensitive lookup for a header value. Returns the trimmed
 // value, or "" if the header is absent.
+//
+// Skips past the request line (everything up to the first \r\n) so a
+// path/query containing the literal "host:" or "authorization:" can
+// never be mistaken for a header. Issue #78 finding L1: previously the
+// first non-boundary match short-circuited the lookup with "", which
+// turned benign URLs like /state/host:foo into spurious 403s and
+// could be turned into a Host/auth bypass by a future refactor.
 find_header_value :: proc(headers: string, name_lower: string) -> string {
 	lower := strings.to_lower(headers, context.temp_allocator)
 	needle := strings.concatenate({name_lower, ":"}, context.temp_allocator)
-	idx := strings.index(lower, needle)
-	if idx < 0 do return ""
-	// Require the header to start at a line boundary (or the very
-	// start of the buffer) so a body substring can't be mistaken for
-	// a header.
-	if idx > 0 && lower[idx - 1] != '\n' do return ""
-	rest := headers[idx + len(needle):]
-	end := strings.index_any(rest, "\r\n")
-	if end < 0 do end = len(rest)
-	return strings.trim_space(rest[:end])
+
+	start := 0
+	if rl_end := strings.index(lower, "\r\n"); rl_end >= 0 {
+		start = rl_end + 2
+	}
+
+	pos := start
+	for pos < len(lower) {
+		rel := strings.index(lower[pos:], needle)
+		if rel < 0 do return ""
+		idx := pos + rel
+		if idx == start || lower[idx - 1] == '\n' {
+			rest := headers[idx + len(needle):]
+			end := strings.index_any(rest, "\r\n")
+			if end < 0 do end = len(rest)
+			return strings.trim_space(rest[:end])
+		}
+		pos = idx + len(needle)
+	}
+	return ""
 }
 
 // Verify the request's Host header matches one of the expected bound
@@ -924,18 +942,36 @@ handle_post_events :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string)
 }
 
 handle_post_click :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	// Issue #78 finding L2: previously this enqueued any (x,y) the
+	// client sent, including NaN, Infinity, negative, and screen-out-of-
+	// bounds values. /resize already validates and returns 400 on bad
+	// input — /click now follows the same pattern.
 	L := ds.bridge.L
 	pos := 0
-	if json_decode_value(L, body, &pos) && lua_istable(L, -1) {
-		lua_getfield(L, -1, "x")
-		x := f32(lua_tonumber(L, -1))
-		lua_pop(L, 1)
-		lua_getfield(L, -1, "y")
-		y := f32(lua_tonumber(L, -1))
-		lua_pop(L, 1)
-		lua_pop(L, 1)
-		append(&ds.event_queue, types.InputEvent(types.MouseEvent{x = x, y = y, button = .LEFT}))
+	if !json_decode_value(L, body, &pos) {
+		respond_json_error(ch, 400, `{"error":"invalid JSON"}`)
+		return
 	}
+	defer lua_pop(L, 1)
+	if !lua_istable(L, -1) {
+		respond_json_error(ch, 400, `{"error":"body must be an object"}`)
+		return
+	}
+	lua_getfield(L, -1, "x")
+	x := f32(lua_tonumber(L, -1))
+	lua_pop(L, 1)
+	lua_getfield(L, -1, "y")
+	y := f32(lua_tonumber(L, -1))
+	lua_pop(L, 1)
+
+	sw := f32(rl.GetScreenWidth())
+	sh := f32(rl.GetScreenHeight())
+	if math.is_nan(x) || math.is_nan(y) || math.is_inf(x) || math.is_inf(y) ||
+	   x < 0 || y < 0 || x > sw || y > sh {
+		respond_json_error(ch, 400, `{"error":"x,y out of range"}`)
+		return
+	}
+	append(&ds.event_queue, types.InputEvent(types.MouseEvent{x = x, y = y, button = .LEFT}))
 	respond_json_ok(ch)
 }
 

--- a/src/redin/bridge/devserver_headers_test.odin
+++ b/src/redin/bridge/devserver_headers_test.odin
@@ -1,0 +1,52 @@
+package bridge
+
+// Regression tests for issue #78 finding L1: find_header_value used
+// strings.index, which returns the first match anywhere in the buffer.
+// If the request line contains the literal "host:" (e.g. inside a
+// path or query), the first match is non-boundary, the boundary check
+// fails, and the lookup returns "" without continuing past the
+// poisoned occurrence — so the *real* Host header below is never seen
+// and the request is rejected with 403.
+
+import "core:testing"
+
+@(test)
+test_find_header_value_simple :: proc(t: ^testing.T) {
+	headers := "GET / HTTP/1.1\r\nHost: localhost:8800\r\nAuthorization: Bearer abc\r\nContent-Length: 0"
+	testing.expect_value(t, find_header_value(headers, "host"), "localhost:8800")
+	testing.expect_value(t, find_header_value(headers, "authorization"), "Bearer abc")
+	testing.expect_value(t, find_header_value(headers, "content-length"), "0")
+}
+
+@(test)
+test_find_header_value_missing :: proc(t: ^testing.T) {
+	headers := "GET / HTTP/1.1\r\nHost: localhost:8800"
+	testing.expect_value(t, find_header_value(headers, "x-not-here"), "")
+}
+
+@(test)
+test_find_header_value_case_insensitive :: proc(t: ^testing.T) {
+	headers := "GET / HTTP/1.1\r\nHOST: localhost:8800\r\nauthorization: Bearer xyz"
+	testing.expect_value(t, find_header_value(headers, "host"), "localhost:8800")
+	testing.expect_value(t, find_header_value(headers, "authorization"), "Bearer xyz")
+}
+
+@(test)
+test_find_header_value_path_contains_host :: proc(t: ^testing.T) {
+	// The request line contains "host:" inside the path. The lookup
+	// must skip past it and still find the real Host header below.
+	headers := "GET /state/host:foo HTTP/1.1\r\nHost: localhost:8800\r\n"
+	testing.expect_value(t, find_header_value(headers, "host"), "localhost:8800")
+}
+
+@(test)
+test_find_header_value_query_contains_authorization :: proc(t: ^testing.T) {
+	headers := "GET /search?q=authorization:Bearer HTTP/1.1\r\nAuthorization: Bearer real-token\r\n"
+	testing.expect_value(t, find_header_value(headers, "authorization"), "Bearer real-token")
+}
+
+@(test)
+test_find_header_value_trims_whitespace :: proc(t: ^testing.T) {
+	headers := "GET / HTTP/1.1\r\nHost:    localhost:8800   \r\n"
+	testing.expect_value(t, find_header_value(headers, "host"), "localhost:8800")
+}

--- a/test/ui/test_smoke.bb
+++ b/test/ui/test_smoke.bb
@@ -1,4 +1,21 @@
-(require '[redin-test :refer :all])
+(require '[redin-test :refer :all]
+         '[babashka.http-client :as http]
+         '[cheshire.core :as json]
+         '[clojure.string :as str])
+
+(defn- click-status
+  "POST /click with the given JSON body, return the HTTP status code.
+   Used by the /click validation regression tests for issue #78 L2 —
+   redin-test/click hides the status."
+  [body]
+  (let [port  (slurp ".redin-port")
+        token (str/trim (slurp ".redin-token"))
+        resp  (http/post (str "http://localhost:" (str/trim port) "/click")
+                         {:headers {"Content-Type" "application/json"
+                                    "Authorization" (str "Bearer " token)}
+                          :body (json/generate-string body)
+                          :throw false})]
+    (:status resp)))
 
 (deftest inspect-frame
   (let [frame (get-frame)]
@@ -46,3 +63,22 @@
   (wait-ms 100)
   (dispatch ["event/inc"])
   (wait-for (state= "counter" 1) {:timeout 2000}))
+
+;; Issue #78 L2: /click previously accepted any (x,y) including
+;; out-of-window values. /resize already validates and returns 400;
+;; /click must do the same. NaN/Infinity rejection is also part of the
+;; fix but isn't reachable through JSON (the literals aren't valid JSON
+;; and cheshire-encoded strings get coerced to 0 by lua_tonumber), so
+;; only the reachable cases are exercised here.
+
+(deftest click-rejects-negative
+  (assert (= 400 (click-status {:x -10 :y 100}))
+          "Negative x must be rejected with 400"))
+
+(deftest click-rejects-out-of-bounds
+  (assert (= 400 (click-status {:x 99999 :y 100}))
+          "x past the screen width must be rejected with 400"))
+
+(deftest click-accepts-valid-coords
+  (assert (= 200 (click-status {:x 10 :y 10}))
+          "Valid in-bounds coordinates must still succeed"))


### PR DESCRIPTION
## Summary

- **L1** — `find_header_value` searched the entire request buffer with `strings.index`, including the request line. A path/query containing the literal `host:` (or `authorization:`) hit a non-boundary match first, the boundary check failed, and the function returned `""` without continuing — so the real header below was never seen and the request was rejected with 403. Fix: skip past the request line, then loop past non-boundary matches.
- **L2** — `/click` enqueued any `(x,y)` including NaN, Infinity, negative, and out-of-window coordinates. `/resize` already validates and returns 400; `/click` now follows the same pattern (JSON shape check, NaN/Inf reject, range clamp to screen rect).
- Addresses findings **L1** and **L2** from #78.

## Test plan

- [x] New unit tests in `src/redin/bridge/devserver_headers_test.odin` — 6/6 pass; the two L1 regressions (`path_contains_host`, `query_contains_authorization`) fail on the pre-fix code (red-green-revert verified)
- [x] New bb tests in `test/ui/test_smoke.bb` — `click-rejects-negative`, `click-rejects-out-of-bounds`, `click-accepts-valid-coords` (RED before fix, all pass after)
- [x] `odin test src/redin/bridge ...` — 11/11 pass (5 font_path + 6 header)
- [x] `odin build src/cmd/redin ...` — exit 0
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 122/122 pass
- [x] `bash test/ui/run-all.sh --headless` — all suites pass (test_smoke 11/11)
- [x] `--track-mem` smoke run with live `/click` (negative→400, valid→200) and graceful shutdown — no leak / outstanding reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)