### PR TITLE
feat(input): Esc cancels in-flight drag

### DIFF
--- a/src/redin/input/drag.odin
+++ b/src/redin/input/drag.odin
@@ -34,6 +34,15 @@ free_animate :: proc(m: Maybe(types.Animate_Decoration)) {
 	if dec, ok := m.?; ok && len(dec.provider) > 0 do delete(dec.provider)
 }
 
+// Release every heap-owned field of a Drag_Captured. Safe to call once per
+// transition out of Pending or Active back to Idle.
+free_captured :: proc(c: Drag_Captured) {
+	free_string_slice(c.src_tags)
+	if len(c.src_event) > 0 do delete(c.src_event)
+	if len(c.src_aspect) > 0 do delete(c.src_aspect)
+	free_animate(c.src_animate)
+}
+
 // ---- v2 state machine ----
 
 Drag_Captured :: struct {
@@ -121,6 +130,38 @@ process_drag :: proc(
 	dispatch: [dynamic]types.Dispatch_Event
 	mouse := rl.GetMousePosition()
 
+	// Escape cancels any in-flight drag (Pending or Active). When cancelling
+	// from Active with an entered :drag-over zone, fire a final :phase :leave
+	// so the app can tear down zone-level state. No drop event fires.
+	esc_pressed := false
+	for event in input_events {
+		if ke, is_key := event.(types.KeyEvent); is_key && ke.key == .ESCAPE {
+			esc_pressed = true
+			break
+		}
+	}
+	if esc_pressed {
+		switch &s in drag {
+		case Drag_Idle:
+			// Nothing to cancel.
+		case Drag_Pending:
+			free_captured(s.captured)
+			drag = Drag_Idle{}
+		case Drag_Active:
+			if s.over_zone_idx >= 0 && s.over_zone_idx < len(nodes) {
+				if ev := node_over_event(nodes[s.over_zone_idx]); len(ev) > 0 {
+					append(&dispatch, types.Dispatch_Event(types.Drag_Over_Event{
+						event_name = ev,
+						phase      = .Leave,
+					}))
+				}
+			}
+			free_captured(s.captured)
+			drag = Drag_Idle{}
+		}
+		return dispatch
+	}
+
 	switch &s in drag {
 	case Drag_Idle:
 		// Mouse-down on a DragListener → Pending.
@@ -197,10 +238,7 @@ process_drag :: proc(
 				}
 			}
 		} else {
-			free_string_slice(s.src_tags)
-			if len(s.src_event) > 0 do delete(s.src_event)
-			if len(s.src_aspect) > 0 do delete(s.src_aspect)
-			free_animate(s.src_animate)
+			free_captured(s.captured)
 			drag = Drag_Idle{}
 		}
 
@@ -208,10 +246,7 @@ process_drag :: proc(
 		// Re-flatten safety: if the source idx no longer points at a draggable
 		// with our tags, cancel.
 		if s.src_idx < 0 || s.src_idx >= len(nodes) {
-			free_string_slice(s.src_tags)
-			if len(s.src_event) > 0 do delete(s.src_event)
-			if len(s.src_aspect) > 0 do delete(s.src_aspect)
-			free_animate(s.src_animate)
+			free_captured(s.captured)
 			drag = Drag_Idle{}
 			return dispatch
 		}
@@ -284,10 +319,7 @@ process_drag :: proc(
 				}
 			}
 
-			free_string_slice(s.src_tags)
-			if len(s.src_event) > 0 do delete(s.src_event)
-			if len(s.src_aspect) > 0 do delete(s.src_aspect)
-			free_animate(s.src_animate)
+			free_captured(s.captured)
 			drag = Drag_Idle{}
 		}
 	}

--- a/src/redin/runtime.odin
+++ b/src/redin/runtime.odin
@@ -143,6 +143,10 @@ run :: proc(cfg: Config) {
 	rl.InitWindow(g_window_config.width, g_window_config.height, g_window_config.title)
 	defer rl.CloseWindow()
 	rl.SetTargetFPS(120)
+	// Disable Raylib's default Escape-closes-window behavior. Apps own the
+	// Escape key (drag-cancel, modal-dismiss, etc.); the window closes via
+	// the close button or `redin.request_shutdown()`.
+	rl.SetExitKey(.KEY_NULL)
 
 	font.init()
 	defer font.destroy()


### PR DESCRIPTION
## Summary

Pressing Escape while a drag is `Drag_Pending` or `Drag_Active` resets the state machine to `Drag_Idle{}`. When cancelling from Active with a `:drag-over` zone entered, fires a final `:phase :leave` so apps can tear down zone-level state. No drop event fires — matches the release-over-nothing semantics.

Also factors the heap cleanup at the three Idle-transition sites into a single `free_captured` helper (was previously four lines repeated three times).

Stacked on `spec/draggable-v2`. Closes the Esc-cancel item from #90.

## Test plan

- [x] Build clean: `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin`
- [x] Drag suite: `bb test/ui/run.bb test/ui/test_drag.bb` (10/10 pass under `--track-mem`, no leak warnings)
- [x] Manual: launch kitchen-sink, press-and-hold a row, press Esc — drag should cancel, no drop fires, source row drops back into list
- [x] Manual: with `:drag-over` zone entered, press Esc — `:event/over` should fire once with `{:phase :leave}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)