### PR TITLE
feat: mouse takeover for UI testing

### DIFF
--- a/.claude/skills/redin-dev/SKILL.md
+++ b/.claude/skills/redin-dev/SKILL.md
@@ -220,7 +220,7 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:$PORT/state
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | /frames | Last pushed frame tree |
+| GET | /frames | Last pushed frame tree (each node's attrs include `"rect":[x,y,w,h]` from last layout) |
 | GET | /state | Full app state |
 | GET | /state/path.to.value | Nested state lookup |
 | GET | /aspects | Current theme |
@@ -230,6 +230,12 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:$PORT/state
 | POST | /click | Inject click (JSON: `{"x":N,"y":N}`) |
 | POST | /shutdown | Graceful shutdown |
 | PUT | /aspects | Replace theme |
+| POST | /input/takeover | Take over mouse polling for tests. Required before `/input/mouse/*`. Returns 409 if already active. |
+| POST | /input/release | Restore raylib mouse polling. |
+| POST | /input/mouse/move | Set override mouse position (`{"x":N,"y":N}`). Requires takeover. |
+| POST | /input/mouse/down | Press a button (`{"button":"left\|right\|middle"}`). Requires takeover. Returns 409 if already down. |
+| POST | /input/mouse/up | Release a button (`{"button":...}`). Requires takeover. Returns 409 if already up. |
+| POST | /input/key | Synthesise one KeyEvent (`{"key":"...", "mods"?}`). Does not require takeover. |
 
 ## Testing
 

--- a/.claude/skills/redin-maintenance/SKILL.md
+++ b/.claude/skills/redin-maintenance/SKILL.md
@@ -58,6 +58,14 @@ Every non-OPTIONS request to the dev server needs `Authorization: Bearer <token>
 
 `smoke`, `input`, `button`, `canvas`, `drag`, `image`, `line_height`, `modal`, `multiline`, `popout`, `resize`, `scroll`, `scroll_x`, `shadow`, `text_select`, `viewport`, `animate`
 
+### Drag tests and the mouse-takeover pipeline
+
+Drag tests exercise the real input pipeline through the `/input/takeover` / `/input/mouse/*` dev-server endpoints rather than the older synthetic `/click`. The takeover lifecycle: `POST /input/takeover` to acquire, then `POST /input/mouse/move` / `down` / `up` to feed override state, then `POST /input/release` to restore raylib polling. This lets tests drive hover, drag-threshold, and drop events end-to-end without mocking the input layer.
+
+`test/ui/artifacts/` is gitignored and created lazily by tests that write screenshots; no manual setup required.
+
+`odin test src/redin/input` requires `-define:ODIN_TEST_THREADS=1` to avoid races on package-global state. This applies to `override_test.odin`'s tests and to pre-existing races in `state_test.odin`; always pass the flag when running the input package tests.
+
 ## Memory leak detection
 
 Add `--track-mem` to enable the tracking allocator:

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ test/integration/testapp/
 .nrepl-port
 docs/superpowers
 .worktrees/
+
+# UI test screenshot artifacts
+test/ui/artifacts/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Available when running with `--dev`. Listens on port 8800 by default; walks upwa
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/frames` | Last pushed frame (view tree as JSON) |
+| `GET` | `/frames` | Last pushed frame (view tree as JSON). Each node's attrs include `"rect":[x,y,w,h]` from the most recent layout. |
 | `GET` | `/state` | Full app state |
 | `GET` | `/state/<dot.path>` | Nested state lookup (e.g. `/state/form.name`) |
 | `GET` | `/aspects` | Current theme map |
@@ -102,6 +102,12 @@ Available when running with `--dev`. Listens on port 8800 by default; walks upwa
 | `POST` | `/click` | Inject a mouse click (JSON body: `{"x":N,"y":N}`) |
 | `POST` | `/shutdown` | Request graceful shutdown |
 | `PUT` | `/aspects` | Replace the theme map (JSON body) |
+| `POST` | `/input/takeover` | Take over mouse polling for tests. Required before `/input/mouse/*`. |
+| `POST` | `/input/release` | Restore raylib mouse polling. |
+| `POST` | `/input/mouse/move` | Set override mouse position (`{x,y}`). Requires takeover. |
+| `POST` | `/input/mouse/down` | Press a button (`{button:"left\|right\|middle"}`). Requires takeover. |
+| `POST` | `/input/mouse/up` | Release a button (`{button:...}`). Requires takeover. |
+| `POST` | `/input/key` | Synthesise one KeyEvent (`{key, mods?}`). Does not require takeover. |
 
 Example:
 

--- a/docs/core-api.md
+++ b/docs/core-api.md
@@ -524,7 +524,7 @@ Runs on `localhost:8800` when started with `--dev` flag. All responses are JSON 
 | ------ | --------- | ---- | ------------------------------------ |
 | GET    | `/frames` | --   | Full frame tree (from last `redin.push`) |
 
-Calls into Lua (`view.get-last-push`) to retrieve the last pushed frame.
+Calls into Lua (`view.get-last-push`) to retrieve the last pushed frame. Each node's attrs object includes `:rect [x y w h]` from the most recent layout. Tests use this to resolve element coordinates without hard-coding positions.
 
 ### State
 
@@ -574,6 +574,32 @@ Click injects a `MouseEvent` into the input queue, which is processed on the nex
 | POST   | `/shutdown` | --   | `{"ok": true}`  |
 
 Requests graceful shutdown of the application.
+
+### Mouse takeover (test only)
+
+The dev server exposes mouse-state takeover so UI tests can drive the
+real input pipeline. The takeover lifecycle is explicit:
+
+- `POST /input/takeover` — flips a flag so subsequent raylib mouse
+  polls are ignored; mouse position and button states come from the
+  override instead.
+- `POST /input/release` — restores raylib polling.
+
+Once takeover is active, three endpoints feed the override state:
+
+- `POST /input/mouse/move` with `{"x":N,"y":N}` — set position.
+- `POST /input/mouse/down` with `{"button":"left|right|middle"}` —
+  flip the held-state and synthesise a press edge.
+- `POST /input/mouse/up` with `{"button":...}` — flip held-state and
+  synthesise a release edge.
+
+Double-acquire (`/input/takeover` while already active), double-press
+(`/input/mouse/down` for an already-down button), and the symmetric
+double-release cases all return 409.
+
+`POST /input/key` synthesises a single KeyEvent (`{"key":"escape", ...}`).
+It does not require takeover — keys are event-driven, not continuous
+polling.
 
 ### CORS
 

--- a/docs/reference/dev-server.md
+++ b/docs/reference/dev-server.md
@@ -46,7 +46,7 @@ AUTH="Authorization: Bearer $TOKEN"
 curl -H "$AUTH" http://localhost:$PORT/frames
 ```
 
-Response: the full frame tree as JSON. Calls `view.get-last-push` in Lua to retrieve the last rendered frame.
+Response: the full frame tree as JSON. Calls `view.get-last-push` in Lua to retrieve the last rendered frame. Each node's attrs object includes a `"rect":[x,y,w,h]` field from the most recent layout pass. Tests use this to resolve element coordinates without hard-coding positions.
 
 ### `GET /state` -- full app-db
 
@@ -160,6 +160,77 @@ curl -X PUT -H "$AUTH" http://localhost:$PORT/aspects \
 Response: `{"ok": true}`
 
 Decodes the JSON body and calls `theme.set-theme` in Lua, replacing the entire theme.
+
+### `POST /input/takeover` -- take over mouse polling
+
+```bash
+curl -X POST -H "$AUTH" http://localhost:$PORT/input/takeover
+```
+
+Response: `{"ok": true}`. Flips a flag so raylib mouse polls are ignored; position and button states come from the override instead. Returns `409` if takeover is already active.
+
+### `POST /input/release` -- restore raylib mouse polling
+
+```bash
+curl -X POST -H "$AUTH" http://localhost:$PORT/input/release
+```
+
+Response: `{"ok": true}`. Restores raylib polling and clears all override state.
+
+### `POST /input/mouse/move` -- set override position
+
+Requires takeover to be active.
+
+```bash
+curl -X POST -H "$AUTH" -d '{"x":50,"y":80}' http://localhost:$PORT/input/mouse/move
+```
+
+Response: `{"ok": true}`.
+
+### `POST /input/mouse/down` -- press a mouse button
+
+Requires takeover. Flips the held-state and synthesises a press edge for the next input poll.
+
+```bash
+curl -X POST -H "$AUTH" -d '{"button":"left"}' http://localhost:$PORT/input/mouse/down
+```
+
+`button` is one of `"left"`, `"right"`, `"middle"`. Returns `409` if that button is already down.
+
+### `POST /input/mouse/up` -- release a mouse button
+
+Requires takeover. Flips the held-state and synthesises a release edge.
+
+```bash
+curl -X POST -H "$AUTH" -d '{"button":"left"}' http://localhost:$PORT/input/mouse/up
+```
+
+Returns `409` if that button is already up.
+
+### `POST /input/key` -- synthesise a key event
+
+Does **not** require takeover — keys are event-driven, not continuous polling.
+
+```bash
+curl -X POST -H "$AUTH" -d '{"key":"escape"}' http://localhost:$PORT/input/key
+```
+
+Body: `{"key": "<name>", "mods": [...]}`. Synthesises a single `KeyEvent` delivered on the next input poll.
+
+---
+
+### Worked example: drive a drag from a test
+
+```bash
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+H="Authorization: Bearer $TOKEN"
+curl -sH "$H" -X POST http://localhost:$PORT/input/takeover
+curl -sH "$H" -X POST -d '{"x":50,"y":50}'   http://localhost:$PORT/input/mouse/move
+curl -sH "$H" -X POST -d '{"button":"left"}' http://localhost:$PORT/input/mouse/down
+curl -sH "$H" -X POST -d '{"x":80,"y":50}'   http://localhost:$PORT/input/mouse/move
+curl -sH "$H" -X POST -d '{"button":"left"}' http://localhost:$PORT/input/mouse/up
+curl -sH "$H" -X POST http://localhost:$PORT/input/release
+```
 
 ---
 

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -101,10 +101,12 @@ destroy :: proc(b: ^Bridge) {
 	lua_close(b.L)
 }
 
-poll_devserver :: proc(b: ^Bridge, events: ^[dynamic]types.InputEvent) {
+poll_devserver :: proc(b: ^Bridge, events: ^[dynamic]types.InputEvent, node_rects: []rl.Rectangle) {
 	if !b.dev_mode do return
+	b.dev_server.current_rects = node_rects
 	devserver_poll(&b.dev_server)
 	devserver_drain_events(&b.dev_server, events)
+	b.dev_server.current_rects = nil
 }
 
 is_shutdown_requested :: proc(b: ^Bridge) -> bool {

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -129,7 +129,21 @@ clear_draggable_attrs :: proc(m: Maybe(types.Draggable_Attrs)) {
 	if len(d.event) > 0 do delete(d.event)
 	if len(d.aspect) > 0 do delete(d.aspect)
 	if dec, ok2 := d.animate.?; ok2 && len(dec.provider) > 0 do delete(dec.provider)
-	if d.ctx != 0 do luaL_unref(g_bridge.L, LUA_REGISTRYINDEX, d.ctx)
+	if d.ctx != 0 {
+		// Don't unref the Lua registry slot while a drag is in flight and
+		// the captured ctx_ref refers to this very slot. The node may be
+		// re-rendered (and its ctx unreffed) before the drop fires, which
+		// would free the slot prematurely and deliver nil to the drop handler.
+		active_ref: i32 = 0
+		switch s in input.drag {
+		case input.Drag_Pending: active_ref = s.src_ctx_ref
+		case input.Drag_Active:  active_ref = s.src_ctx_ref
+		case nil, input.Drag_Idle:
+		}
+		if d.ctx != active_ref {
+			luaL_unref(g_bridge.L, LUA_REGISTRYINDEX, d.ctx)
+		}
+	}
 }
 
 clear_dropable_attrs :: proc(m: Maybe(types.Dropable_Attrs)) {

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -9,6 +9,7 @@ import "core:time"
 import "core:unicode/utf8"
 import "base:runtime"
 import "../font"
+import "../input"
 import text_pkg "../text"
 import "../types"
 import rl "vendor:raylib"
@@ -461,7 +462,7 @@ read_number_field :: proc(L: ^Lua_State, idx: i32, field: cstring) -> f32 {
 // ---------------------------------------------------------------------------
 
 // Push a {left=bool, right=bool, middle=bool} table for a mouse button query
-push_mouse_buttons :: proc(L: ^Lua_State, parent_idx: i32, field: cstring, query: proc "c" (button: rl.MouseButton) -> bool) {
+push_mouse_buttons :: proc(L: ^Lua_State, parent_idx: i32, field: cstring, query: proc(button: rl.MouseButton) -> bool) {
 	lua_createtable(L, 0, 3)
 	btn_idx := lua_gettop(L)
 	lua_pushboolean(L, query(.LEFT) ? 1 : 0)
@@ -478,20 +479,20 @@ push_canvas_input_state :: proc(L: ^Lua_State, rect: rl.Rectangle) {
 	lua_createtable(L, 0, 6)
 	input_idx := lua_gettop(L)
 
-	mouse_pos := rl.GetMousePosition()
-	lua_pushnumber(L, f64(mouse_pos.x - rect.x))
+	m := input.mouse_pos()
+	lua_pushnumber(L, f64(m.x - rect.x))
 	lua_setfield(L, input_idx, "mouse-x")
-	lua_pushnumber(L, f64(mouse_pos.y - rect.y))
+	lua_pushnumber(L, f64(m.y - rect.y))
 	lua_setfield(L, input_idx, "mouse-y")
 
-	mouse_in := mouse_pos.x >= rect.x && mouse_pos.x <= rect.x + rect.width &&
-	            mouse_pos.y >= rect.y && mouse_pos.y <= rect.y + rect.height
+	mouse_in := m.x >= rect.x && m.x <= rect.x + rect.width &&
+	            m.y >= rect.y && m.y <= rect.y + rect.height
 	lua_pushboolean(L, mouse_in ? 1 : 0)
 	lua_setfield(L, input_idx, "mouse-in")
 
-	push_mouse_buttons(L, input_idx, "mouse-down", rl.IsMouseButtonDown)
-	push_mouse_buttons(L, input_idx, "mouse-pressed", rl.IsMouseButtonPressed)
-	push_mouse_buttons(L, input_idx, "mouse-released", rl.IsMouseButtonReleased)
+	push_mouse_buttons(L, input_idx, "mouse-down", input.is_mouse_button_down)
+	push_mouse_buttons(L, input_idx, "mouse-pressed", input.is_mouse_button_pressed)
+	push_mouse_buttons(L, input_idx, "mouse-released", input.is_mouse_button_released)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -596,6 +596,12 @@ process_request :: proc(ds: ^Dev_Server, req: ^Pending_Request) {
 			handle_post_input_takeover(ds, ch)
 		} else if req.path == "/input/release" {
 			handle_post_input_release(ds, ch)
+		} else if req.path == "/input/mouse/move" {
+			handle_post_input_mouse_move(ds, ch, req.body)
+		} else if req.path == "/input/mouse/down" {
+			handle_post_input_mouse_down(ds, ch, req.body)
+		} else if req.path == "/input/mouse/up" {
+			handle_post_input_mouse_up(ds, ch, req.body)
 		} else if req.path == "/shutdown" {
 			ds.shutdown_requested = true
 			respond_json_ok(ch)
@@ -1034,6 +1040,150 @@ handle_post_input_release :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
 		return
 	}
 	input.override = input.Mouse_Override{}
+	respond_json_ok(ch)
+}
+
+// Decode {"button":"left|right|middle"} from a Lua-staged table at -1.
+read_mouse_button :: proc(L: ^Lua_State) -> (rl.MouseButton, bool) {
+	lua_getfield(L, -1, "button")
+	defer lua_pop(L, 1)
+	if !lua_isstring(L, -1) do return .LEFT, false
+	s := string(lua_tostring_raw(L, -1))
+	switch s {
+	case "left":   return .LEFT,   true
+	case "right":  return .RIGHT,  true
+	case "middle": return .MIDDLE, true
+	}
+	return .LEFT, false
+}
+
+handle_post_input_mouse_move :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	if !input.override.active {
+		respond_json_error(ch, 409, `{"error":"takeover not active"}`)
+		return
+	}
+	L := ds.bridge.L
+	pos := 0
+	if !json_decode_value(L, body, &pos) {
+		respond_json_error(ch, 400, `{"error":"invalid JSON"}`)
+		return
+	}
+	defer lua_pop(L, 1)
+	if !lua_istable(L, -1) {
+		respond_json_error(ch, 400, `{"error":"body must be an object"}`)
+		return
+	}
+	lua_getfield(L, -1, "x")
+	x := f32(lua_tonumber(L, -1))
+	lua_pop(L, 1)
+	lua_getfield(L, -1, "y")
+	y := f32(lua_tonumber(L, -1))
+	lua_pop(L, 1)
+	if math.is_nan(x) || math.is_nan(y) || math.is_inf(x) || math.is_inf(y) {
+		respond_json_error(ch, 400, `{"error":"x,y must be finite"}`)
+		return
+	}
+	input.override.pos = rl.Vector2{x, y}
+	respond_json_ok(ch)
+}
+
+handle_post_input_mouse_down :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	if !input.override.active {
+		respond_json_error(ch, 409, `{"error":"takeover not active"}`)
+		return
+	}
+	L := ds.bridge.L
+	pos := 0
+	if !json_decode_value(L, body, &pos) {
+		respond_json_error(ch, 400, `{"error":"invalid JSON"}`)
+		return
+	}
+	defer lua_pop(L, 1)
+	if !lua_istable(L, -1) {
+		respond_json_error(ch, 400, `{"error":"body must be an object"}`)
+		return
+	}
+	btn, ok := read_mouse_button(L)
+	if !ok {
+		respond_json_error(ch, 400, `{"error":"button must be left|right|middle"}`)
+		return
+	}
+	already_down := false
+	switch btn {
+	case .LEFT:
+		already_down = input.override.button_left
+		if !already_down {
+			input.override.button_left = true
+			input.override.pending_press_left = true
+		}
+	case .RIGHT:
+		already_down = input.override.button_right
+		if !already_down {
+			input.override.button_right = true
+			input.override.pending_press_right = true
+		}
+	case .MIDDLE:
+		already_down = input.override.button_middle
+		if !already_down {
+			input.override.button_middle = true
+			input.override.pending_press_middle = true
+		}
+	case .SIDE, .EXTRA, .FORWARD, .BACK:
+	}
+	if already_down {
+		respond_json_error(ch, 409, `{"error":"button already down"}`)
+		return
+	}
+	respond_json_ok(ch)
+}
+
+handle_post_input_mouse_up :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	if !input.override.active {
+		respond_json_error(ch, 409, `{"error":"takeover not active"}`)
+		return
+	}
+	L := ds.bridge.L
+	pos := 0
+	if !json_decode_value(L, body, &pos) {
+		respond_json_error(ch, 400, `{"error":"invalid JSON"}`)
+		return
+	}
+	defer lua_pop(L, 1)
+	if !lua_istable(L, -1) {
+		respond_json_error(ch, 400, `{"error":"body must be an object"}`)
+		return
+	}
+	btn, ok := read_mouse_button(L)
+	if !ok {
+		respond_json_error(ch, 400, `{"error":"button must be left|right|middle"}`)
+		return
+	}
+	already_up := false
+	switch btn {
+	case .LEFT:
+		already_up = !input.override.button_left
+		if !already_up {
+			input.override.button_left = false
+			input.override.pending_release_left = true
+		}
+	case .RIGHT:
+		already_up = !input.override.button_right
+		if !already_up {
+			input.override.button_right = false
+			input.override.pending_release_right = true
+		}
+	case .MIDDLE:
+		already_up = !input.override.button_middle
+		if !already_up {
+			input.override.button_middle = false
+			input.override.pending_release_middle = true
+		}
+	case .SIDE, .EXTRA, .FORWARD, .BACK:
+	}
+	if already_up {
+		respond_json_error(ch, 409, `{"error":"button already up"}`)
+		return
+	}
 	respond_json_ok(ch)
 }
 

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -592,6 +592,10 @@ process_request :: proc(ds: ^Dev_Server, req: ^Pending_Request) {
 			handle_post_events(ds, ch, req.body)
 		} else if req.path == "/click" {
 			handle_post_click(ds, ch, req.body)
+		} else if req.path == "/input/takeover" {
+			handle_post_input_takeover(ds, ch)
+		} else if req.path == "/input/release" {
+			handle_post_input_release(ds, ch)
 		} else if req.path == "/shutdown" {
 			ds.shutdown_requested = true
 			respond_json_ok(ch)
@@ -1012,6 +1016,24 @@ handle_post_click :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) 
 		return
 	}
 	append(&ds.event_queue, types.InputEvent(types.MouseEvent{x = x, y = y, button = .LEFT}))
+	respond_json_ok(ch)
+}
+
+handle_post_input_takeover :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
+	if input.override.active {
+		respond_json_error(ch, 409, `{"error":"takeover already active"}`)
+		return
+	}
+	input.override = input.Mouse_Override{active = true}
+	respond_json_ok(ch)
+}
+
+handle_post_input_release :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
+	if !input.override.active {
+		respond_json_error(ch, 409, `{"error":"takeover not active"}`)
+		return
+	}
+	input.override = input.Mouse_Override{}
 	respond_json_ok(ch)
 }
 

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -50,6 +50,7 @@ Dev_Server :: struct {
 	server_thread:      ^thread.Thread,
 	incoming:           Sync_Queue,
 	event_queue:        [dynamic]types.InputEvent,
+	current_rects:      []rl.Rectangle, // borrowed during a poll cycle, nil otherwise
 	running:            bool,
 	shutdown_requested: bool,
 }
@@ -691,9 +692,104 @@ handle_get_frames :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
 	}
 	b := strings.builder_make()
 	defer strings.builder_destroy(&b)
-	lua_value_to_json(&b, L, -1)
+	dfs_idx := 0
+	frame_value_to_json(&b, L, -1, ds.current_rects, &dfs_idx)
 	lua_pop(L, 1)
 	respond_json(ch, strings.to_string(b))
+}
+
+// Walks a Fennel-shaped frame value [tag attrs ...children] DFS, emitting
+// JSON. For each node table, injects "rect":[x,y,w,h] into the attrs
+// object using `dfs_idx` as the lookup into node_rects.
+//
+// For non-frame values (numbers, strings, primitive children inside
+// e.g. canvas attribute tables), defers to lua_value_to_json.
+//
+// Mirrors lua_read_node's flattening order. dfs_idx must be incremented
+// exactly once per node (vector with a tag at slot 1).
+frame_value_to_json :: proc(
+	b: ^strings.Builder, L: ^Lua_State, index: i32,
+	rects: []rl.Rectangle, dfs_idx: ^int,
+) {
+	// Normalise to absolute so the index stays valid as we push values.
+	idx := index < 0 ? lua_gettop(L) + index + 1 : index
+	if !lua_istable(L, idx) {
+		lua_value_to_json(b, L, idx)
+		return
+	}
+	// Detect a frame node: table whose [1] is a non-empty string.
+	// Frame tags are plain strings like "vbox", "hbox", "text", etc.
+	lua_rawgeti(L, idx, 1)
+	is_node := lua_isstring(L, -1)
+	tag := ""
+	if is_node {
+		tag = string(lua_tostring_raw(L, -1))
+		if len(tag) == 0 do is_node = false
+	}
+	lua_pop(L, 1)
+	if !is_node {
+		lua_value_to_json(b, L, idx)
+		return
+	}
+
+	// Capture rect now (before recursing into children, which would advance dfs_idx).
+	my_idx := dfs_idx^
+	dfs_idx^ += 1
+	rect_str := ""
+	if my_idx >= 0 && my_idx < len(rects) {
+		r := rects[my_idx]
+		rect_str = fmt.tprintf(`,"rect":[%g,%g,%g,%g]`, r.x, r.y, r.width, r.height)
+	} else {
+		rect_str = `,"rect":null`
+	}
+
+	// Emit ["tag", attrs-with-rect, ...children-recursed]
+	strings.write_string(b, "[")
+	// tag
+	strings.write_string(b, `"`)
+	strings.write_string(b, tag)
+	strings.write_string(b, `"`)
+	// attrs at slot [2]
+	lua_rawgeti(L, idx, 2)
+	strings.write_string(b, ",")
+	if lua_istable(L, -1) {
+		// Re-emit attrs as object via lua_value_to_json into a temp builder,
+		// then splice in the rect: rewind one byte ("}"), append rect_str, append "}".
+		tmp := strings.builder_make()
+		defer strings.builder_destroy(&tmp)
+		lua_value_to_json(&tmp, L, -1)
+		s := strings.to_string(tmp)
+		if len(s) >= 2 && s[len(s)-1] == '}' {
+			if s == "{}" {
+				strings.write_string(b, "{")
+				// rect_str starts with ','; strip the leading comma.
+				strings.write_string(b, rect_str[1:])
+				strings.write_string(b, "}")
+			} else {
+				strings.write_string(b, s[:len(s)-1])
+				strings.write_string(b, rect_str)
+				strings.write_string(b, "}")
+			}
+		} else {
+			// Defensive: emit as-is.
+			strings.write_string(b, s)
+		}
+	} else {
+		// No attrs table — synthesise {rect}.
+		strings.write_string(b, "{")
+		strings.write_string(b, rect_str[1:])
+		strings.write_string(b, "}")
+	}
+	lua_pop(L, 1)
+	// children at slots 3..n
+	n := lua_objlen(L, idx)
+	for i in 3..=n {
+		strings.write_string(b, ",")
+		lua_rawgeti(L, idx, i32(i))
+		frame_value_to_json(b, L, -1, rects, dfs_idx)
+		lua_pop(L, 1)
+	}
+	strings.write_string(b, "]")
 }
 
 handle_get_state :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -602,6 +602,8 @@ process_request :: proc(ds: ^Dev_Server, req: ^Pending_Request) {
 			handle_post_input_mouse_down(ds, ch, req.body)
 		} else if req.path == "/input/mouse/up" {
 			handle_post_input_mouse_up(ds, ch, req.body)
+		} else if req.path == "/input/key" {
+			handle_post_input_key(ds, ch, req.body)
 		} else if req.path == "/shutdown" {
 			ds.shutdown_requested = true
 			respond_json_ok(ch)
@@ -1184,6 +1186,76 @@ handle_post_input_mouse_up :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body:
 		respond_json_error(ch, 409, `{"error":"button already up"}`)
 		return
 	}
+	respond_json_ok(ch)
+}
+
+// Inverse of input.key_to_string_input: maps the same string names back
+// to raylib KeyboardKey enum values for /input/key synthesis.
+key_string_to_raylib :: proc(s: string) -> (rl.KeyboardKey, bool) {
+	switch s {
+	case "enter":     return .ENTER,     true
+	case "escape":    return .ESCAPE,    true
+	case "backspace": return .BACKSPACE, true
+	case "tab":       return .TAB,       true
+	case "space":     return .SPACE,     true
+	case "up":        return .UP,        true
+	case "down":      return .DOWN,      true
+	case "left":      return .LEFT,      true
+	case "right":     return .RIGHT,     true
+	case "delete":    return .DELETE,    true
+	case "home":      return .HOME,      true
+	case "end":       return .END,       true
+	case "pageup":    return .PAGE_UP,   true
+	case "pagedown":  return .PAGE_DOWN, true
+	}
+	if len(s) == 1 {
+		c := s[0]
+		if c >= 'a' && c <= 'z' do return rl.KeyboardKey(int(rl.KeyboardKey.A) + int(c - 'a')), true
+		if c >= 'A' && c <= 'Z' do return rl.KeyboardKey(int(rl.KeyboardKey.A) + int(c - 'A')), true
+		if c >= '0' && c <= '9' do return rl.KeyboardKey(int(rl.KeyboardKey.ZERO) + int(c - '0')), true
+	}
+	return .KEY_NULL, false
+}
+
+handle_post_input_key :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	L := ds.bridge.L
+	pos := 0
+	if !json_decode_value(L, body, &pos) {
+		respond_json_error(ch, 400, `{"error":"invalid JSON"}`)
+		return
+	}
+	defer lua_pop(L, 1)
+	if !lua_istable(L, -1) {
+		respond_json_error(ch, 400, `{"error":"body must be an object"}`)
+		return
+	}
+	lua_getfield(L, -1, "key")
+	key_str := ""
+	if lua_isstring(L, -1) do key_str = string(lua_tostring_raw(L, -1))
+	lua_pop(L, 1)
+	key, ok := key_string_to_raylib(key_str)
+	if !ok {
+		respond_json_error(ch, 400, `{"error":"unknown key"}`)
+		return
+	}
+	mods := types.KeyMods{}
+	lua_getfield(L, -1, "mods")
+	if lua_istable(L, -1) {
+		read_bool :: proc(L: ^Lua_State, key: cstring) -> bool {
+			lua_getfield(L, -1, key)
+			defer lua_pop(L, 1)
+			return lua_toboolean(L, -1) != 0
+		}
+		mods.shift = read_bool(L, "shift")
+		mods.ctrl  = read_bool(L, "ctrl")
+		mods.alt   = read_bool(L, "alt")
+		mods.super = read_bool(L, "super")
+	}
+	lua_pop(L, 1)
+	m := input.mouse_pos()
+	append(&ds.event_queue, types.InputEvent(types.KeyEvent{
+		x = m.x, y = m.y, key = key, mods = mods,
+	}))
 	respond_json_ok(ch)
 }
 

--- a/src/redin/input/drag.odin
+++ b/src/redin/input/drag.odin
@@ -128,7 +128,7 @@ process_drag :: proc(
 	node_rects: []rl.Rectangle,
 ) -> [dynamic]types.Dispatch_Event {
 	dispatch: [dynamic]types.Dispatch_Event
-	mouse := rl.GetMousePosition()
+	mouse := mouse_pos()
 
 	// Escape cancels any in-flight drag (Pending or Active). When cancelling
 	// from Active with an entered :drag-over zone, fire a final :phase :leave
@@ -221,7 +221,7 @@ process_drag :: proc(
 		}
 
 	case Drag_Pending:
-		if rl.IsMouseButtonDown(.LEFT) {
+		if is_mouse_button_down(.LEFT) {
 			dx := mouse.x - s.start_pos.x
 			dy := mouse.y - s.start_pos.y
 			if dx*dx + dy*dy >= DRAG_THRESHOLD * DRAG_THRESHOLD {
@@ -280,7 +280,7 @@ process_drag :: proc(
 		}
 		s.over_drop_idx = new_drop
 
-		if !rl.IsMouseButtonDown(.LEFT) {
+		if !is_mouse_button_down(.LEFT) {
 			// Drop dispatch.
 			if new_drop >= 0 {
 				drop_event := ""

--- a/src/redin/input/drag.odin
+++ b/src/redin/input/drag.odin
@@ -70,7 +70,12 @@ Drag_Active :: struct {
 
 Drag_State :: union { Drag_Idle, Drag_Pending, Drag_Active }
 
-drag: Drag_State = Drag_Idle{}
+// NOTE: Drag_Idle is an empty struct. In Odin's union representation, an
+// empty-struct variant is indistinguishable from nil (both use tag 0). The
+// package-level `drag` variable therefore starts as nil, and `case Drag_Idle:`
+// never matches at runtime. The idle condition is `drag == nil`. All
+// transitions back to "idle" assign `drag = nil` (not `drag = Drag_Idle{}`).
+drag: Drag_State
 
 // True iff src and target share at least one tag.
 drag_matches :: proc(src, target: []string) -> bool {
@@ -142,11 +147,11 @@ process_drag :: proc(
 	}
 	if esc_pressed {
 		switch &s in drag {
-		case Drag_Idle:
+		case nil, Drag_Idle:
 			// Nothing to cancel.
 		case Drag_Pending:
 			free_captured(s.captured)
-			drag = Drag_Idle{}
+			drag = nil
 		case Drag_Active:
 			if s.over_zone_idx >= 0 && s.over_zone_idx < len(nodes) {
 				if ev := node_over_event(nodes[s.over_zone_idx]); len(ev) > 0 {
@@ -157,13 +162,13 @@ process_drag :: proc(
 				}
 			}
 			free_captured(s.captured)
-			drag = Drag_Idle{}
+			drag = nil
 		}
 		return dispatch
 	}
 
 	switch &s in drag {
-	case Drag_Idle:
+	case nil, Drag_Idle:
 		// Mouse-down on a DragListener → Pending.
 		for event in input_events {
 			me, is_mouse := event.(types.MouseEvent)
@@ -239,7 +244,7 @@ process_drag :: proc(
 			}
 		} else {
 			free_captured(s.captured)
-			drag = Drag_Idle{}
+			drag = nil
 		}
 
 	case Drag_Active:
@@ -247,7 +252,7 @@ process_drag :: proc(
 		// with our tags, cancel.
 		if s.src_idx < 0 || s.src_idx >= len(nodes) {
 			free_captured(s.captured)
-			drag = Drag_Idle{}
+			drag = nil
 			return dispatch
 		}
 		// Stale zone/drop indices from a previous frame's layout — clear before use.
@@ -320,7 +325,7 @@ process_drag :: proc(
 			}
 
 			free_captured(s.captured)
-			drag = Drag_Idle{}
+			drag = nil
 		}
 	}
 
@@ -344,7 +349,7 @@ node_over_event :: proc(n: types.Node) -> string {
 is_dragging :: proc() -> bool {
 	switch _ in drag {
 	case Drag_Pending, Drag_Active: return true
-	case Drag_Idle:                 return false
+	case nil, Drag_Idle:            return false
 	}
 	return false
 }

--- a/src/redin/input/input.odin
+++ b/src/redin/input/input.odin
@@ -145,7 +145,7 @@ poll :: proc() -> [dynamic]types.InputEvent {
 		super = rl.IsKeyDown(.LEFT_SUPER) || rl.IsKeyDown(.RIGHT_SUPER),
 	}
 
-	mouse := rl.GetMousePosition()
+	mouse := mouse_pos()
 
 	key := rl.GetKeyPressed()
 	for key != .KEY_NULL {
@@ -181,7 +181,7 @@ poll :: proc() -> [dynamic]types.InputEvent {
 
 	buttons := [?]rl.MouseButton{.LEFT, .RIGHT, .MIDDLE}
 	for btn in buttons {
-		if rl.IsMouseButtonPressed(btn) {
+		if is_mouse_button_pressed(btn) {
 			append(
 				&events,
 				types.InputEvent(
@@ -449,7 +449,7 @@ key_to_string_input :: proc(key: rl.KeyboardKey) -> string {
 // otherwise DEFAULT. Safe to call every frame; Raylib debounces redundant
 // sets internally.
 set_hover_cursor :: proc(listeners: []types.Listener, node_rects: []rl.Rectangle) {
-	mouse := rl.GetMousePosition()
+	mouse := mouse_pos()
 	for listener in listeners {
 		tl, ok := listener.(types.Text_Select_Listener)
 		if !ok do continue

--- a/src/redin/input/override.odin
+++ b/src/redin/input/override.odin
@@ -1,0 +1,87 @@
+package input
+
+import rl "vendor:raylib"
+
+// Test-only override of raylib mouse polling. Driven by the dev server's
+// /input/* endpoints; off in normal runs.
+//
+// Position-only changes do not synthesise events (matches real input).
+// Button transitions go through `pending_press_*` / `pending_release_*`
+// which act as one-shot edges: set when the dev server flips a button,
+// consumed (and cleared) by `is_mouse_button_pressed/released` exactly
+// once. `is_mouse_button_down` reflects the held state continuously.
+Mouse_Override :: struct {
+	active:        bool,
+	pos:           rl.Vector2,
+	button_left:   bool,
+	button_right:  bool,
+	button_middle: bool,
+
+	pending_press_left,    pending_release_left:    bool,
+	pending_press_right,   pending_release_right:   bool,
+	pending_press_middle,  pending_release_middle:  bool,
+}
+
+override: Mouse_Override
+
+mouse_pos :: proc() -> rl.Vector2 {
+	if override.active do return override.pos
+	return rl.GetMousePosition()
+}
+
+is_mouse_button_down :: proc(btn: rl.MouseButton) -> bool {
+	if override.active {
+		switch btn {
+		case .LEFT:    return override.button_left
+		case .RIGHT:   return override.button_right
+		case .MIDDLE:  return override.button_middle
+		case .SIDE, .EXTRA, .FORWARD, .BACK: return false
+		}
+		return false
+	}
+	return rl.IsMouseButtonDown(btn)
+}
+
+is_mouse_button_pressed :: proc(btn: rl.MouseButton) -> bool {
+	if override.active {
+		switch btn {
+		case .LEFT:
+			r := override.pending_press_left
+			override.pending_press_left = false
+			return r
+		case .RIGHT:
+			r := override.pending_press_right
+			override.pending_press_right = false
+			return r
+		case .MIDDLE:
+			r := override.pending_press_middle
+			override.pending_press_middle = false
+			return r
+		case .SIDE, .EXTRA, .FORWARD, .BACK: return false
+		}
+		return false
+	}
+	return rl.IsMouseButtonPressed(btn)
+}
+
+is_mouse_button_released :: proc(btn: rl.MouseButton) -> bool {
+	if override.active {
+		switch btn {
+		case .LEFT:
+			r := override.pending_release_left
+			override.pending_release_left = false
+			return r
+		case .RIGHT:
+			r := override.pending_release_right
+			override.pending_release_right = false
+			return r
+		case .MIDDLE:
+			r := override.pending_release_middle
+			override.pending_release_middle = false
+			return r
+		case .SIDE, .EXTRA, .FORWARD, .BACK: return false
+		}
+		return false
+	}
+	return rl.IsMouseButtonReleased(btn)
+}

--- a/src/redin/input/override_test.odin
+++ b/src/redin/input/override_test.odin
@@ -3,6 +3,15 @@ package input
 import "core:testing"
 import rl "vendor:raylib"
 
+// These tests mutate the package-level `override` variable, so they must
+// be run sequentially. Use:
+//
+//   odin test src/redin/input -collection:lib=lib -collection:luajit=vendor/luajit \
+//       -define:ODIN_TEST_THREADS=1
+//
+// Without the flag, parallel test execution races on the shared global
+// and yields intermittent failures.
+
 @(test)
 test_mouse_pos_falls_back_to_raylib_when_inactive :: proc(t: ^testing.T) {
 	override = Mouse_Override{}
@@ -46,5 +55,24 @@ test_released_clears_pending_flag :: proc(t: ^testing.T) {
 	override = Mouse_Override{active = true, pending_release_left = true}
 	testing.expect(t, is_mouse_button_released(.LEFT))
 	testing.expect(t, !override.pending_release_left)
+	override = Mouse_Override{}
+}
+
+@(test)
+test_pending_flags_do_not_bleed_across_buttons :: proc(t: ^testing.T) {
+	override = Mouse_Override{
+		active             = true,
+		pending_press_left = true,
+	}
+	// Reading RIGHT must not consume LEFT's pending flag.
+	testing.expect(t, !is_mouse_button_pressed(.RIGHT))
+	testing.expect(t,  override.pending_press_left,
+		"reading RIGHT must not clear LEFT pending_press")
+	// Same for MIDDLE.
+	testing.expect(t, !is_mouse_button_pressed(.MIDDLE))
+	testing.expect(t,  override.pending_press_left)
+	// LEFT itself still works.
+	testing.expect(t,  is_mouse_button_pressed(.LEFT))
+	testing.expect(t, !override.pending_press_left)
 	override = Mouse_Override{}
 }

--- a/src/redin/input/override_test.odin
+++ b/src/redin/input/override_test.odin
@@ -1,0 +1,50 @@
+package input
+
+import "core:testing"
+import rl "vendor:raylib"
+
+@(test)
+test_mouse_pos_falls_back_to_raylib_when_inactive :: proc(t: ^testing.T) {
+	override = Mouse_Override{}
+	// Cannot easily mock rl.GetMousePosition; just assert active=false path
+	// returns the raylib value (whatever it is) by reading both.
+	got := mouse_pos()
+	want := rl.GetMousePosition()
+	testing.expect_value(t, got, want)
+}
+
+@(test)
+test_mouse_pos_uses_override_when_active :: proc(t: ^testing.T) {
+	override = Mouse_Override{active = true, pos = {123, 456}}
+	got := mouse_pos()
+	testing.expect_value(t, got.x, f32(123))
+	testing.expect_value(t, got.y, f32(456))
+	override = Mouse_Override{}
+}
+
+@(test)
+test_is_mouse_button_down_uses_override :: proc(t: ^testing.T) {
+	override = Mouse_Override{active = true, button_left = true}
+	testing.expect(t, is_mouse_button_down(.LEFT))
+	testing.expect(t, !is_mouse_button_down(.RIGHT))
+	override = Mouse_Override{}
+}
+
+@(test)
+test_pressed_clears_pending_flag :: proc(t: ^testing.T) {
+	override = Mouse_Override{active = true, pending_press_left = true}
+	testing.expect(t, is_mouse_button_pressed(.LEFT))
+	testing.expect(t, !override.pending_press_left,
+		"pending_press_left should clear after read")
+	testing.expect(t, !is_mouse_button_pressed(.LEFT),
+		"second read returns false")
+	override = Mouse_Override{}
+}
+
+@(test)
+test_released_clears_pending_flag :: proc(t: ^testing.T) {
+	override = Mouse_Override{active = true, pending_release_left = true}
+	testing.expect(t, is_mouse_button_released(.LEFT))
+	testing.expect(t, !override.pending_release_left)
+	override = Mouse_Override{}
+}

--- a/src/redin/input/text_select.odin
+++ b/src/redin/input/text_select.odin
@@ -134,14 +134,14 @@ process_text_selection :: proc(
 	}
 
 	// Phase B: drag extension while LMB is held.
-	if gesture.active_drag && rl.IsMouseButtonDown(.LEFT) {
+	if gesture.active_drag && is_mouse_button_down(.LEFT) {
 		idx := find_node_by_path(paths, gesture.anchor_path[:])
 		if idx < 0 || idx >= len(node_rects) {
 			gesture.active_drag = false
 		} else {
 			text_node, is_text := nodes[idx].(types.NodeText)
 			if is_text {
-				mouse := rl.GetMousePosition()
+				mouse := mouse_pos()
 				rect := node_rects[idx]
 				offset := node_byte_offset_at(idx, text_node, rect, mouse, theme)
 				if offset == gesture.anchor_offset {
@@ -160,7 +160,7 @@ process_text_selection :: proc(
 	}
 
 	// Phase C: mouse released — stop tracking drags.
-	if gesture.active_drag && !rl.IsMouseButtonDown(.LEFT) {
+	if gesture.active_drag && !is_mouse_button_down(.LEFT) {
 		gesture.active_drag = false
 	}
 }

--- a/src/redin/input/user_events.odin
+++ b/src/redin/input/user_events.odin
@@ -14,7 +14,7 @@ get_user_events :: proc(
 		focused_idx = -1
 	}
 
-	mouse := rl.GetMousePosition()
+	mouse := mouse_pos()
 
 	for listener in listeners {
 		if hl, ok := listener.(types.HoverListener); ok {

--- a/src/redin/render.odin
+++ b/src/redin/render.odin
@@ -437,7 +437,7 @@ render_drag_preview :: proc(
 	if a.src_idx >= len(node_rects) do return
 
 	src_rect := node_rects[a.src_idx]
-	mouse    := rl.GetMousePosition()
+	mouse    := input.mouse_pos()
 	delta    := rl.Vector2{
 		mouse.x - src_rect.x - DRAG_PREVIEW_OFFSET,
 		mouse.y - src_rect.y - DRAG_PREVIEW_OFFSET,

--- a/src/redin/runtime.odin
+++ b/src/redin/runtime.odin
@@ -204,7 +204,7 @@ run :: proc(cfg: Config) {
 
 		// --- Devserver: drain pending HTTP requests ---
 		s_ds := profile.begin(.Devserver)
-		bridge.poll_devserver(&b, &input_events)
+		bridge.poll_devserver(&b, &input_events, node_rects[:])
 		profile.end(s_ds)
 
 		// --- Bridge: all Lua-side work ---

--- a/test/ui/redin_test.bb
+++ b/test/ui/redin_test.bb
@@ -234,6 +234,34 @@
    (first (find-elements frame criteria))))
 
 ;; ---------------------------------------------------------------------------
+;; Mouse takeover (test-only — drives input.override via dev server)
+;; ---------------------------------------------------------------------------
+
+(defn input-takeover [] (post-json "/input/takeover" {}))
+(defn input-release  [] (post-json "/input/release"  {}))
+
+(defn input-mouse-move [x y]
+  (post-json "/input/mouse/move" {:x x :y y}))
+
+(defn input-mouse-down [btn]
+  (post-json "/input/mouse/down" {:button (name btn)}))
+
+(defn input-mouse-up [btn]
+  (post-json "/input/mouse/up" {:button (name btn)}))
+
+(defn input-key
+  ([k]      (post-json "/input/key" {:key (name k)}))
+  ([k mods] (post-json "/input/key" {:key (name k) :mods mods})))
+
+(defn rect-of
+  "Read the :rect attr from a frame node and return {:x :y :w :h}.
+   Returns nil if the node has no :rect (e.g. layout not yet computed)."
+  [node]
+  (when-let [r (get (frame-attrs node) :rect)]
+    (let [[x y w h] r]
+      {:x x :y y :w w :h h})))
+
+;; ---------------------------------------------------------------------------
 ;; Assertions
 ;; ---------------------------------------------------------------------------
 

--- a/test/ui/test_drag.bb
+++ b/test/ui/test_drag.bb
@@ -1,4 +1,5 @@
-(require '[redin-test :refer :all])
+(require '[redin-test :refer :all]
+         '[clojure.java.io :as io])
 
 ;; -- Frame structure --
 
@@ -88,3 +89,56 @@
   (wait-ms 200)
   (assert-state "last-drop.from" #(= % 1) "from preserved")
   (assert-state "last-drop.to"   #(= % 4) "to preserved"))
+
+;; ---------------------------------------------------------------------------
+;; End-to-end via input pipeline (real press/move/release through dev server)
+;; ---------------------------------------------------------------------------
+
+(defn- ensure-artifacts-dir []
+  (let [d (io/file "test/ui/artifacts")]
+    (when-not (.exists d) (.mkdirs d))))
+
+(deftest drag-preview-pops-out
+  (dispatch ["event/reset"])
+  (wait-ms 100)
+  (ensure-artifacts-dir)
+  (let [src (rect-of (find-element {:id :row-1}))
+        dst (rect-of (find-element {:id :row-3}))]
+    (assert src "row-1 must have a :rect from /frames")
+    (assert dst "row-3 must have a :rect from /frames")
+    (let [sx (+ (:x src) 10) sy (+ (:y src) 2)   ; y+2 stays in row top-padding, above the text node
+          dx (+ (:x dst) 10) dy (+ (:y dst) 2)]
+      (input-takeover)
+      (try
+        (input-mouse-move sx sy)
+        (input-mouse-down :left)
+        (input-mouse-move (+ sx 20) sy)           ; cross 4px threshold (stay in same row padding row)
+        (wait-for (state= "last-drag" 1) {:timeout 2000})
+        (input-mouse-move dx dy)                  ; preview now over drop target
+        (wait-ms 100)                             ; let render catch up
+        (screenshot "test/ui/artifacts/drag_preview.png")
+        (input-mouse-up :left)
+        (wait-for (state= "last-drop.from" 1) {:timeout 2000})
+        (assert-state "last-drop.to" #(= % 3) "drop target should be row-3")
+        (finally
+          (input-release))))))
+
+(deftest drag-esc-cancels
+  (dispatch ["event/reset"])
+  (wait-ms 100)
+  (let [src (rect-of (find-element {:id :row-1}))]
+    (assert src "row-1 must have a :rect from /frames")
+    (let [sx (+ (:x src) 10) sy (+ (:y src) 2)]   ; y+2 stays in row top-padding, above the text node
+      (input-takeover)
+      (try
+        (input-mouse-move sx sy)
+        (input-mouse-down :left)
+        (input-mouse-move (+ sx 20) sy)
+        (wait-for (state= "last-drag" 1) {:timeout 2000})
+        (input-key :escape)
+        (wait-ms 150)
+        (input-mouse-up :left)
+        (wait-ms 150)
+        (assert-state "last-drop" nil? "Esc should cancel the drag — no drop fires")
+        (finally
+          (input-release))))))


### PR DESCRIPTION
## Summary

Adds a mouse-takeover mechanism to the dev server so UI tests can drive the **real** input pipeline through full drag-and-drop sequences (press → threshold-cross → drop) and inject keys mid-drag. Previously, drag tests could only `dispatch` Lua-level events directly, bypassing `process_drag` entirely — a regression in the Odin-side state machine would not have been caught.

- New `input.override` state + helpers (`mouse_pos`, `is_mouse_button_down/pressed/released`); all direct raylib mouse reads in `input/`, `render`, and `bridge` now go through them.
- Dev-server endpoints: `POST /input/takeover`, `/input/release`, `/input/mouse/{move,down,up}`, `/input/key`.
- `GET /frames` embeds `"rect":[x,y,w,h]` per node so tests can resolve element coordinates.
- Babashka helpers in `redin_test.bb` (`input-takeover`, `input-mouse-move`, `rect-of`, etc.) and two new drag tests: `drag-preview-pops-out` (with mid-drag screenshot artifact) and `drag-esc-cancels`.

Bonus: the takeover tests uncovered two real framework bugs that the dispatch-only tests had been masking:
- Odin union nil/empty-struct equivalence — `case Drag_Idle:` never matched, so drag could not transition out of idle through the real input pipeline. Fixed by using `case nil, Drag_Idle:` and assigning `drag = nil` for idle transitions.
- Lua registry ref premature-free in `clear_draggable_attrs` during in-flight drag — view re-render was freeing the captured `src_ctx_ref` before the drop fired. Fixed by skipping the unref while a drag is in-flight on that ref.

Both fixes live in `16ae71d` since the new tests can't pass without them.

## Test plan

- [x] Build clean (`odin build src/cmd/redin ...`)
- [x] Fennel runtime tests pass (122/122)
- [x] Odin parser tests pass (26/26)
- [x] Odin input package tests pass (17/17, requires `-define:ODIN_TEST_THREADS=1`; documented in test header)
- [x] Full UI suite passes (`bash test/ui/run-all.sh --headless`) — includes 12 drag tests
- [x] Memory check clean under `--track-mem` for a full takeover sequence
- [x] Mid-drag screenshot artifact (`test/ui/artifacts/drag_preview.png`) visually shows the preview clone at the cursor position over the drop target

## Spec / plan

- Spec: `docs/superpowers/specs/2026-05-01-mouse-takeover-design.md` (gitignored)
- Plan: `docs/superpowers/plans/2026-05-01-mouse-takeover.md` (gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)