### PR TITLE
feat(devserver): drag-and-drop test API

### DIFF
--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -584,6 +584,8 @@ process_request :: proc(ds: ^Dev_Server, req: ^Pending_Request) {
 			handle_screenshot(ch)
 		} else if req.path == "/window" {
 			handle_get_window(ch)
+		} else if req.path == "/drag-state" {
+			handle_get_drag_state(ch)
 		} else {
 			respond_text(ch, 404, "Not found")
 		}
@@ -603,6 +605,14 @@ process_request :: proc(ds: ^Dev_Server, req: ^Pending_Request) {
 		} else if req.path == "/restore" {
 			rl.RestoreWindow()
 			respond_json_ok(ch)
+		} else if req.path == "/input/mouse-down" {
+			handle_post_mouse_down(ds, ch, req.body)
+		} else if req.path == "/input/mouse-move" {
+			handle_post_mouse_move(ds, ch, req.body)
+		} else if req.path == "/input/mouse-up" {
+			handle_post_mouse_up(ds, ch, req.body)
+		} else if req.path == "/input/key" {
+			handle_post_key(ds, ch, req.body)
 		} else {
 			respond_text(ch, 404, "Not found")
 		}
@@ -1079,6 +1089,232 @@ handle_put_aspects :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string)
 	} else {
 		lua_pop(L, 1)
 	}
