### PR TITLE
fix(canvas): sanitize colours, dimensions, text in command dispatch (#78 L3)

### DIFF
--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -1,6 +1,7 @@
 package bridge
 
 import "core:fmt"
+import "core:math"
 import "core:os"
 import "core:path/filepath"
 import "core:strings"
@@ -362,6 +363,30 @@ lua_rawgeti_number :: proc(L: ^Lua_State, idx: i32, i: i32) -> f64 {
 	return lua_tonumber(L, -1)
 }
 
+// Clamp an arbitrary numeric value to a u8. Used for canvas colour
+// components — pre-fix they were truncated via `u8(...)`, so a buggy
+// Fennel provider returning {255, 256, -1} silently rendered the wrong
+// colour. Issue #78 finding L3.
+clamp_byte :: proc(n: f64) -> u8 {
+	if math.is_nan(n) do return 0
+	if n <= 0 do return 0
+	if n >= 255 do return 255
+	return u8(n)
+}
+
+// Sanitize a canvas dimension (width / height / radius / coordinate
+// magnitude). Bails on NaN, Inf, negative, or above the texture-side
+// ceiling, so a malformed canvas command can be skipped instead of
+// flowing junk into Raylib's draw calls. Issue #78 finding L3.
+@(private = "file")
+DIM_MAX :: 16384
+
+sanitize_dim :: proc(v: f32) -> (f32, bool) {
+	if math.is_nan(v) || math.is_inf(v) do return 0, false
+	if v < 0 || v > DIM_MAX do return 0, false
+	return v, true
+}
+
 // Read a color [r,g,b] or [r,g,b,a] from a table field. Returns ok=false if field missing.
 read_color_field :: proc(L: ^Lua_State, idx: i32, field: cstring) -> (rl.Color, bool) {
 	lua_getfield(L, idx, field)
@@ -369,14 +394,14 @@ read_color_field :: proc(L: ^Lua_State, idx: i32, field: cstring) -> (rl.Color, 
 	if !lua_istable(L, -1) do return {}, false
 
 	color_idx := lua_gettop(L)
-	r := u8(lua_rawgeti_number(L, color_idx, 1))
-	g := u8(lua_rawgeti_number(L, color_idx, 2))
-	b := u8(lua_rawgeti_number(L, color_idx, 3))
+	r := clamp_byte(lua_rawgeti_number(L, color_idx, 1))
+	g := clamp_byte(lua_rawgeti_number(L, color_idx, 2))
+	b := clamp_byte(lua_rawgeti_number(L, color_idx, 3))
 
 	lua_rawgeti(L, color_idx, 4)
 	a := u8(255)
 	if lua_isnumber(L, -1) {
-		a = u8(lua_tonumber(L, -1))
+		a = clamp_byte(lua_tonumber(L, -1))
 	}
 	lua_pop(L, 1)
 
@@ -490,8 +515,9 @@ execute_canvas_command :: proc(L: ^Lua_State, idx: i32, tag: string, ox: f32, oy
 	case "rect":
 		x := f32(lua_rawgeti_number(L, idx, 2)) + ox
 		y := f32(lua_rawgeti_number(L, idx, 3)) + oy
-		w := f32(lua_rawgeti_number(L, idx, 4))
-		h := f32(lua_rawgeti_number(L, idx, 5))
+		w, w_ok := sanitize_dim(f32(lua_rawgeti_number(L, idx, 4)))
+		h, h_ok := sanitize_dim(f32(lua_rawgeti_number(L, idx, 5)))
+		if !w_ok || !h_ok do return
 		lua_rawgeti(L, idx, 6)
 		opts := lua_gettop(L)
 
@@ -521,7 +547,8 @@ execute_canvas_command :: proc(L: ^Lua_State, idx: i32, tag: string, ox: f32, oy
 	case "circle":
 		cx := f32(lua_rawgeti_number(L, idx, 2)) + ox
 		cy := f32(lua_rawgeti_number(L, idx, 3)) + oy
-		cr := f32(lua_rawgeti_number(L, idx, 4))
+		cr, cr_ok := sanitize_dim(f32(lua_rawgeti_number(L, idx, 4)))
+		if !cr_ok do return
 		lua_rawgeti(L, idx, 5)
 		opts := lua_gettop(L)
 
@@ -536,8 +563,9 @@ execute_canvas_command :: proc(L: ^Lua_State, idx: i32, tag: string, ox: f32, oy
 	case "ellipse":
 		cx := f32(lua_rawgeti_number(L, idx, 2)) + ox
 		cy := f32(lua_rawgeti_number(L, idx, 3)) + oy
-		rx := f32(lua_rawgeti_number(L, idx, 4))
-		ry := f32(lua_rawgeti_number(L, idx, 5))
+		rx, rx_ok := sanitize_dim(f32(lua_rawgeti_number(L, idx, 4)))
+		ry, ry_ok := sanitize_dim(f32(lua_rawgeti_number(L, idx, 5)))
+		if !rx_ok || !ry_ok do return
 		lua_rawgeti(L, idx, 6)
 		opts := lua_gettop(L)
 
@@ -572,6 +600,12 @@ execute_canvas_command :: proc(L: ^Lua_State, idx: i32, tag: string, ox: f32, oy
 		x := f32(lua_rawgeti_number(L, idx, 2)) + ox
 		y := f32(lua_rawgeti_number(L, idx, 3)) + oy
 		lua_rawgeti(L, idx, 4)
+		// Skip the command instead of feeding nil into DrawTextEx if the
+		// table cell isn't a string. Issue #78 finding L3.
+		if !lua_isstring(L, -1) {
+			lua_pop(L, 1)
+			return
+		}
 		text := lua_tostring_raw(L, -1)
 		lua_rawgeti(L, idx, 5)
 		opts := lua_gettop(L)
@@ -635,8 +669,9 @@ execute_canvas_command :: proc(L: ^Lua_State, idx: i32, tag: string, ox: f32, oy
 	case "image":
 		x := f32(lua_rawgeti_number(L, idx, 2)) + ox
 		y := f32(lua_rawgeti_number(L, idx, 3)) + oy
-		w := f32(lua_rawgeti_number(L, idx, 4))
-		h := f32(lua_rawgeti_number(L, idx, 5))
+		w, w_ok := sanitize_dim(f32(lua_rawgeti_number(L, idx, 4)))
+		h, h_ok := sanitize_dim(f32(lua_rawgeti_number(L, idx, 5)))
+		if !w_ok || !h_ok do return
 		rl.DrawRectangleLinesEx({x, y, w, h}, 1, rl.GRAY)
 		rl.DrawText("img", i32(x) + 2, i32(y) + 2, 12, rl.GRAY)
 	}

--- a/src/redin/bridge/canvas_sanitize_test.odin
+++ b/src/redin/bridge/canvas_sanitize_test.odin
@@ -1,0 +1,81 @@
+package bridge
+
+// Regression tests for issue #78 finding L3: the canvas command parser
+// trusted Lua-side values without bounds-checking. A buggy Fennel
+// canvas provider that returned `{255, 256, -1}` for an RGB triple
+// would silently truncate via `u8(...)` (256 wraps to 0, -1 to 255),
+// painting the wrong colour without surfacing the mistake. Negative or
+// NaN sizes propagated into Raylib draw calls and could crash the host.
+
+import "core:math"
+import "core:testing"
+
+@(test)
+test_clamp_byte_in_range :: proc(t: ^testing.T) {
+	testing.expect_value(t, clamp_byte(0),   u8(0))
+	testing.expect_value(t, clamp_byte(128), u8(128))
+	testing.expect_value(t, clamp_byte(255), u8(255))
+}
+
+@(test)
+test_clamp_byte_below_range :: proc(t: ^testing.T) {
+	// Pre-fix: u8(-1) silently wrapped to 255. After: clamps to 0.
+	testing.expect_value(t, clamp_byte(-1),    u8(0))
+	testing.expect_value(t, clamp_byte(-1000), u8(0))
+}
+
+@(test)
+test_clamp_byte_above_range :: proc(t: ^testing.T) {
+	// Pre-fix: u8(256) wrapped to 0. After: clamps to 255.
+	testing.expect_value(t, clamp_byte(256),  u8(255))
+	testing.expect_value(t, clamp_byte(1000), u8(255))
+}
+
+@(test)
+test_clamp_byte_handles_nan :: proc(t: ^testing.T) {
+	// NaN must not produce a garbage colour byte.
+	testing.expect_value(t, clamp_byte(math.nan_f64()), u8(0))
+}
+
+@(test)
+test_sanitize_dim_accepts_normal :: proc(t: ^testing.T) {
+	v, ok := sanitize_dim(0)
+	testing.expect(t, ok)
+	testing.expect_value(t, v, f32(0))
+
+	v2, ok2 := sanitize_dim(100)
+	testing.expect(t, ok2)
+	testing.expect_value(t, v2, f32(100))
+
+	// Up to the texture-side ceiling.
+	v3, ok3 := sanitize_dim(16384)
+	testing.expect(t, ok3)
+	testing.expect_value(t, v3, f32(16384))
+}
+
+@(test)
+test_sanitize_dim_rejects_negative :: proc(t: ^testing.T) {
+	_, ok := sanitize_dim(-1)
+	testing.expect(t, !ok, "negative dimension must be rejected")
+}
+
+@(test)
+test_sanitize_dim_rejects_nan :: proc(t: ^testing.T) {
+	_, ok := sanitize_dim(math.nan_f32())
+	testing.expect(t, !ok, "NaN dimension must be rejected")
+}
+
+@(test)
+test_sanitize_dim_rejects_infinity :: proc(t: ^testing.T) {
+	_, ok := sanitize_dim(math.inf_f32(1))
+	testing.expect(t, !ok, "+Inf dimension must be rejected")
+
+	_, ok2 := sanitize_dim(math.inf_f32(-1))
+	testing.expect(t, !ok2, "-Inf dimension must be rejected")
+}
+
+@(test)
+test_sanitize_dim_rejects_oversize :: proc(t: ^testing.T) {
+	_, ok := sanitize_dim(99999)
+	testing.expect(t, !ok, "dimension above the texture-side ceiling must be rejected")
+}


### PR DESCRIPTION
## Summary

The canvas command parser trusted Lua-side values from the Fennel provider. Three concrete failure modes:

1. **Colour components truncated** via `u8(...)`. \`{255, 256, -1}\` silently rendered as \`{255, 0, 255}\` — wrap-around junk, no diagnostic.
2. **Negative / NaN / Inf dimensions** on rect / circle / ellipse / image flowed into Raylib draw calls. The audit called out potential host crashes.
3. **Text command read the table cell via \`lua_tostring_raw\` without a type check.** Non-string cells produce a NULL cstring that \`DrawTextEx\` doesn't tolerate.

Threat model is self-inflicted: a buggy Fennel canvas provider crashing the host, not adversarial input. Still worth tightening — the canvas producer is the user's own code, but they shouldn't be paying for a typo in colour notation with a SIGSEGV.

Addresses finding **L3** from #78.

## Fix

- \`clamp_byte(f64) -> u8\` clamps colours to \`[0, 255]\`, NaN → 0. Used in \`read_color_field\` for r/g/b/a.
- \`sanitize_dim(f32) -> (f32, bool)\` rejects NaN / Inf / negative / >16384. Bad dims short-circuit rect / circle / ellipse / image with \`return\`, skipping the command and continuing to the next.
- \`text\` command early-returns if cell 4 isn't a string (after popping the cell off the stack).

Stack discipline preserved: in each early-return branch the canvas opts table hasn't been pushed yet, so no extra cleanup is needed. The text case pops its already-pushed cell before returning.

## Test plan

- [x] New unit tests in \`src/redin/bridge/canvas_sanitize_test.odin\` — 9 cases (clamp_byte: in-range, below, above, NaN; sanitize_dim: normal, negative, NaN, +Inf/-Inf, oversize). RED before helpers were declared, GREEN after.
- [x] \`odin test src/redin/bridge ...\` — 24/24 pass
- [x] \`odin build src/cmd/redin ...\` — exit 0
- [x] \`luajit test/lua/runner.lua test/lua/test_*.fnl\` — 122/122 pass
- [x] \`bash test/ui/run-all.sh --headless\` — all suites pass (test_canvas exercises rect / circle / ellipse / line / text / polygon happy paths and continues to render correctly with the sanitized helpers)
- [x] \`--track-mem\` smoke run on \`canvas_app.fnl\` with graceful shutdown — no leak / outstanding reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)