### PR TITLE
chore(ci): upgrade GitHub Actions to current majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -87,7 +87,7 @@ jobs:
         run: bash scripts/smoke-native.sh "redin-${VERSION}-linux-amd64.tar.gz"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: redin-${{ steps.version.outputs.tag }}-linux-amd64
           path: redin-${{ steps.version.outputs.tag }}-linux-amd64.tar.gz
@@ -100,15 +100,15 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.version }}
           name: redin ${{ inputs.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 


### PR DESCRIPTION
Resolves the Node 20 deprecation warning surfaced during the v0.3.0 release run.

| Action                       | Was | Now |
|------------------------------|-----|-----|
| \`actions/checkout\`           | v4  | v6  |
| \`actions/upload-artifact\`    | v4  | v7  |
| \`actions/download-artifact\`  | v4  | v8  |
| \`softprops/action-gh-release\`| v2  | v3  |

Versions confirmed against \`releases/latest\` on each action's repo (\`v6.0.2\`, \`v7.0.1\`, \`v8.0.1\`, \`v3.0.0\`). Pinned to major to receive non-breaking updates within the major, matching the project's existing pin style.

The workflow only uses standard \`name:\` / \`path:\` / \`files:\` parameters that all four actions still accept in their current major — no migration of parameter names needed.

## Test plan

- [x] CI on this PR runs the test workflow with the new \`actions/checkout@v6\` — verifies test path
- [x] Next release (next \`gh workflow run release.yml -f version=...\`) verifies upload-artifact v7, download-artifact v8, gh-release v3 end-to-end. Can rollback if any break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)