+	respond_json_ok(ch)
+}
+
+// --- Drag state GET ---
+
+handle_get_drag_state :: proc(ch: ^Response_Channel) {
+	b := strings.builder_make()
+	defer strings.builder_destroy(&b)
+
+	switch s in input.drag {
+	case input.Drag_Idle:
+		strings.write_string(&b, `{"state":"idle"}`)
+
+	case input.Drag_Pending:
+		// Build src_tags JSON array.
+		tags_str := drag_tags_to_json(s.src_tags)
+		defer delete(tags_str)
+		src_mode_str := drag_mode_string(s.src_mode)
+		src_event_json := fmt.tprintf("%q", s.src_event)
+		fmt.sbprintf(&b,
+			`{{"state":"pending","src_idx":%d,"over_drop_idx":null,"over_zone_idx":null,"src_tags":%s,"src_event":%s,"src_mode":"%s"}}`,
+			s.src_idx, tags_str, src_event_json, src_mode_str,
+		)
+
+	case input.Drag_Active:
+		tags_str := drag_tags_to_json(s.src_tags)
+		defer delete(tags_str)
+		src_mode_str := drag_mode_string(s.src_mode)
+		src_event_json := fmt.tprintf("%q", s.src_event)
+		over_drop: string
+		over_zone: string
+		if s.over_drop_idx < 0 {
+			over_drop = "null"
+		} else {
+			over_drop = fmt.tprintf("%d", s.over_drop_idx)
+		}
+		if s.over_zone_idx < 0 {
+			over_zone = "null"
+		} else {
+			over_zone = fmt.tprintf("%d", s.over_zone_idx)
+		}
+		fmt.sbprintf(&b,
+			`{{"state":"active","src_idx":%d,"over_drop_idx":%s,"over_zone_idx":%s,"src_tags":%s,"src_event":%s,"src_mode":"%s"}}`,
+			s.src_idx, over_drop, over_zone, tags_str, src_event_json, src_mode_str,
+		)
+
+	case:
+		// Nil union state (should not happen in practice).
+		strings.write_string(&b, `{"state":"idle"}`)
+	}
+
+	respond_json(ch, strings.to_string(b))
+}
+
+@(private)
+drag_tags_to_json :: proc(tags: []string) -> string {
+	if tags == nil || len(tags) == 0 do return "null"
+	b := strings.builder_make()
+	strings.write_byte(&b, '[')
+	for tag, i in tags {
+		if i > 0 do strings.write_byte(&b, ',')
+		fmt.sbprintf(&b, "%q", tag)
+	}
+	strings.write_byte(&b, ']')
+	return strings.to_string(b)
+}
+
+@(private)
+drag_mode_string :: proc(mode: types.Drag_Mode) -> string {
+	switch mode {
+	case .Preview: return "preview"
+	case .None:    return "none"
+	}
+	return "none"
+}
+
+// --- Input override helpers ---
+
+// Parse {x, y} from JSON body. Returns ok=false and responds with 400 if
+// the body is invalid or coordinates are out of range.
+@(private)
+parse_xy_body :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) -> (x, y: f32, ok: bool) {
+	L := ds.bridge.L
+	pos := 0
+	if !json_decode_value(L, body, &pos) {
+		respond_json_error(ch, 400, `{"error":"invalid JSON"}`)
+		return 0, 0, false
+	}
+	defer lua_pop(L, 1)
+	if !lua_istable(L, -1) {
+		respond_json_error(ch, 400, `{"error":"body must be an object"}`)
+		return 0, 0, false
+	}
+	lua_getfield(L, -1, "x")
+	x = f32(lua_tonumber(L, -1))
+	lua_pop(L, 1)
+	lua_getfield(L, -1, "y")
+	y = f32(lua_tonumber(L, -1))
+	lua_pop(L, 1)
+
+	sw := f32(rl.GetScreenWidth())
+	sh := f32(rl.GetScreenHeight())
+	if math.is_nan(x) || math.is_nan(y) || math.is_inf(x) || math.is_inf(y) ||
+	   x < 0 || y < 0 || x > sw || y > sh {
+		respond_json_error(ch, 400, `{"error":"x,y out of range"}`)
+		return 0, 0, false
+	}
+	return x, y, true
+}
+
+// --- POST /input/mouse-down ---
+
+handle_post_mouse_down :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	x, y, ok := parse_xy_body(ds, ch, body)
+	if !ok do return
+	input.fake_mouse_pos = rl.Vector2{x, y}
+	input.fake_lmb_down  = true
+	append(&ds.event_queue, types.InputEvent(types.MouseEvent{x = x, y = y, button = .LEFT}))
+	respond_json_ok(ch)
+}
+
+// --- POST /input/mouse-move ---
+
+handle_post_mouse_move :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	x, y, ok := parse_xy_body(ds, ch, body)
+	if !ok do return
+	input.fake_mouse_pos = rl.Vector2{x, y}
+	// fake_lmb_down is unchanged — move-while-held is detected via threshold
+	respond_json_ok(ch)
+}
+
+// --- POST /input/mouse-up ---
+
+handle_post_mouse_up :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	// x,y are optional. Parse them only if present and non-empty.
+	if len(strings.trim_space(body)) > 2 {
+		// Body is non-trivial; try to parse x,y. We use the same Lua decoder
+		// but only update fake_mouse_pos when x,y are valid numbers.
+		L := ds.bridge.L
+		pos := 0
+		if !json_decode_value(L, body, &pos) {
+			respond_json_error(ch, 400, `{"error":"invalid JSON"}`)
+			return
+		}
+		defer lua_pop(L, 1)
+		if lua_istable(L, -1) {
+			lua_getfield(L, -1, "x")
+			xv := f32(lua_tonumber(L, -1))
+			lua_pop(L, 1)
+			lua_getfield(L, -1, "y")
+			yv := f32(lua_tonumber(L, -1))
+			lua_pop(L, 1)
+			sw := f32(rl.GetScreenWidth())
+			sh := f32(rl.GetScreenHeight())
+			if !math.is_nan(xv) && !math.is_nan(yv) &&
+			   !math.is_inf(xv) && !math.is_inf(yv) &&
+			   xv >= 0 && yv >= 0 && xv <= sw && yv <= sh {
+				input.fake_mouse_pos = rl.Vector2{xv, yv}
+			}
+		}
+	}
+	input.fake_lmb_down = false
+	respond_json_ok(ch)
+}
+
+// --- POST /input/key ---
+
+handle_post_key :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	L := ds.bridge.L
+	pos := 0
+	if !json_decode_value(L, body, &pos) {
+		respond_json_error(ch, 400, `{"error":"invalid JSON"}`)
+		return
+	}
+	defer lua_pop(L, 1)
+	if !lua_istable(L, -1) {
+		respond_json_error(ch, 400, `{"error":"body must be an object"}`)
+		return
+	}
+
+	// Read key name
+	lua_getfield(L, -1, "key")
+	key_cstr := lua_tostring_raw(L, -1)
+	key_str := string(key_cstr)
+	lua_pop(L, 1)
+
+	// Use the shared string_to_key from bridge.odin (returns .KEY_NULL for unknowns).
+	rl_key := string_to_key(strings.to_lower(key_str, context.temp_allocator))
+	if rl_key == .KEY_NULL {
+		respond_json_error(ch, 400, `{"error":"unknown key name"}`)
+		return
+	}
+
+	// Optional mods object
+	mods: types.KeyMods
+	lua_getfield(L, -1, "mods")
+	if lua_istable(L, -1) {
+		lua_getfield(L, -1, "shift")
+		mods.shift = lua_toboolean(L, -1) != 0
+		lua_pop(L, 1)
+		lua_getfield(L, -1, "ctrl")
+		mods.ctrl = lua_toboolean(L, -1) != 0
+		lua_pop(L, 1)
+		lua_getfield(L, -1, "alt")
+		mods.alt = lua_toboolean(L, -1) != 0
+		lua_pop(L, 1)
+		lua_getfield(L, -1, "super")
+		mods.super = lua_toboolean(L, -1) != 0
+		lua_pop(L, 1)
+	}
+	lua_pop(L, 1)
+
+	// Use fake mouse pos if set, else 0,0
+	mx: f32 = 0
+	my: f32 = 0
+	if pos_v, pos_ok := input.fake_mouse_pos.?; pos_ok {
+		mx = pos_v.x
+		my = pos_v.y
+	}
+
+	append(&ds.event_queue, types.InputEvent(types.KeyEvent{
+		x   = mx,
+		y   = my,
+		key = rl_key,
+		mods = mods,
+	}))
 	respond_json_ok(ch)
 }
 

