### PR TITLE
fix(http): cap response body at 16 MiB (#78 M2)

### DIFF
--- a/src/redin/bridge/http_client.odin
+++ b/src/redin/bridge/http_client.odin
@@ -8,6 +8,13 @@ import "core:thread"
 import http "lib:odin-http"
 import http_client "lib:odin-http/client"
 
+// Cap on the response body the HTTP client is willing to allocate for a
+// single request. odin-http honours the cap based on Content-Length, so
+// an oversized announcement short-circuits before any body bytes are
+// read. Issue #78 finding M2: previously unbounded — a malicious or
+// misbehaving remote could exhaust host memory.
+HTTP_MAX_BODY :: 16 * 1024 * 1024 // 16 MiB
+
 Http_Request :: struct {
 	id:      string,
 	url:     string,
@@ -98,7 +105,6 @@ http_request_destroy :: proc(req: ^Http_Request) {
 	delete(req.headers)
 }
 
-@(private = "file")
 execute_http_request :: proc(req: Http_Request) -> Http_Response {
 	response: Http_Response
 	response.id = req.id
@@ -145,7 +151,7 @@ execute_http_request :: proc(req: Http_Request) -> Http_Response {
 
 	response.status = int(res.status)
 
-	body, was_alloc, body_err := http_client.response_body(&res)
+	body, was_alloc, body_err := http_client.response_body(&res, HTTP_MAX_BODY)
 	if body_err == .None {
 		switch b in body {
 		case http_client.Body_Plain:
@@ -154,6 +160,11 @@ execute_http_request :: proc(req: Http_Request) -> Http_Response {
 			response.body = strings.clone("")
 		case http_client.Body_Error:
 		}
+	} else if body_err == .Too_Long {
+		response.status = 0
+		response.error_msg = fmt.aprintf(
+			"Response body too large (cap %d bytes)", HTTP_MAX_BODY,
+		)
 	} else {
 		response.error_msg = fmt.aprintf("Body read failed: %v", body_err)
 	}

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -1,0 +1,122 @@
+package bridge
+
+// Regression tests for issue #78 finding M2: execute_http_request
+// passed no max_length to http_client.response_body, so a malicious or
+// misbehaving remote could announce an arbitrary Content-Length and
+// drive the host out of memory. The fix caps the body at HTTP_MAX_BODY
+// and surfaces Too_Long as an explicit error.
+//
+// Test strategy: spin up a single-shot TCP mock server in a goroutine,
+// have it answer the next connection with a response header that
+// claims a Content-Length above the cap, and assert that
+// execute_http_request reports an error rather than streaming the body.
+
+import "core:fmt"
+import "core:net"
+import "core:strings"
+import "core:sync"
+import "core:testing"
+import "core:thread"
+
+@(private = "file")
+Mock_Server :: struct {
+	sock:     net.TCP_Socket,
+	port:     int,
+	response: string,
+	thread:   ^thread.Thread,
+	done:     sync.Sema,
+}
+
+@(private = "file")
+mock_serve :: proc(m: ^Mock_Server) {
+	defer sync.sema_post(&m.done)
+	client, _, err := net.accept_tcp(m.sock)
+	if err != nil do return
+	defer net.close(client)
+	// Read until the request headers end so the client doesn't see RST
+	// before it consumes our response.
+	buf: [4096]u8
+	total := 0
+	for total < len(buf) {
+		n, rerr := net.recv_tcp(client, buf[total:])
+		if rerr != nil || n <= 0 do break
+		total += n
+		if strings.contains(string(buf[:total]), "\r\n\r\n") do break
+	}
+	net.send_tcp(client, transmute([]u8)m.response)
+}
+
+@(private = "file")
+mock_start :: proc(response: string) -> ^Mock_Server {
+	m := new(Mock_Server)
+	m.response = response
+	for p in 18900 ..< 19000 {
+		s, err := net.listen_tcp(net.Endpoint{address = net.IP4_Loopback, port = p})
+		if err == nil {
+			m.sock = s
+			m.port = p
+			break
+		}
+	}
+	if m.port == 0 do return nil
+	m.thread = thread.create_and_start_with_poly_data(m, mock_serve, context)
+	return m
+}
+
+@(private = "file")
+mock_stop :: proc(m: ^Mock_Server) {
+	sync.sema_wait(&m.done)
+	if m.thread != nil {
+		thread.join(m.thread)
+		thread.destroy(m.thread)
+	}
+	net.close(m.sock)
+	free(m)
+}
+
+@(test)
+test_http_response_cap_rejects_oversized_content_length :: proc(t: ^testing.T) {
+	// Announce 32 MiB. With a HTTP_MAX_BODY cap of 16 MiB the underlying
+	// scanner returns Too_Long without reading the body.
+	announced := 32 * 1024 * 1024
+	resp := fmt.aprintf("HTTP/1.1 200 OK\r\nContent-Length: %d\r\nConnection: close\r\n\r\n", announced)
+	defer delete(resp)
+
+	m := mock_start(resp)
+	if m == nil {
+		testing.fail_now(t, "could not bind a mock server port in 18900..19000")
+	}
+	defer mock_stop(m)
+
+	url := fmt.tprintf("http://127.0.0.1:%d/", m.port)
+	req := Http_Request{
+		id     = strings.clone("test-1"),
+		url    = strings.clone(url),
+		method = strings.clone("GET"),
+	}
+	defer {
+		delete(req.id)
+		delete(req.url)
+		delete(req.method)
+	}
+
+	got := execute_http_request(req)
+	// NOTE: don't call http_response_destroy — got.id is a slice-copy of
+	// req.id (shared storage; pre-existing ownership quirk in the worker
+	// thread path). Free only the fields execute_http_request allocated
+	// exclusively for the response.
+	defer {
+		delete(got.body)
+		delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+
+	// Status must NOT reflect a successful 200; we want the body cap
+	// to short-circuit the response with an explicit error message.
+	testing.expect(t, got.status == 0,
+		fmt.tprintf("expected status 0 (capped), got %d", got.status))
+	testing.expect(t, len(got.error_msg) > 0, "expected an error message about the cap")
+	testing.expect(t, strings.contains(got.error_msg, "too large"),
+		fmt.tprintf("expected error_msg to mention 'too large', got %q", got.error_msg))
+}


### PR DESCRIPTION
## Summary

- `execute_http_request` passed no `max_length` to `http_client.response_body`, so a malicious or misbehaving remote could announce an arbitrary `Content-Length` and drive the host out of memory by streaming a body the client would gladly clone into the heap.
- Add `HTTP_MAX_BODY = 16 MiB` and pass it to `response_body`. odin-http checks the cap against `Content-Length` before reading any body bytes (`_response_body_length` in `lib/odin-http/client/client.odin:337`), so an oversized announcement short-circuits with `Body_Error.Too_Long` without allocating.
- Surface the error explicitly so callers see `"Response body too large (cap N bytes)"` instead of the generic `Scan_Failed`.
- Addresses finding **M2** from #78.

## Out of scope (deliberately)

- **Per-request wall-clock timeout.** The Fennel-side `:timeout` in `effect.fnl` is silently dropped today. odin-http's `client.request` signature has no deadline parameter, so wiring it requires a watchdog around the worker thread — a separate change with a separate review surface. Tracked as a follow-up.

## Implementation note

`execute_http_request` lost its `@(private = "file")` annotation. Nothing outside `http_client.odin` was calling it before either; the change just lets the regression test reach it directly without adding thread/poll flake to the test path.

## Test plan

- [x] New unit test in `src/redin/bridge/http_client_test.odin`: in-process TCP mock answers with `Content-Length: 33554432`, closes; assert status 0 + error message contains `"too large"`. Pre-fix: status 200 + `Body read failed: Scan_Failed`. Post-fix: status 0 + `Response body too large (cap 16777216 bytes)`.
- [x] Red-green-revert verified: removing the `max_length` argument from `response_body` makes the test fail with the exact pre-fix output.
- [x] `odin test src/redin/bridge ...` — 15/15 pass
- [x] `odin build src/cmd/redin ...` — exit 0
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 122/122 pass
- [x] `bash test/ui/run-all.sh --headless` — all suites pass
- [x] `--track-mem` smoke run with graceful shutdown — no leak / outstanding reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)