### PR TITLE
feat(drag): explicit drag-handle attribute (closes #94)

### DIFF
--- a/.claude/skills/redin-dev/SKILL.md
+++ b/.claude/skills/redin-dev/SKILL.md
@@ -125,6 +125,22 @@ Tags = single keyword (`:item`) or vector (`[:item :sword]`); a draggable and a 
       ...])]
 ```
 
+### Drag handles
+
+When a draggable container has interactive children (text that should be selectable, buttons), the click winner is the deepest hit — usually the text — so dragging-by-row-body breaks. Use a drag handle:
+
+```fennel
+[:hbox {:draggable [:row-drag {:handle false :event :event/drag} payload]
+        :dropable  [:row-drag {:event :event/drop} payload]}
+ [:vbox {:width 24 :aspect :grip :drag-handle true}]   ;; grab surface
+ [:text {} item.text]                                  ;; selectable
+ [:button {:click :remove} "x"]]                       ;; clickable
+```
+
+`:handle false` on the draggable opts the container out; `:drag-handle true` on any descendant marks it as a grab surface for the nearest `:draggable` ancestor. `:handle true` (default) keeps the container as a grab surface and makes any handles additive.
+
+`:drag-handle` is allowed on `:vbox`, `:hbox`, and `:button`. On a button, it is mutually exclusive with `:click` (parser warns, drops `:click`).
+
 ## Canvas API (Fennel/Lua)
 
 ### Drawing from scripting (no binary changes needed)

--- a/docs/core-api.md
+++ b/docs/core-api.md
@@ -214,9 +214,11 @@ If the provider name isn't registered, `canvas.process` silently no-ops (same po
 
 Three universal attributes; all share `[tags {options} ?payload]`:
 
-- `:draggable [tags {options} payload]` — declares "what I am" + how the element behaves while dragged. Required: `:event`. Optional: `:mode` (`:preview` (default) | `:none`), `:aspect`, `:animate`.
+- `:draggable [tags {options} payload]` — declares "what I am" + how the element behaves while dragged. Required: `:event`. Optional: `:mode` (`:preview` (default) | `:none`), `:aspect`, `:animate`, `:handle` (bool, default `true` — set `false` to disable container-as-grab and require an explicit `:drag-handle` descendant).
 - `:dropable [tags {options} payload]` — declares "what I accept" + the hover aspect. Required: `:event`. Optional: `:aspect`, `:animate`.
 - `:drag-over [tags {options}]` — container-level zone. Optional: `:event` (fires `:phase :enter` / `:leave`), `:aspect`, `:animate`. No payload slot.
+
+A draggable container's whole rect is the grab surface by default. To dedicate the grab to a small sub-region (handy when the row contains selectable text or buttons that would otherwise win the click), set `:handle false` on the draggable and add a child node carrying `:drag-handle true`. The handle binds to the nearest `:draggable` ancestor (no tag repetition needed). `:drag-handle` is supported on `:vbox`, `:hbox`, and `:button`. On `:button`, it is mutually exclusive with `:click` — when both are set, the parser warns and drops `:click`.
 
 Tags are a single keyword (one tag) or a vector of keywords (multi-tag); a draggable and a dropable interact when their tag sets intersect.
 

--- a/docs/reference/elements.md
+++ b/docs/reference/elements.md
@@ -155,6 +155,7 @@ A clickable element with a text label. Dispatches an event on click.
 | --------- | ---- | ------- | ----- |
 | `click` | keyword | -- | Event dispatched on click. **Required.** |
 | `label` | string | -- | Button text. Can also be passed as a child string. |
+| `drag-handle` | bool | `false` | Marks this button as a grab surface for the nearest `:draggable` ancestor. Mutually exclusive with `click` — if both set, parser warns and drops `click`. |
 
 Visual properties come from `aspect`.
 
@@ -239,6 +240,7 @@ Lays out children in a horizontal row, left to right.
 | --------- | ---- | ------- | ----- |
 | `overflow` | `"scroll-x"` | -- | Clip + horizontal wheel scroll. Children must set `:width`. See Scrolling. |
 | `layout` | anchor keyword (see below) | `"top_left"` | Child alignment along both axes. |
+| `drag-handle` | bool | `false` | Marks this hbox as a grab surface for the nearest `:draggable` ancestor. |
 
 `:layout` takes one of nine two-axis anchors: `top_left`, `top_center`, `top_right`, `center_left`, `center`, `center_right`, `bottom_left`, `bottom_center`, `bottom_right`. For an hbox the horizontal component selects where the children *group* sits on the main axis; the vertical component selects how each child is aligned on the cross axis. For a vbox the roles swap. Unrecognized values log a warning and fall back to `top_left`.
 

--- a/docs/reference/elements.md
+++ b/docs/reference/elements.md
@@ -260,7 +260,7 @@ Lays out children in a vertical column, top to bottom.
 
 **Required attrs:** none
 
-**Optional attrs:** identical to `hbox`. `overflow` is `"scroll-y"` (see Scrolling).
+**Optional attrs:** identical to `hbox` (including `drag-handle`). `overflow` is `"scroll-y"` (see Scrolling).
 
 For a vbox, the horizontal component of `:layout` aligns each child across the row (cross axis), and the vertical component positions the children group within the container's height (main axis).
 

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -80,6 +80,7 @@
                       :muted-armed {:font-size 13
                                     :color [76 86 106]
                                     :bg [54 60 72]}
+                      :drag-handle {:bg [66 66 86]}
                       :input {:bg [59 66 82]
                               :color [236 239 244]
                               :border [76 86 106]
@@ -226,6 +227,7 @@
                               :height 42
                               :draggable [:row-drag
                                           {:mode :preview
+                                           :handle false
                                            :event :event/drag
                                            :aspect :row-dragging
                                            :animate {:provider :pulse-dot
@@ -236,6 +238,9 @@
                                          {:event :event/drop
                                           :aspect :row-drop-hot}
                                          i]}
+                             [:vbox {:width 24
+                                     :aspect :drag-handle
+                                     :drag-handle true}]
                              [:text {:aspect :body} item.text]
                              [:button
                               {:width 250

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -1227,6 +1227,18 @@ lua_read_node :: proc(L: ^Lua_State, tag: string, attrs_idx: i32, text_content: 
 			btn.click_ctx = lua_get_event_ctx(L, attrs_idx, "click")
 			btn.width = lua_get_size_f32(L, attrs_idx, "width")
 			btn.height = lua_get_size_f32(L, attrs_idx, "height")
+			if dh, exists := lua_get_bool_field_opt(L, attrs_idx, "drag-handle"); exists {
+				btn.drag_handle = dh
+			}
+			if btn.drag_handle && len(btn.click) > 0 {
+				fmt.eprintln(":button: :drag-handle conflicts with :click — dropping :click")
+				delete(btn.click)
+				btn.click = ""
+				if btn.click_ctx != 0 {
+					luaL_unref(L, LUA_REGISTRYINDEX, btn.click_ctx)
+					btn.click_ctx = 0
+				}
+			}
 		}
 		if len(text_content) > 0 do btn.label = text_content
 		return btn

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -118,6 +118,70 @@ check_hotreload :: proc(b: ^Bridge) {
 	}
 }
 
+// Walk the flat tree once: for each draggable with handle_off, ensure at
+// least one descendant carries drag_handle. Otherwise the draggable is
+// silently ungrabbable. Stops the descendant walk at nested-draggable
+// boundaries (handle binds to nearest draggable ancestor).
+//
+// Logged per-frame in line with the existing parse-warning convention
+// (no dedupe).
+validate_drag_handles :: proc(
+	nodes: []types.Node,
+	children_list: []types.Children,
+	paths: []types.Path,
+) {
+	for node, idx in nodes {
+		handle_off := false
+		switch n in node {
+		case types.NodeVbox:
+			if d, ok := n.draggable.?; ok do handle_off = d.handle_off
+		case types.NodeHbox:
+			if d, ok := n.draggable.?; ok do handle_off = d.handle_off
+		case types.NodeStack, types.NodeCanvas, types.NodeInput,
+		     types.NodeButton, types.NodeText, types.NodeImage,
+		     types.NodePopout, types.NodeModal:
+		}
+		if !handle_off do continue
+		if !subtree_has_drag_handle(idx, nodes, children_list) {
+			fmt.eprintfln(
+				":draggable at idx %d has :handle false but no descendant :drag-handle true — ungrabbable",
+				idx,
+			)
+		}
+	}
+}
+
+// True iff any descendant of `root` carries drag_handle == true.
+// Stops descent at nested-draggable boundaries.
+subtree_has_drag_handle :: proc(
+	root: int,
+	nodes: []types.Node,
+	children_list: []types.Children,
+) -> bool {
+	if root < 0 || root >= len(children_list) do return false
+	kids := children_list[root]
+	for i in 0 ..< int(kids.length) {
+		ci := int(kids.value[i])
+		if ci < 0 || ci >= len(nodes) do continue
+		nested := false
+		switch n in nodes[ci] {
+		case types.NodeVbox:
+			if _, ok := n.draggable.?; ok do nested = true
+			if n.drag_handle do return true
+		case types.NodeHbox:
+			if _, ok := n.draggable.?; ok do nested = true
+			if n.drag_handle do return true
+		case types.NodeButton:
+			if n.drag_handle do return true
+		case types.NodeStack, types.NodeCanvas, types.NodeInput,
+		     types.NodeText, types.NodeImage, types.NodePopout,
+		     types.NodeModal:
+		}
+		if !nested && subtree_has_drag_handle(ci, nodes, children_list) do return true
+	}
+	return false
+}
+
 clear_draggable_attrs :: proc(m: Maybe(types.Draggable_Attrs)) {
 	d, ok := m.?
 	if !ok do return

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -2018,6 +2018,15 @@ lua_read_draggable :: proc(L: ^Lua_State, attrs_idx: i32) -> Maybe(types.Draggab
 	}
 	lua_pop(L, 1)
 
+	// :handle (optional, default true). Only an explicit `false` disables
+	// container-as-grab-surface; descendants marked :drag-handle become the
+	// only grab targets. Validated later by validate_drag_handles.
+	lua_getfield(L, opts, "handle")
+	if lua_isboolean(L, -1) {
+		if lua_toboolean(L, -1) == 0 do out.handle_off = true
+	}
+	lua_pop(L, 1)
+
 	// :animate (optional, reuse parse_animate_attr against the options table)
 	if dec, ok := parse_animate_attr(L, opts); ok {
 		out.animate = dec

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -128,7 +128,6 @@ check_hotreload :: proc(b: ^Bridge) {
 validate_drag_handles :: proc(
 	nodes: []types.Node,
 	children_list: []types.Children,
-	paths: []types.Path,
 ) {
 	for node, idx in nodes {
 		handle_off := false
@@ -164,6 +163,10 @@ subtree_has_drag_handle :: proc(
 		ci := int(kids.value[i])
 		if ci < 0 || ci >= len(nodes) do continue
 		nested := false
+		// Edge case: a node that is BOTH a draggable container and carries
+		// drag_handle = true counts as a handle for *this* outer draggable
+		// (we report `return true` before checking `nested`). This is exotic;
+		// idiomatic apps don't combine the two on one node.
 		switch n in nodes[ci] {
 		case types.NodeVbox:
 			if _, ok := n.draggable.?; ok do nested = true

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -1179,6 +1179,9 @@ lua_read_node :: proc(L: ^Lua_State, tag: string, attrs_idx: i32, text_content: 
 			v.draggable = lua_read_draggable(L, attrs_idx)
 			v.dropable  = lua_read_dropable (L, attrs_idx)
 			v.drag_over = lua_read_drag_over(L, attrs_idx)
+			if dh, exists := lua_get_bool_field_opt(L, attrs_idx, "drag-handle"); exists {
+				v.drag_handle = dh
+			}
 		}
 		return v
 
@@ -1196,6 +1199,9 @@ lua_read_node :: proc(L: ^Lua_State, tag: string, attrs_idx: i32, text_content: 
 			h.draggable = lua_read_draggable(L, attrs_idx)
 			h.dropable  = lua_read_dropable (L, attrs_idx)
 			h.drag_over = lua_read_drag_over(L, attrs_idx)
+			if dh, exists := lua_get_bool_field_opt(L, attrs_idx, "drag-handle"); exists {
+				h.drag_handle = dh
+			}
 		}
 		return h
 

--- a/src/redin/bridge/lua_api.odin
+++ b/src/redin/bridge/lua_api.odin
@@ -106,6 +106,10 @@ lua_isnumber :: #force_inline proc "contextless" (L: ^Lua_State, index: i32) -> 
 	return lua_type(L, index) == LUA_TNUMBER
 }
 
+lua_isboolean :: #force_inline proc "contextless" (L: ^Lua_State, index: i32) -> bool {
+	return lua_type(L, index) == LUA_TBOOLEAN
+}
+
 // Lua 5.1 / LuaJIT: upvalue indices are encoded as offsets from
 // LUA_GLOBALSINDEX. Used by closure-based cfuncs to access values
 // captured at lua_pushcclosure time.

--- a/src/redin/input/drag.odin
+++ b/src/redin/input/drag.odin
@@ -173,27 +173,32 @@ process_drag :: proc(
 			winner := deepest_listener_idx(listeners, node_rects, pt)
 			if winner < 0 do continue
 
-			// Confirm the deepest listener winner is actually a DragListener.
+			// Confirm the deepest listener winner is actually a DragListener,
+			// and capture its source_idx (the draggable container — same as
+			// node_idx for container-grab listeners, the parent draggable for
+			// handle listeners).
 			has_drag := false
+			src_idx := -1
 			tags: []string
 			for listener in listeners {
 				dl, ok := listener.(types.DragListener)
 				if !ok do continue
 				if dl.node_idx == winner {
 					has_drag = true
+					src_idx = dl.source_idx
 					tags = dl.tags
 					break
 				}
 			}
 			if !has_drag do continue
 
-			// Read drag attrs from the source node (vbox / hbox only).
+			// Read drag attrs from the source node (the draggable container).
 			cap := Drag_Captured{
-				src_idx   = winner,
+				src_idx   = src_idx,
 				start_pos = pt,
 				src_tags  = clone_string_slice(tags),
 			}
-			switch n in nodes[winner] {
+			switch n in nodes[src_idx] {
 			case types.NodeVbox:
 				if d, ok := n.draggable.?; ok {
 					cap.src_event   = strings.clone(d.event)

--- a/src/redin/input/extract_listeners_test.odin
+++ b/src/redin/input/extract_listeners_test.odin
@@ -1,0 +1,256 @@
+package input
+
+import "core:testing"
+import "../types"
+
+// Helpers — build a tiny flat tree of N nodes in DFS order with a fixed
+// parent layout. Saves repetitive boilerplate in each test.
+
+@(private="file")
+mk_draggable :: proc(handle_off: bool) -> Maybe(types.Draggable_Attrs) {
+	tags := make([]string, 1)
+	tags[0] = "row"
+	return types.Draggable_Attrs{
+		tags = tags, event = "ev", handle_off = handle_off,
+	}
+}
+
+@(private="file")
+mk_children :: proc(values: ..i32) -> types.Children {
+	v := make([]i32, len(values))
+	for x, i in values do v[i] = x
+	return types.Children{value = v, length = i32(len(values))}
+}
+
+// Free inner allocations of nodes and children arrays.
+@(private="file")
+free_nodes :: proc(nodes: [dynamic]types.Node) {
+	for n in nodes {
+		if vb, ok := n.(types.NodeVbox); ok {
+			if d, dok := vb.draggable.?; dok {
+				delete(d.tags)
+			}
+		}
+		if hb, ok := n.(types.NodeHbox); ok {
+			if d, dok := hb.draggable.?; dok {
+				delete(d.tags)
+			}
+		}
+	}
+}
+
+@(private="file")
+free_children :: proc(children: [dynamic]types.Children) {
+	for c in children {
+		delete(c.value)
+	}
+}
+
+@(private="file")
+count_drag_listeners :: proc(ls: [dynamic]types.Listener) -> int {
+	n := 0
+	for l in ls do if _, ok := l.(types.DragListener); ok do n += 1
+	return n
+}
+
+@(private="file")
+drag_listener_with_node :: proc(ls: [dynamic]types.Listener, node_idx: int) -> (types.DragListener, bool) {
+	for l in ls {
+		if dl, ok := l.(types.DragListener); ok && dl.node_idx == node_idx do return dl, true
+	}
+	return {}, false
+}
+
+// Case 1: default :handle true, no handle children — single DragListener
+// at the container, source_idx == node_idx.
+@(test)
+test_extract_default_handle_emits_container_listener :: proc(t: ^testing.T) {
+	nodes: [dynamic]types.Node
+	defer free_nodes(nodes)
+	defer delete(nodes)
+	append(&nodes, types.Node(types.NodeVbox{
+		draggable = mk_draggable(false /* handle_off */),
+	}))
+
+	children: [dynamic]types.Children
+	defer free_children(children)
+	defer delete(children)
+	append(&children, mk_children())
+
+	paths: [dynamic]types.Path
+	defer delete(paths)
+	append(&paths, types.Path{})
+
+	theme: map[string]types.Theme
+	defer delete(theme)
+
+	ls := extract_listeners(paths, nodes, children, theme)
+	defer delete(ls)
+
+	testing.expect_value(t, count_drag_listeners(ls), 1)
+	dl, ok := drag_listener_with_node(ls, 0)
+	testing.expect(t, ok, "should have DragListener at idx 0")
+	testing.expect_value(t, dl.source_idx, 0)
+}
+
+// Case 2: :handle false with a child :drag-handle true — single DragListener
+// at the handle, source_idx points back to the container.
+@(test)
+test_extract_handle_off_emits_handle_listener_only :: proc(t: ^testing.T) {
+	nodes: [dynamic]types.Node
+	defer free_nodes(nodes)
+	defer delete(nodes)
+	// idx 0: draggable container with handle_off
+	append(&nodes, types.Node(types.NodeVbox{
+		draggable = mk_draggable(true),
+	}))
+	// idx 1: handle vbox
+	append(&nodes, types.Node(types.NodeVbox{drag_handle = true}))
+
+	children: [dynamic]types.Children
+	defer free_children(children)
+	defer delete(children)
+	append(&children, mk_children(1))   // 0 -> [1]
+	append(&children, mk_children())    // 1 leaf
+
+	paths: [dynamic]types.Path
+	defer delete(paths)
+	append(&paths, types.Path{})
+	append(&paths, types.Path{})
+
+	theme: map[string]types.Theme
+	defer delete(theme)
+
+	ls := extract_listeners(paths, nodes, children, theme)
+	defer delete(ls)
+
+	testing.expect_value(t, count_drag_listeners(ls), 1)
+	dl, ok := drag_listener_with_node(ls, 1)
+	testing.expect(t, ok, "should have DragListener at handle idx 1")
+	testing.expect_value(t, dl.source_idx, 0)
+}
+
+// Case 3: default :handle true with a handle child — TWO listeners,
+// container + handle, both with source_idx = container idx.
+@(test)
+test_extract_default_with_handle_emits_both :: proc(t: ^testing.T) {
+	nodes: [dynamic]types.Node
+	defer free_nodes(nodes)
+	defer delete(nodes)
+	append(&nodes, types.Node(types.NodeVbox{
+		draggable = mk_draggable(false),
+	}))
+	append(&nodes, types.Node(types.NodeVbox{drag_handle = true}))
+
+	children: [dynamic]types.Children
+	defer free_children(children)
+	defer delete(children)
+	append(&children, mk_children(1))
+	append(&children, mk_children())
+
+	paths: [dynamic]types.Path
+	defer delete(paths)
+	append(&paths, types.Path{})
+	append(&paths, types.Path{})
+
+	theme: map[string]types.Theme
+	defer delete(theme)
+
+	ls := extract_listeners(paths, nodes, children, theme)
+	defer delete(ls)
+
+	testing.expect_value(t, count_drag_listeners(ls), 2)
+	dl0, ok0 := drag_listener_with_node(ls, 0)
+	dl1, ok1 := drag_listener_with_node(ls, 1)
+	testing.expect(t, ok0, "container listener missing")
+	testing.expect(t, ok1, "handle listener missing")
+	testing.expect_value(t, dl0.source_idx, 0)
+	testing.expect_value(t, dl1.source_idx, 0)
+}
+
+// Case 4: multiple handles — one DragListener per handle, all sourcing
+// the same container.
+@(test)
+test_extract_multiple_handles_each_emit_listener :: proc(t: ^testing.T) {
+	nodes: [dynamic]types.Node
+	defer free_nodes(nodes)
+	defer delete(nodes)
+	append(&nodes, types.Node(types.NodeVbox{
+		draggable = mk_draggable(true),
+	}))
+	append(&nodes, types.Node(types.NodeVbox{drag_handle = true}))
+	append(&nodes, types.Node(types.NodeVbox{drag_handle = true}))
+
+	children: [dynamic]types.Children
+	defer free_children(children)
+	defer delete(children)
+	append(&children, mk_children(1, 2))
+	append(&children, mk_children())
+	append(&children, mk_children())
+
+	paths: [dynamic]types.Path
+	defer delete(paths)
+	for _ in 0 ..< 3 do append(&paths, types.Path{})
+
+	theme: map[string]types.Theme
+	defer delete(theme)
+
+	ls := extract_listeners(paths, nodes, children, theme)
+	defer delete(ls)
+
+	testing.expect_value(t, count_drag_listeners(ls), 2)
+	handle_indices := []int{1, 2}
+	for h in handle_indices {
+		dl, ok := drag_listener_with_node(ls, h)
+		testing.expect(t, ok, "handle listener missing")
+		testing.expect_value(t, dl.source_idx, 0)
+	}
+}
+
+// Case 5: nested draggables — handle inside an inner draggable belongs
+// to the inner one, not the outer.
+@(test)
+test_extract_nested_draggable_does_not_steal_handle :: proc(t: ^testing.T) {
+	nodes: [dynamic]types.Node
+	defer free_nodes(nodes)
+	defer delete(nodes)
+	// idx 0: outer draggable with handle_off
+	append(&nodes, types.Node(types.NodeVbox{
+		draggable = mk_draggable(true),
+	}))
+	// idx 1: inner draggable (default handle true, no handle_off)
+	append(&nodes, types.Node(types.NodeVbox{
+		draggable = mk_draggable(false),
+	}))
+	// idx 2: handle inside inner — belongs to inner, NOT outer
+	append(&nodes, types.Node(types.NodeVbox{drag_handle = true}))
+
+	children: [dynamic]types.Children
+	defer free_children(children)
+	defer delete(children)
+	append(&children, mk_children(1))
+	append(&children, mk_children(2))
+	append(&children, mk_children())
+
+	paths: [dynamic]types.Path
+	defer delete(paths)
+	for _ in 0 ..< 3 do append(&paths, types.Path{})
+
+	theme: map[string]types.Theme
+	defer delete(theme)
+
+	ls := extract_listeners(paths, nodes, children, theme)
+	defer delete(ls)
+
+	// Outer: handle_off + no handle in its non-nested subtree → 0 listeners
+	// Inner: default + a handle below → container listener (1) + handle (2)
+	dl1, ok1 := drag_listener_with_node(ls, 1)
+	dl2, ok2 := drag_listener_with_node(ls, 2)
+	testing.expect(t, ok1, "inner container listener missing")
+	testing.expect(t, ok2, "handle listener missing")
+	testing.expect_value(t, dl1.source_idx, 1) // inner is its own source
+	testing.expect_value(t, dl2.source_idx, 1) // handle sources inner, not outer
+	// Outer should have NO listener (handle_off + 0 reachable handles)
+	_, has_outer := drag_listener_with_node(ls, 0)
+	testing.expect(t, !has_outer, "outer container should not emit a listener")
+}

--- a/src/redin/input/input.odin
+++ b/src/redin/input/input.odin
@@ -70,7 +70,7 @@ extract_listeners :: proc(
 			aspect = n.aspect
 			if d, ok := n.draggable.?; ok && len(d.tags) > 0 && len(d.event) > 0 {
 				append(&listeners, types.Listener(types.DragListener{
-					node_idx = idx, tags = d.tags,
+					node_idx = idx, source_idx = idx, tags = d.tags,
 				}))
 			}
 			if d, ok := n.dropable.?; ok && len(d.tags) > 0 && len(d.event) > 0 {
@@ -87,7 +87,7 @@ extract_listeners :: proc(
 			aspect = n.aspect
 			if d, ok := n.draggable.?; ok && len(d.tags) > 0 && len(d.event) > 0 {
 				append(&listeners, types.Listener(types.DragListener{
-					node_idx = idx, tags = d.tags,
+					node_idx = idx, source_idx = idx, tags = d.tags,
 				}))
 			}
 			if d, ok := n.dropable.?; ok && len(d.tags) > 0 && len(d.event) > 0 {

--- a/src/redin/input/input.odin
+++ b/src/redin/input/input.odin
@@ -34,6 +34,9 @@ collect_drag_handles_recur :: proc(
 		ci := int(kids.value[i])
 		if ci < 0 || ci >= len(nodes) do continue
 		// Stop descending into nested draggables.
+		// Edge case: a node that is BOTH a draggable container and carries
+		// drag_handle = true is appended as a handle for *this* outer
+		// draggable. Idiomatic apps don't combine the two on one node.
 		nested := false
 		switch n in nodes[ci] {
 		case types.NodeVbox:

--- a/src/redin/input/input.odin
+++ b/src/redin/input/input.odin
@@ -6,6 +6,52 @@ import text_pkg "../text"
 import font "../font"
 import rl "vendor:raylib"
 
+// Collect descendant indices of `root` that carry drag_handle == true.
+// Stops at nested-draggable boundaries — a handle inside an inner
+// draggable belongs to that inner one (nearest-ancestor rule).
+// Allocates with context.temp_allocator; caller does not free.
+collect_drag_handles_in_subtree :: proc(
+	root: int,
+	nodes: [dynamic]types.Node,
+	children_list: [dynamic]types.Children,
+) -> [dynamic]int {
+	out: [dynamic]int
+	out.allocator = context.temp_allocator
+	collect_drag_handles_recur(root, nodes, children_list, &out)
+	return out
+}
+
+@(private="file")
+collect_drag_handles_recur :: proc(
+	root: int,
+	nodes: [dynamic]types.Node,
+	children_list: [dynamic]types.Children,
+	out: ^[dynamic]int,
+) {
+	if root < 0 || root >= len(children_list) do return
+	kids := children_list[root]
+	for i in 0 ..< int(kids.length) {
+		ci := int(kids.value[i])
+		if ci < 0 || ci >= len(nodes) do continue
+		// Stop descending into nested draggables.
+		nested := false
+		switch n in nodes[ci] {
+		case types.NodeVbox:
+			if _, ok := n.draggable.?; ok do nested = true
+			if n.drag_handle do append(out, ci)
+		case types.NodeHbox:
+			if _, ok := n.draggable.?; ok do nested = true
+			if n.drag_handle do append(out, ci)
+		case types.NodeButton:
+			if n.drag_handle do append(out, ci)
+		case types.NodeStack, types.NodeCanvas, types.NodeInput,
+		     types.NodeText, types.NodeImage, types.NodePopout,
+		     types.NodeModal:
+		}
+		if !nested do collect_drag_handles_recur(ci, nodes, children_list, out)
+	}
+}
+
 // Currently focused node index, -1 means none.
 focused_idx: int = -1
 
@@ -43,6 +89,7 @@ deepest_listener_idx :: proc(
 extract_listeners :: proc(
 	paths: [dynamic]types.Path,
 	nodes: [dynamic]types.Node,
+	children_list: [dynamic]types.Children,
 	theme: map[string]types.Theme,
 ) -> [dynamic]types.Listener {
 	listeners: [dynamic]types.Listener
@@ -69,9 +116,17 @@ extract_listeners :: proc(
 		case types.NodeVbox:
 			aspect = n.aspect
 			if d, ok := n.draggable.?; ok && len(d.tags) > 0 && len(d.event) > 0 {
-				append(&listeners, types.Listener(types.DragListener{
-					node_idx = idx, source_idx = idx, tags = d.tags,
-				}))
+				if !d.handle_off {
+					append(&listeners, types.Listener(types.DragListener{
+						node_idx = idx, source_idx = idx, tags = d.tags,
+					}))
+				}
+				handles := collect_drag_handles_in_subtree(idx, nodes, children_list)
+				for h in handles {
+					append(&listeners, types.Listener(types.DragListener{
+						node_idx = h, source_idx = idx, tags = d.tags,
+					}))
+				}
 			}
 			if d, ok := n.dropable.?; ok && len(d.tags) > 0 && len(d.event) > 0 {
 				append(&listeners, types.Listener(types.DropListener{
@@ -86,9 +141,17 @@ extract_listeners :: proc(
 		case types.NodeHbox:
 			aspect = n.aspect
 			if d, ok := n.draggable.?; ok && len(d.tags) > 0 && len(d.event) > 0 {
-				append(&listeners, types.Listener(types.DragListener{
-					node_idx = idx, source_idx = idx, tags = d.tags,
-				}))
+				if !d.handle_off {
+					append(&listeners, types.Listener(types.DragListener{
+						node_idx = idx, source_idx = idx, tags = d.tags,
+					}))
+				}
+				handles := collect_drag_handles_in_subtree(idx, nodes, children_list)
+				for h in handles {
+					append(&listeners, types.Listener(types.DragListener{
+						node_idx = h, source_idx = idx, tags = d.tags,
+					}))
+				}
 			}
 			if d, ok := n.dropable.?; ok && len(d.tags) > 0 && len(d.event) > 0 {
 				append(&listeners, types.Listener(types.DropListener{

--- a/src/redin/input/input.odin
+++ b/src/redin/input/input.odin
@@ -508,15 +508,33 @@ key_to_string_input :: proc(key: rl.KeyboardKey) -> string {
 	}
 }
 
-// Set the system mouse cursor to I-beam while hovering a selectable text,
-// otherwise DEFAULT. Safe to call every frame; Raylib debounces redundant
-// sets internally.
+// Cursor precedence (highest first):
+//   1. Active or pending drag → RESIZE_ALL ("grabbing"; raylib has no
+//      grab cursor, this is the closest analogue).
+//   2. Mouse over a DragListener (handle or container) → POINTING_HAND.
+//   3. Mouse over a Text_Select_Listener → IBEAM.
+//   4. Otherwise DEFAULT.
 set_hover_cursor :: proc(listeners: []types.Listener, node_rects: []rl.Rectangle) {
+	switch _ in drag {
+	case Drag_Pending, Drag_Active:
+		rl.SetMouseCursor(.RESIZE_ALL)
+		return
+	case Drag_Idle:
+	}
 	mouse := rl.GetMousePosition()
+	for listener in listeners {
+		dl, ok := listener.(types.DragListener)
+		if !ok do continue
+		if dl.node_idx < 0 || dl.node_idx >= len(node_rects) do continue
+		if rl.CheckCollisionPointRec(mouse, node_rects[dl.node_idx]) {
+			rl.SetMouseCursor(.POINTING_HAND)
+			return
+		}
+	}
 	for listener in listeners {
 		tl, ok := listener.(types.Text_Select_Listener)
 		if !ok do continue
-		if tl.node_idx >= len(node_rects) do continue
+		if tl.node_idx < 0 || tl.node_idx >= len(node_rects) do continue
 		if rl.CheckCollisionPointRec(mouse, node_rects[tl.node_idx]) {
 			rl.SetMouseCursor(.IBEAM)
 			return

--- a/src/redin/runtime.odin
+++ b/src/redin/runtime.odin
@@ -185,7 +185,7 @@ run :: proc(cfg: Config) {
 
 		if b.frame_changed {
 			delete(listeners)
-			bridge.validate_drag_handles(b.nodes[:], b.children_list[:], b.paths[:])
+			bridge.validate_drag_handles(b.nodes[:], b.children_list[:])
 			listeners = input.extract_listeners(b.paths, b.nodes, b.children_list, b.theme)
 		}
 

--- a/src/redin/runtime.odin
+++ b/src/redin/runtime.odin
@@ -185,6 +185,7 @@ run :: proc(cfg: Config) {
 
 		if b.frame_changed {
 			delete(listeners)
+			bridge.validate_drag_handles(b.nodes[:], b.children_list[:], b.paths[:])
 			listeners = input.extract_listeners(b.paths, b.nodes, b.theme)
 		}
 

--- a/src/redin/runtime.odin
+++ b/src/redin/runtime.odin
@@ -186,7 +186,7 @@ run :: proc(cfg: Config) {
 		if b.frame_changed {
 			delete(listeners)
 			bridge.validate_drag_handles(b.nodes[:], b.children_list[:], b.paths[:])
-			listeners = input.extract_listeners(b.paths, b.nodes, b.theme)
+			listeners = input.extract_listeners(b.paths, b.nodes, b.children_list, b.theme)
 		}
 
 		// --- Input (1/4): raw poll + user filter ---

--- a/src/redin/types/listener_events.odin
+++ b/src/redin/types/listener_events.odin
@@ -24,8 +24,9 @@ ChangeListener :: struct {
 }
 
 DragListener :: struct {
-	node_idx: int,
-	tags:     []string, // borrowed from node; lives until next clear_frame
+	node_idx:   int,    // hit-test surface (handle if present, else container)
+	source_idx: int,    // the draggable container; equals node_idx for container-grabs
+	tags:       []string, // borrowed from node; lives until next clear_frame
 }
 
 DropListener :: struct {

--- a/src/redin/types/view_tree.odin
+++ b/src/redin/types/view_tree.odin
@@ -53,12 +53,13 @@ Drag_Mode :: enum u8 {
 
 // :draggable — declares "what I am" + how I behave while dragged.
 Draggable_Attrs :: struct {
-	tags:    []string,                  // owned slice of cloned strings
-	event:   string,                    // owned, freed by clear_node_strings
-	mode:    Drag_Mode,                 // zero = .Preview
-	aspect:  string,                    // owned
-	animate: Maybe(Animate_Decoration), // owned provider string inside
-	ctx:     i32,                       // Lua registry ref (0 = none)
+	tags:       []string,                  // owned slice of cloned strings
+	event:      string,                    // owned, freed by clear_node_strings
+	mode:       Drag_Mode,                 // zero = .Preview
+	aspect:     string,                    // owned
+	animate:    Maybe(Animate_Decoration), // owned provider string inside
+	ctx:        i32,                       // Lua registry ref (0 = none)
+	handle_off: bool,                      // zero-value = container is a grab surface
 }
 
 // :dropable — declares "what I accept" + how it looks on hover.
@@ -120,6 +121,7 @@ NodeVbox :: struct {
 	draggable:  Maybe(Draggable_Attrs),
 	dropable:   Maybe(Dropable_Attrs),
 	drag_over:  Maybe(Drag_Over_Attrs),
+	drag_handle: bool,
 }
 
 NodeHbox :: struct {
@@ -137,6 +139,7 @@ NodeHbox :: struct {
 	draggable:  Maybe(Draggable_Attrs),
 	dropable:   Maybe(Dropable_Attrs),
 	drag_over:  Maybe(Drag_Over_Attrs),
+	drag_handle: bool,
 }
 
 NodeInput :: struct {
@@ -169,6 +172,7 @@ NodeButton :: struct {
 	},
 	label:     string,
 	aspect:    string,
+	drag_handle: bool,
 }
 
 NodeText :: struct {

--- a/test/ui/drag_app.fnl
+++ b/test/ui/drag_app.fnl
@@ -88,4 +88,18 @@
                              {:event :event/drop
                               :aspect :row-drop-hot}
                              i]}
-           [:text {:id (.. :item- (tostring i)) :aspect :body} item.text]])]])))
+           [:text {:id (.. :item- (tostring i)) :aspect :body} item.text]])]
+       [:vbox {:id :handle-row-demo :aspect :muted}
+        [:hbox {:id :handle-row
+                :aspect :muted :height 42
+                :draggable [:demo
+                            {:mode :preview
+                             :handle false
+                             :event :event/drag
+                             :aspect :row-dragging} 99]}
+         [:vbox {:id :handle-grip
+                 :width 24 :height 24
+                 :aspect :muted
+                 :drag-handle true}]
+         [:text {:id :handle-row-text :aspect :body} "drag me by the grip"]]]
+       ])))


### PR DESCRIPTION
## Summary

Resolves the text-vs-drag click conflict from #94 by adding an explicit drag-handle pattern.

- **New `:handle` option on `:draggable`** (bool, default `true`). Set `false` to opt the container out of being a grab surface — the only grab surfaces become descendants marked `:drag-handle true`.
- **New `:drag-handle` attribute on `:vbox` / `:hbox` / `:button`** (bool, default `false`). Marks the node as a grab surface for the nearest `:draggable` ancestor. On `:button`, mutually exclusive with `:click` — parser stderr-warns and drops `:click`.
- **`DragListener` gains `source_idx`** so the hit-test surface (the handle) and the captured draggable container can differ. Drag capture reads attrs from `source_idx`, so dragging by a handle still operates on the row.
- **Validation**: post-parse walk warns when `:handle false` has no descendant carrying `:drag-handle true` (otherwise the draggable would be silently ungrabbable).
- **Cursor precedence** in `set_hover_cursor`: `RESIZE_ALL` during an in-flight drag → `POINTING_HAND` over any `DragListener` → `IBEAM` over text-select → `DEFAULT`. (raylib has no dedicated grab cursor; `RESIZE_ALL` is the closest analogue.)
- **Kitchen-sink** todo row updated to demonstrate the pattern: leading-edge grip vbox + selectable body text + remove button.
- **Docs sweep**: `docs/core-api.md`, `docs/reference/elements.md`, `.claude/skills/redin-dev/SKILL.md`.

Spec + plan in `docs/superpowers/{specs,plans}/2026-04-29-drag-handle*.md` (gitignored, local-only).

## Test plan

- [x] `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin` — clean
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 122/122 passed
- [x] `odin test src/redin/input -collection:lib=lib -collection:luajit=vendor/luajit -define:ODIN_TEST_THREADS=1` — 16/16 passed (5 new in `extract_listeners_test.odin` covering default, handle-off, additive, multiple handles, nested-draggable cases)
- [x] `bash test/ui/run-all.sh --headless` — all suites green, no regression
- [x] `--track-mem` run on `drag_app.fnl` — no new leaks from the descendant walk
- [x] Manual visual smoke: `./build/redin --dev examples/kitchen-sink.fnl` — clicking a todo row's text starts a text selection; clicking the grip on the leading edge starts a drag
- [x] Manual stderr check: button with both `:click` and `:drag-handle true` warns + drops `:click`; `:draggable` with `:handle false` and no descendant `:drag-handle true` warns "ungrabbable"

## Notes

- Stderr-warning tests aren't automated — the existing `bb test/ui/run.bb` harness connects to an already-running dev server and can't capture spawned-process stderr. The two warning paths are exercised by the manual checks above.
- `src/redin/input` Odin tests run locally only; CI's `test.yml` currently runs `odin test src/redin/parser` only. Adding the input suite to CI is a worthwhile follow-up in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)