--- a/src/redin/input/drag.odin
+++ b/src/redin/input/drag.odin
@@ -128,7 +128,8 @@ process_drag :: proc(
 	node_rects: []rl.Rectangle,
 ) -> [dynamic]types.Dispatch_Event {
 	dispatch: [dynamic]types.Dispatch_Event
-	mouse := rl.GetMousePosition()
+	mouse := mouse_position()
+
 
 	// Escape cancels any in-flight drag (Pending or Active). When cancelling
 	// from Active with an entered :drag-over zone, fire a final :phase :leave
@@ -142,7 +143,7 @@ process_drag :: proc(
 	}
 	if esc_pressed {
 		switch &s in drag {
-		case Drag_Idle:
+		case Drag_Idle, nil:
 			// Nothing to cancel.
 		case Drag_Pending:
 			free_captured(s.captured)
@@ -163,7 +164,10 @@ process_drag :: proc(
 	}
 
 	switch &s in drag {
-	case Drag_Idle:
+	case Drag_Idle, nil:
+		// nil case: Drag_Idle is a zero-sized struct; Odin's union
+		// discriminant is 0 for nil/zero-value, same as for an unset union.
+		// Treat nil as Idle so the initial state correctly handles mouse-down.
 		// Mouse-down on a DragListener → Pending.
 		for event in input_events {
 			me, is_mouse := event.(types.MouseEvent)
@@ -221,7 +225,7 @@ process_drag :: proc(
 		}
 
 	case Drag_Pending:
-		if rl.IsMouseButtonDown(.LEFT) {
+		if lmb_down() {
 			dx := mouse.x - s.start_pos.x
 			dy := mouse.y - s.start_pos.y
 			if dx*dx + dy*dy >= DRAG_THRESHOLD * DRAG_THRESHOLD {
@@ -280,7 +284,7 @@ process_drag :: proc(
 		}
 		s.over_drop_idx = new_drop
 
-		if !rl.IsMouseButtonDown(.LEFT) {
+		if !lmb_down() {
 			// Drop dispatch.
 			if new_drop >= 0 {
 				drop_event := ""
@@ -344,7 +348,7 @@ node_over_event :: proc(n: types.Node) -> string {
 is_dragging :: proc() -> bool {
 	switch _ in drag {
 	case Drag_Pending, Drag_Active: return true
-	case Drag_Idle:                 return false
+	case Drag_Idle, nil:            return false
 	}
 	return false
 }

--- a/src/redin/input/input.odin
+++ b/src/redin/input/input.odin
@@ -9,6 +9,23 @@ import rl "vendor:raylib"
 // Currently focused node index, -1 means none.
 focused_idx: int = -1
 
+// Test-mode overrides for raylib mouse state. When unset (nil), the
+// accessors fall through to real raylib state. Set by the dev server
+// via /input/* endpoints. Persists across frames until the test changes
+// or clears it.
+fake_mouse_pos: Maybe(rl.Vector2)
+fake_lmb_down:  Maybe(bool)
+
+mouse_position :: proc() -> rl.Vector2 {
+	if pos, ok := fake_mouse_pos.?; ok do return pos
+	return rl.GetMousePosition()
+}
+
+lmb_down :: proc() -> bool {
+	if d, ok := fake_lmb_down.?; ok do return d
+	return rl.IsMouseButtonDown(.LEFT)
+}
+
 // Deepest event-listener-bearing node under `pt`, or -1 if none.
 // "Deepest" = highest node_idx among listener matches; nodes[] is
 // DFS-ordered, so a descendant always has a higher idx than its

--- a/src/redin/runtime.odin
+++ b/src/redin/runtime.odin
@@ -212,6 +212,14 @@ run :: proc(cfg: Config) {
 		bridge.poll_timers(&b)
 		profile.end(s_br1)
 
+		// Re-extract listeners if render_tick pushed a new frame (which calls
+		// clear_frame, invalidating the node strings that listeners reference).
+		// This must happen after render_tick and before any hit-testing.
+		if b.frame_changed {
+			delete(listeners)
+			listeners = input.extract_listeners(b.paths, b.nodes, b.theme)
+		}
+
 		// --- Input (2/4): listener / focus / drag computation ---
 		s_input2a := profile.begin(.Input)
 		user_events := input.get_user_events(input_events, listeners, node_rects[:])

--- a/test/ui/drag_input_app.fnl
+++ b/test/ui/drag_input_app.fnl
@@ -1,0 +1,91 @@
+;; Test app for drag-and-drop UI tests (v2 API)
+(local dataflow (require :dataflow))
+(local theme-mod (require :theme))
+
+(theme-mod.set-theme
+  {:surface       {:bg [46 52 64] :padding [24 24 24 24]}
+   :body          {:font-size 14 :color [216 222 233]}
+   :row           {:padding [4 4 4 4]}
+   :row-dragging  {:bg [136 46 106] :padding [4 4 4 4] :radius 4}
+   :row-drop-hot  {:bg [76 86 106] :padding [4 4 4 4]}
+   :muted         {:font-size 13 :color [76 86 106]}
+   :muted-armed   {:font-size 13 :color [76 86 106] :bg [54 60 72]}})
+
+(dataflow.init
+  {:items [{:text "A" :kind :sword}
+           {:text "B" :kind :shield}
+           {:text "C" :kind :sword}
+           {:text "D" :kind :shield}]
+   :last-drag nil
+   :last-drop nil
+   :last-over nil})
+
+(global redin_get_state (. dataflow :_get-raw-db))
+
+(reg-handler :event/drag
+  (fn [db event]
+    (let [ctx (. event 2)]
+      (assoc db :last-drag ctx.value))))
+
+(reg-handler :event/over
+  (fn [db event]
+    (let [ctx (. event 2)]
+      (assoc db :last-over ctx.phase))))
+
+(reg-handler :event/drop
+  (fn [db event]
+    (let [ctx (. event 2)
+          from-idx ctx.from
+          to-idx   ctx.to
+          items    (get db :items [])]
+      (assoc db :last-drop {:from from-idx :to to-idx})
+      (when (and from-idx to-idx
+                 (> from-idx 0) (<= from-idx (length items))
+                 (> to-idx 0)   (<= to-idx (length items))
+                 (not= from-idx to-idx))
+        (let [item (. items from-idx)
+              new-items (icollect [i v (ipairs items)]
+                          (when (not= i from-idx) v))]
+          (let [insert-at (if (> from-idx to-idx) to-idx (- to-idx 1))]
+            (table.insert new-items (math.min insert-at (+ (length new-items) 1)) item)
+            (assoc db :items new-items))))
+      db)))
+
+(reg-handler :event/reset
+  (fn [db event]
+    (-> db
+        (assoc :items [{:text "A" :kind :sword}
+                       {:text "B" :kind :shield}
+                       {:text "C" :kind :sword}
+                       {:text "D" :kind :shield}])
+        (assoc :last-drag nil)
+        (assoc :last-drop nil)
+        (assoc :last-over nil))))
+
+(reg-sub :items     (fn [db] (get db :items [])))
+(reg-sub :last-drag (fn [db] (get db :last-drag)))
+(reg-sub :last-drop (fn [db] (get db :last-drop)))
+(reg-sub :last-over (fn [db] (get db :last-over)))
+
+(global main_view
+  (fn []
+    (let [items (subscribe :items)]
+      [:vbox {:aspect :surface}
+       [:text {:id :title :aspect :body} "Drag Test v2"]
+       [:vbox {:id :item-list
+               :aspect :muted
+               :drag-over [:item {:event :event/over :aspect :muted-armed}]}
+        (icollect [i item (ipairs (or items []))]
+          [:hbox {:id (.. :row- (tostring i))
+                  :aspect :row
+                  :height 42
+                  :draggable [[:item item.kind]
+                              {:mode :preview
+                               :event :event/drag
+                               :aspect :row-dragging}
+                              i]
+                  :dropable [[:item item.kind]
+                             {:event :event/drop
+                              :aspect :row-drop-hot}
+                             i]}
+           [:text {:id (.. :item- (tostring i)) :aspect :body :selectable false} item.text]])]])))

--- a/test/ui/redin_test.bb
+++ b/test/ui/redin_test.bb
@@ -95,6 +95,34 @@
   [x y]
   (post-json "/click" {:x x :y y}))
 
+(defn mouse-down
+  "Press the left mouse button at (x, y) via POST /input/mouse-down."
+  [x y]
+  (post-json "/input/mouse-down" {:x x :y y}))
+
+(defn mouse-move
+  "Move the mouse to (x, y) without releasing via POST /input/mouse-move."
+  [x y]
+  (post-json "/input/mouse-move" {:x x :y y}))
+
+(defn mouse-up
+  "Release the left mouse button via POST /input/mouse-up.
+   Optional (x, y) to also update position."
+  ([] (post-json "/input/mouse-up" {}))
+  ([x y] (post-json "/input/mouse-up" {:x x :y y})))
+
+(defn key-press
+  "Queue a key press event via POST /input/key.
+   keyname is a string like \"escape\", \"enter\", \"a\", \"f1\", etc.
+   Optional mods map: {:shift bool :ctrl bool :alt bool :super bool}."
+  ([keyname] (post-json "/input/key" {:key keyname}))
+  ([keyname mods] (post-json "/input/key" {:key keyname :mods mods})))
+
+(defn drag-state
+  "Fetch current drag state via GET /drag-state."
+  []
+  (get-json "/drag-state"))
+
 (defn set-theme
   "Replace the theme via PUT /aspects."
   [theme]

--- a/test/ui/test_drag_input.bb
+++ b/test/ui/test_drag_input.bb
@@ -1,0 +1,174 @@
+(require '[redin-test :refer :all])
+
+;; ---------------------------------------------------------------------------
+;; Helpers to find row positions from the frame tree
+;; ---------------------------------------------------------------------------
+
+(defn- find-rows
+  "Return all :hbox nodes with :row aspect from the current frame."
+  []
+  (find-elements {:tag :hbox :aspect :row}))
+
+(defn- row-center-x [row]
+  (let [attrs (when (and (vector? row) (> (count row) 1)) (second row))]
+    (or (:cx attrs) 300)))
+
+(defn- row-center-y [row]
+  (let [attrs (when (and (vector? row) (> (count row) 1)) (second row))]
+    (or (:cy attrs) 100)))
+
+;; Approximate positions from the drag_app.fnl layout:
+;;   surface padding 24, title ~20px, rows height 42, row padding 4
+;;   row 1 top ≈ y=68, center ≈ y=89
+;;   The window is 800×600 by default; x center ≈ 400, but rows fill the vbox
+;;   We use a fixed x=300 (within any normal window width) for reliability.
+
+(def ROW-X 300)
+(def ROW1-Y 89)
+(def ROW2-Y 131)
+(def ROW3-Y 173)
+(def ROW4-Y 215)
+;; A move of 10px clearly crosses the 4px threshold from row1 start.
+(def MOVE-Y (+ ROW1-Y 10))
+
+;; ---------------------------------------------------------------------------
+;; Test: idle state before any input
+;; ---------------------------------------------------------------------------
+
+(deftest drag-state-idle-initially
+  (dispatch ["event/reset"])
+  (wait-ms 100)
+  (let [ds (drag-state)]
+    (assert (= "idle" (:state ds))
+            (str "Expected idle drag state, got: " (pr-str ds)))))
+
+;; ---------------------------------------------------------------------------
+;; Test: mouse-down transitions to pending
+;; ---------------------------------------------------------------------------
+
+(deftest mouse-down-enters-pending
+  (dispatch ["event/reset"])
+  (wait-ms 100)
+  (mouse-down ROW-X ROW1-Y)
+  (wait-ms 100)
+  (let [ds (drag-state)]
+    (assert (= "pending" (:state ds))
+            (str "Expected pending after mouse-down, got: " (pr-str ds)))
+    (assert (some? (:src_idx ds))
+            "Expected src_idx to be set in pending state"))
+  ;; Clean up
+  (mouse-up)
+  (wait-ms 100))
+
+;; ---------------------------------------------------------------------------
+;; Test: mouse-up from pending returns to idle
+;; ---------------------------------------------------------------------------
+
+(deftest mouse-up-from-pending-returns-idle
+  (dispatch ["event/reset"])
+  (wait-ms 100)
+  (mouse-down ROW-X ROW1-Y)
+  (wait-ms 100)
+  (let [ds (drag-state)]
+    (assert (= "pending" (:state ds))
+            (str "Expected pending, got: " (pr-str ds))))
+  (mouse-up)
+  (wait-ms 100)
+  (let [ds (drag-state)]
+    (assert (= "idle" (:state ds))
+            (str "Expected idle after mouse-up, got: " (pr-str ds)))))
+
+;; ---------------------------------------------------------------------------
+;; Test: full drag flow — pending → active → drop → idle + state updated
+;; ---------------------------------------------------------------------------
+
+(deftest full-drag-flow
+  (dispatch ["event/reset"])
+  (wait-ms 150)
+  ;; 1. Mouse down on row 1
+  (mouse-down ROW-X ROW1-Y)
+  (wait-ms 100)
+  (let [ds (drag-state)]
+    (assert (= "pending" (:state ds))
+            (str "Step 1: expected pending, got: " (pr-str ds))))
+  ;; 2. Move past the 4px threshold to activate the drag
+  (mouse-move ROW-X MOVE-Y)
+  (wait-ms 100)
+  (let [ds (drag-state)]
+    (assert (= "active" (:state ds))
+            (str "Step 2: expected active after threshold move, got: " (pr-str ds))))
+  ;; 3. Move over row 3 (target drop zone)
+  (mouse-move ROW-X ROW3-Y)
+  (wait-ms 100)
+  ;; 4. Release over row 3
+  (mouse-up ROW-X ROW3-Y)
+  (wait-ms 200)
+  ;; 5. State should return to idle
+  (let [ds (drag-state)]
+    (assert (= "idle" (:state ds))
+            (str "Step 4: expected idle after drop, got: " (pr-str ds))))
+  ;; 6. last-drop should reflect the drop (from=1, to varies based on hit-test)
+  ;;    We just verify the drop handler was called (last-drop is not nil).
+  (assert-state "last-drop" some?
+                "Expected last-drop to be set after a real drop"))
+
+;; ---------------------------------------------------------------------------
+;; Test: Escape cancels in-flight drag
+;; ---------------------------------------------------------------------------
+
+(deftest esc-cancels-pending-drag
+  (dispatch ["event/reset"])
+  (wait-ms 100)
+  (mouse-down ROW-X ROW1-Y)
+  (wait-ms 100)
+  (let [ds (drag-state)]
+    (assert (= "pending" (:state ds))
+            (str "Expected pending before Esc, got: " (pr-str ds))))
+  (key-press "escape")
+  (wait-ms 100)
+  (let [ds (drag-state)]
+    (assert (= "idle" (:state ds))
+            (str "Expected idle after Esc from pending, got: " (pr-str ds)))))
+
+(deftest esc-cancels-active-drag
+  (dispatch ["event/reset"])
+  (wait-ms 100)
+  ;; Enter active state
+  (mouse-down ROW-X ROW1-Y)
+  (wait-ms 100)
+  (mouse-move ROW-X MOVE-Y)
+  (wait-ms 100)
+  (let [ds (drag-state)]
+    (assert (= "active" (:state ds))
+            (str "Expected active before Esc, got: " (pr-str ds))))
+  ;; Press Escape
+  (key-press "escape")
+  (wait-ms 100)
+  (let [ds (drag-state)]
+    (assert (= "idle" (:state ds))
+            (str "Expected idle after Esc from active, got: " (pr-str ds))))
+  ;; last-drop should NOT have been set (cancel, not drop)
+  (assert-state "last-drop" nil?
+                "Expected last-drop nil after Esc cancel"))
+
+;; ---------------------------------------------------------------------------
+;; Test: /drag-state JSON shape for active state
+;; ---------------------------------------------------------------------------
+
+(deftest drag-state-active-has-expected-fields
+  (dispatch ["event/reset"])
+  (wait-ms 100)
+  (mouse-down ROW-X ROW1-Y)
+  (wait-ms 100)
+  (mouse-move ROW-X MOVE-Y)
+  (wait-ms 100)
+  (let [ds (drag-state)]
+    (assert (= "active" (:state ds))
+            (str "Expected active, got: " (pr-str ds)))
+    (assert (some? (:src_idx ds))   "src_idx should be present")
+    (assert (some? (:src_event ds)) "src_event should be present")
+    (assert (some? (:src_mode ds))  "src_mode should be present")
+    (assert (some? (:src_tags ds))  "src_tags should be present"))
+  ;; Clean up
+  (key-press "escape")
+  (wait-ms 100))


### PR DESCRIPTION
## Summary

- Adds `/input/mouse-down`, `/input/mouse-move`, `/input/mouse-up`, `/input/key` POST endpoints and `/drag-state` GET to the dev server. Tests can drive the drag state machine end-to-end without relying on real OS mouse state.
- `input/input.odin` gains `fake_mouse_pos` / `fake_lmb_down` package-level overrides; `process_drag` reads through `mouse_position()` / `lmb_down()` accessors that fall through to raylib when no override is set.
- Adds helpers `mouse-down`, `mouse-move`, `mouse-up`, `key-press`, `drag-state` to `test/ui/redin_test.bb`.
- New test app `test/ui/drag_input_app.fnl` + test `test/ui/test_drag_input.bb` with 7 cases covering full drag flow and Esc cancel.

## Bug fixes discovered

**1. `Drag_Idle` union nil-matching** — `Drag_Idle` is a zero-sized struct; Odin's union discriminant is 0 for both nil/unset union and `Drag_Idle{}`, so `case Drag_Idle:` never matched and the drag state machine couldn't transition from idle to pending via real mouse events. Fixed by using `case Drag_Idle, nil:` in all union switches in `drag.odin`.

**2. Stale listener references after `render_tick`** — Listeners were extracted at the top of the frame loop from `b.nodes` string data. `render_tick` may call `clear_frame` (freeing those strings) before `process_drag` runs its hit tests against the same listeners. Fixed by adding a second listener refresh after `render_tick` when `frame_changed` is set in `runtime.odin`.

## Test plan

- [x] New test: 7/7 pass (`test_drag_input`)
- [x] Existing drag tests: 10/10 pass (`test_drag`)  
- [x] Full UI suite: all suites pass
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)