### PR TITLE
feat: agent channel for in-app user/agent interaction

### DIFF
--- a/.claude/skills/redin-dev/SKILL.md
+++ b/.claude/skills/redin-dev/SKILL.md
@@ -252,6 +252,18 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:$PORT/state
 | POST | /input/mouse/down | Press a button (`{"button":"left\|right\|middle"}`). Requires takeover. Returns 409 if already down. |
 | POST | /input/mouse/up | Release a button (`{"button":...}`). Requires takeover. Returns 409 if already up. |
 | POST | /input/key | Synthesise one KeyEvent (`{"key":"...", "mods"?}`). Does not require takeover. |
+| GET | /agent/nodes | List `:agent`-tagged nodes: `[{id, mode, type}, ...]` (REDIN_AGENT only). |
+| GET | /agent/content/<id> | Read node content: `{"content": <string-or-array>}` (REDIN_AGENT only). |
+| PUT | /agent/content/<id> | Write node content; node must be `:agent :edit` (REDIN_AGENT only). |
+
+### Agent channel (`REDIN_AGENT`)
+
+The agent channel is compiled in only when the binary is built with `-define:REDIN_AGENT=true`. Default release builds carry zero agent code. When the flag is set, the dev-server listener starts even without `--dev` and the `/agent/*` endpoints are active. Any node type except `:canvas` accepts an `:agent :read` or `:agent :edit` attribute (combined with `:id`) to make it addressable. Writes dispatch `:event/agent-edit {id "<id>" content <value>}` into the Fennel event queue; the runtime stores the value in `db.agent[id]` and applies overrides at view-render time. App code can also subscribe via `(subscribe [:agent <id>])`.
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
+    -define:REDIN_AGENT=true -out:build/redin
+```
 
 ## Testing
 

--- a/.claude/skills/redin-maintenance/SKILL.md
+++ b/.claude/skills/redin-maintenance/SKILL.md
@@ -135,6 +135,20 @@ If a contract was described incorrectly (not just incompletely), fix the doc eve
 | `src/redin/canvas/` | Yes | - | Yes (canvas) | - |
 | `src/cmd/redin/` (CLI flags, --track-mem) | Yes | - | - | Yes |
 
+## Agent channel build
+
+The agent channel feature is gated by `-define:REDIN_AGENT=true`. To
+run its UI test suite, build with the flag:
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
+    -define:REDIN_AGENT=true -out:build/redin
+bash test/ui/run-all.sh --headless
+```
+
+Without the flag, `test/ui/test_agent.bb` skips itself. CI runs both
+flavors via the `test:` and `test-agent:` jobs in `.github/workflows/test.yml`.
+
 ## Cutting a release
 
 Releases are built by the `release.yml` GitHub Actions workflow (manual dispatch). It builds the binary, AOT-compiles the Fennel runtime, packages docs + the `redin-dev` skill into a tarball, and creates a GitHub release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,35 @@ jobs:
           name: redin-${{ steps.version.outputs.tag }}-linux-amd64
           path: redin-${{ steps.version.outputs.tag }}-linux-amd64.tar.gz
 
+      - name: Build agent binary
+        run: |
+          rm -rf dist-agent
+          mkdir -p dist-agent
+          odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
+            -define:REDIN_AGENT=true -out:dist-agent/redin -o:speed
+
+      - name: Package agent release
+        env:
+          VERSION: ${{ steps.version.outputs.tag }}
+        run: |
+          # Mirror dist/'s structure but swap in the agent binary.
+          # Other files (runtime, lib, vendor, docs, skills, LICENSE) are
+          # identical to the default build, so we copy them from dist/
+          # rather than re-running the bundling steps.
+          cp -r dist/runtime dist-agent/
+          cp -r dist/lib dist-agent/
+          cp -r dist/vendor dist-agent/
+          cp -r dist/docs dist-agent/
+          cp -r dist/skills dist-agent/
+          [ -f dist/LICENSE ] && cp dist/LICENSE dist-agent/ || true
+          tar czf "redin-${VERSION}-agent-linux-amd64.tar.gz" -C dist-agent .
+
+      - name: Upload agent artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: redin-${{ steps.version.outputs.tag }}-agent-linux-amd64
+          path: redin-${{ steps.version.outputs.tag }}-agent-linux-amd64.tar.gz
+
   release:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,3 +37,38 @@ jobs:
         run: |
           mkdir -p build
           odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+
+  test-agent:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y luajit libssl-dev xvfb \
+            libgl1-mesa-dev libx11-dev libxrandr-dev libxi-dev \
+            libxcursor-dev libxinerama-dev
+
+      - name: Install Babashka
+        run: curl -sL https://raw.githubusercontent.com/babashka/babashka/master/install | sudo bash
+
+      - name: Install Odin
+        uses: laytan/setup-odin@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Fennel tests
+        run: luajit test/lua/runner.lua test/lua/test_*.fnl
+
+      - name: Build redin (REDIN_AGENT=true)
+        run: |
+          mkdir -p build
+          odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
+            -define:REDIN_AGENT=true -out:build/redin
+
+      - name: Run UI tests under xvfb (includes agent suite)
+        run: bash test/ui/run-all.sh --headless

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,22 @@ These docs are the source of truth. When implementing, follow them exactly.
 
 ## Building
 
+Default build:
+
 ```bash
 odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 ```
+
+With the agent channel feature:
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
+    -define:REDIN_AGENT=true -out:build/redin
+```
+
+When `REDIN_AGENT` is set, the dev-server listener starts in any run
+(not just `--dev`) and exposes the `/agent/*` endpoints. Default
+release builds carry zero agent code.
 
 ## Running
 
@@ -108,6 +121,9 @@ Available when running with `--dev`. Listens on port 8800 by default; walks upwa
 | `POST` | `/input/mouse/down` | Press a button (`{button:"left\|right\|middle"}`). Requires takeover. |
 | `POST` | `/input/mouse/up` | Release a button (`{button:...}`). Requires takeover. |
 | `POST` | `/input/key` | Synthesise one KeyEvent (`{key, mods?}`). Does not require takeover. |
+| `GET`  | `/agent/nodes` | List `:agent`-tagged nodes (REDIN_AGENT only). |
+| `GET`  | `/agent/content/<id>` | Read content (REDIN_AGENT only). |
+| `PUT`  | `/agent/content/<id>` | Write content; node must be `:agent :edit` (REDIN_AGENT only). |
 
 Example:
 

--- a/docs/core-api.md
+++ b/docs/core-api.md
@@ -606,3 +606,66 @@ polling.
 ### CORS
 
 The dev server emits no `Access-Control-*` headers and serves `OPTIONS` with a `405 Method Not Allowed`. CORS preflight is intentionally not supported: the server is for local tools (curl, Claude, IDE extensions), not browser-origin code, and admitting browser callers would weaken the same-origin protection that already comes for free with the auth-token requirement.
+
+### Agent channel (test only)
+
+The agent channel lets an external agent read and write content of redin
+nodes by `:id`. It is gated behind a compile-time flag:
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
+    -define:REDIN_AGENT=true -out:build/redin
+```
+
+Default release builds carry zero agent code. When the flag is set,
+the dev-server listener starts even without `--dev` and exposes the
+`/agent/*` endpoints.
+
+The `/frames` endpoint shape is unchanged when `REDIN_AGENT` is on.
+
+#### `:agent` attribute
+
+Any node type except `:canvas` accepts an `:agent` attribute with
+either `:read` or `:edit`. Combine with `:id` to make the node
+addressable.
+
+```fennel
+[:text  {:id :reply :agent :edit} "…"]    ;; agent writes content here
+[:input {:id :user-input :agent :read}]   ;; agent observes the live value
+```
+
+When the agent writes to an `:edit` node, the framework swaps the
+node's content for the agent's value at view-render time. App authors
+can also subscribe via `(subscribe [:agent <id>])`.
+
+Per-node-type semantics:
+
+| Tag | `:read` returns | `:edit` accepts |
+|---|---|---|
+| `:text` | text string | string → replaces text |
+| `:input` | current value (live) | string → sets value |
+| `:button` | label string | string → sets label |
+| `:image` | source path | string → sets source |
+| `:vbox` `:hbox` `:stack` `:popout` `:modal` | children list as JSON array | JSON array → replaces children |
+
+#### Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/agent/nodes` | List all `:agent`-tagged nodes: `[{id, mode, type}, ...]`. |
+| `GET` | `/agent/content/<id>` | Returns `{"content": <string-or-array>}`. 404 if id missing. |
+| `PUT` | `/agent/content/<id>` | Body: `{"content": <string-or-array>}`. Dispatches `:event/agent-edit`. 404/403/400 on the respective error paths. |
+
+Example (write a markdown reply):
+
+```bash
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -H "Authorization: Bearer $TOKEN" \
+     -X PUT -d '{"content":"**Answer:** 4"}' \
+     http://localhost:$PORT/agent/content/reply
+```
+
+The framework dispatches `:event/agent-edit {id "reply" content "**Answer:** 4"}`,
+the Fennel handler stores it in `db.agent.reply`, and the next render
+shows it in the `:reply` text node. Markdown rendering is tracked in
+issue #100.

--- a/docs/reference/dev-server.md
+++ b/docs/reference/dev-server.md
@@ -234,6 +234,54 @@ curl -sH "$H" -X POST http://localhost:$PORT/input/release
 
 ---
 
+## Agent channel (REDIN_AGENT only)
+
+These endpoints are compiled in only when the binary is built with
+`-define:REDIN_AGENT=true`. Without that flag the routes return 404.
+When the flag is set, the dev-server listener starts even without
+`--dev`.
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
+    -define:REDIN_AGENT=true -out:build/redin
+```
+
+### `GET /agent/nodes` -- list agent-tagged nodes
+
+```bash
+curl -H "$AUTH" http://localhost:$PORT/agent/nodes
+```
+
+Response: JSON array of `{id, mode, type}` objects for every node
+whose attributes include both `:agent` (`:read` or `:edit`) and `:id`.
+Canvas nodes are silently excluded.
+
+### `GET /agent/content/<id>` -- read node content
+
+```bash
+curl -H "$AUTH" http://localhost:$PORT/agent/content/reply
+```
+
+Response: `{"content": <string-or-array>}`. Returns `404` if no
+agent-tagged node with the given id exists in the last pushed frame.
+
+### `PUT /agent/content/<id>` -- write node content
+
+Body: `{"content": <string-or-array>}`.
+
+```bash
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -H "Authorization: Bearer $TOKEN" \
+     -X PUT -d '{"content":"**Answer:** 4"}' \
+     http://localhost:$PORT/agent/content/reply
+```
+
+Response: `{"ok": true}`. Dispatches `:event/agent-edit {id "<id>" content <value>}` into the Fennel event queue. The framework stores the value in `db.agent[id]`; the next render swaps the node's content with the stored value.
+
+Error codes: `404` — id not found; `403` — node is `:agent :read` (not editable); `400` — malformed body.
+
+---
+
 ## Not implemented
 
 The following endpoints from the previous design are **not** present:

--- a/docs/reference/elements.md
+++ b/docs/reference/elements.md
@@ -88,6 +88,7 @@ Renders a string of text. The text content is the last positional argument, not 
 | --------- | ---- | ------- | ----- |
 | `wrap` | `"word"` \| `"char"` \| `"none"` | `"word"` | Line-wrapping strategy. |
 | `selectable` | boolean | `true` | Set to `false` to opt the node out of mouse-selection. |
+| `:agent` | `:read \| :edit` | -- | Optional. Pairs with `:id` to expose the node to the agent channel (REDIN_AGENT only). |
 
 Typography (`font-size`, `weight`, `color`) comes from `aspect`.
 
@@ -110,6 +111,7 @@ Renders a texture loaded from a file path.
 | Attribute | Type | Default | Notes |
 | --------- | ---- | ------- | ----- |
 | `src` | string | -- | File path to the image. **Required.** |
+| `:agent` | `:read \| :edit` | -- | Optional. Pairs with `:id` to expose the node to the agent channel (REDIN_AGENT only). |
 
 ```fennel
 [:image {:src "assets/logo.png" :width 120 :height 40}]
@@ -131,6 +133,7 @@ An editable text field. Drives its displayed value from the `value` attribute.
 | `change` | keyword | -- | Event dispatched when the value changes. |
 | `key` | keyword | -- | Event dispatched on key press (e.g. enter). |
 | `placeholder` | string | `""` | Hint text shown when value is empty. |
+| `:agent` | `:read \| :edit` | -- | Optional. Pairs with `:id` to expose the node to the agent channel (REDIN_AGENT only). |
 
 Visual properties (`bg`, `color`, `border`, `radius`, `border-width`, `opacity`) come from `aspect`.
 
@@ -156,6 +159,7 @@ A clickable element with a text label. Dispatches an event on click.
 | `click` | keyword | -- | Event dispatched on click. **Required.** |
 | `label` | string | -- | Button text. Can also be passed as a child string. |
 | `drag-handle` | bool | `false` | Marks this button as a grab surface for the nearest `:draggable` ancestor. Mutually exclusive with `click` — if both set, parser warns and drops `click`. |
+| `:agent` | `:read \| :edit` | -- | Optional. Pairs with `:id` to expose the node to the agent channel (REDIN_AGENT only). |
 
 Visual properties come from `aspect`.
 
@@ -178,6 +182,7 @@ An independent render region managed by a registered canvas provider. The provid
 | Attribute | Type | Default | Notes |
 | --------- | ---- | ------- | ----- |
 | `provider` | keyword | -- | Name of a registered canvas provider. **Required.** |
+| `:agent` | (rejected) | -- | Not supported on `:canvas` — silently ignored at parse time. |
 
 The element's `width` and `height` define the render texture size. See the [canvas provider docs](canvas.md) for registration and lifecycle details.
 
@@ -204,6 +209,7 @@ All children receive the full available space and overlap. Use for layering (e.g
 | Attribute | Type | Default | Notes |
 | --------- | ---- | ------- | ----- |
 | `viewport` | `[[x y w h] ...]` | -- | Array of rects, one per child. Positions children absolutely relative to the window. |
+| `:agent` | `:read \| :edit` | -- | Optional. Pairs with `:id` to expose the node to the agent channel (REDIN_AGENT only). |
 
 Each viewport value can be:
 - **px number** -- fixed pixels (e.g. `42`, `250`)
@@ -241,6 +247,7 @@ Lays out children in a horizontal row, left to right.
 | `overflow` | `"scroll-x"` | -- | Clip + horizontal wheel scroll. Children must set `:width`. See Scrolling. |
 | `layout` | anchor keyword (see below) | `"top_left"` | Child alignment along both axes. |
 | `drag-handle` | bool | `false` | Marks this hbox as a grab surface for the nearest `:draggable` ancestor. |
+| `:agent` | `:read \| :edit` | -- | Optional. Pairs with `:id` to expose the node to the agent channel (REDIN_AGENT only). |
 
 `:layout` takes one of nine two-axis anchors: `top_left`, `top_center`, `top_right`, `center_left`, `center`, `center_right`, `bottom_left`, `bottom_center`, `bottom_right`. For an hbox the horizontal component selects where the children *group* sits on the main axis; the vertical component selects how each child is aligned on the cross axis. For a vbox the roles swap. Unrecognized values log a warning and fall back to `top_left`.
 
@@ -260,7 +267,7 @@ Lays out children in a vertical column, top to bottom.
 
 **Required attrs:** none
 
-**Optional attrs:** identical to `hbox` (including `drag-handle`). `overflow` is `"scroll-y"` (see Scrolling).
+**Optional attrs:** identical to `hbox` (including `drag-handle` and `:agent`). `overflow` is `"scroll-y"` (see Scrolling).
 
 For a vbox, the horizontal component of `:layout` aligns each child across the row (cross axis), and the vertical component positions the children group within the container's height (main axis).
 
@@ -279,7 +286,12 @@ For a vbox, the horizontal component of `:layout` aligns each child across the r
 A full-screen overlay that blocks all interaction with content behind it.
 
 **Required attrs:** none
-**Optional attrs:** none beyond the common set.
+
+**Optional attrs:**
+
+| Attribute | Type | Default | Notes |
+| --------- | ---- | ------- | ----- |
+| `:agent` | `:read \| :edit` | -- | Optional. Pairs with `:id` to expose the node to the agent channel (REDIN_AGENT only). |
 
 Background color and opacity come from `aspect`.
 
@@ -312,6 +324,7 @@ A container anchored to its parent that escapes parent clipping. Rendered in the
 | `mode` | `"mouse"` \| `"fixed"` | `"mouse"` | Positioning mode. |
 | `x` | number | -- | Fixed x position (when mode is `"fixed"`). |
 | `y` | number | -- | Fixed y position (when mode is `"fixed"`). |
+| `:agent` | `:read \| :edit` | -- | Optional. Pairs with `:id` to expose the node to the agent channel (REDIN_AGENT only). |
 
 Visual properties come from `aspect`.
 

--- a/examples/ai-chat.fnl
+++ b/examples/ai-chat.fnl
@@ -1,0 +1,39 @@
+;; AI chat example -- requires a build with -define:REDIN_AGENT=true.
+;;
+;; The :reply text is :agent :edit -- the agent posts content via
+;;   PUT /agent/content/reply
+;; and it appears here.
+;;
+;; The :user-input is :agent :read -- the agent polls
+;;   GET /agent/content/user-input
+;; to see what the user is currently typing.
+;;
+;; Markdown rendering for the reply is tracked in issue #100.
+
+(local dataflow (require :dataflow))
+(local theme    (require :theme))
+
+(theme.set-theme
+  {:surface       {:bg [30 33 42] :padding [16 16 16 16]}
+   :user-bubble   {:bg [60 80 110] :color [240 240 240]
+                   :padding [8 12 8 12] :radius 6}
+   :agent-bubble  {:bg [40 50 60]  :color [220 230 240]
+                   :padding [8 12 8 12] :radius 6}
+   :user-input    {:bg [25 28 35] :color [240 240 240]
+                   :padding [8 8 8 8] :radius 4}})
+
+(dataflow.init {:typed ""})
+
+(reg-handler :event/typed     (fn [db ev] (let [ctx (. ev 2)] (assoc db :typed (or ctx.value "")))))
+(reg-handler :event/submitted (fn [db _]  (assoc db :typed "")))
+
+(reg-sub :sub/typed (fn [db] (get db :typed "")))
+
+(fn _G.main_view []
+  [:vbox {:aspect :surface :width :full :height :full}
+    [:text  {:id :reply :agent :edit :aspect :agent-bubble} "…"]
+    [:input {:id :user-input :agent :read :aspect :user-input
+             :value (subscribe :sub/typed)
+             :change :event/typed
+             :submit :event/submitted}
+            ""]])

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -1,5 +1,11 @@
 package bridge
 
+// Compile-time flag enabling the agent channel feature. Default is false;
+// set with `odin build ... -define:REDIN_AGENT=true`. When false, the
+// agent endpoints, walker, and listener-gate widening all compile out
+// to zero bytes.
+REDIN_AGENT :: #config(REDIN_AGENT, false)
+
 import "core:fmt"
 import "core:math"
 import "core:os"

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -86,15 +86,27 @@ init :: proc(b: ^Bridge, dev_mode: bool) {
 	load_fennel(b.L)
 	load_runtime(b.L)
 
+	needs_listener := dev_mode
+	when REDIN_AGENT {
+		needs_listener = true
+	}
+	if needs_listener {
+		devserver_init(&b.dev_server, b)
+	}
 	if dev_mode {
 		hotreload_init(&b.hot_reload)
-		devserver_init(&b.dev_server, b)
 	}
 }
 
 destroy :: proc(b: ^Bridge) {
-	if b.dev_mode {
+	needs_listener := b.dev_mode
+	when REDIN_AGENT {
+		needs_listener = true
+	}
+	if needs_listener {
 		devserver_destroy(&b.dev_server)
+	}
+	if b.dev_mode {
 		hotreload_destroy(&b.hot_reload)
 	}
 	http_client_destroy(&b.http_client)
@@ -108,7 +120,11 @@ destroy :: proc(b: ^Bridge) {
 }
 
 poll_devserver :: proc(b: ^Bridge, events: ^[dynamic]types.InputEvent, node_rects: []rl.Rectangle) {
-	if !b.dev_mode do return
+	needs_poll := b.dev_mode
+	when REDIN_AGENT {
+		needs_poll = true
+	}
+	if !needs_poll do return
 	b.dev_server.current_rects = node_rects
 	devserver_poll(&b.dev_server)
 	devserver_drain_events(&b.dev_server, events)
@@ -116,7 +132,11 @@ poll_devserver :: proc(b: ^Bridge, events: ^[dynamic]types.InputEvent, node_rect
 }
 
 is_shutdown_requested :: proc(b: ^Bridge) -> bool {
-	return b.dev_mode && b.dev_server.shutdown_requested
+	needs_listener := b.dev_mode
+	when REDIN_AGENT {
+		needs_listener = true
+	}
+	return needs_listener && b.dev_server.shutdown_requested
 }
 
 check_hotreload :: proc(b: ^Bridge) {

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -630,6 +630,12 @@ process_request :: proc(ds: ^Dev_Server, req: ^Pending_Request) {
 			respond_text(ch, 404, "Not found")
 		}
 	case "PUT":
+		when REDIN_AGENT {
+			if strings.has_prefix(req.path, "/agent/content/") {
+				handle_put_agent_content(ds, ch, req.path[len("/agent/content/"):], req.body)
+				return
+			}
+		}
 		if req.path == "/aspects" {
 			handle_put_aspects(ds, ch, req.body)
 		} else {
@@ -1024,6 +1030,151 @@ handle_get_agent_content :: proc(ds: ^Dev_Server, ch: ^Response_Channel, id: str
 	defer strings.builder_destroy(&b)
 	emit_agent_content(&b, L, tag)
 	respond_json(ch, strings.to_string(b))
+}
+
+handle_put_agent_content :: proc(ds: ^Dev_Server, ch: ^Response_Channel, id: string, body: string) {
+	L := ds.bridge.L
+
+	// 1. Decode body. Expect {"content": <string-or-array>}.
+	pos := 0
+	if !json_decode_value(L, body, &pos) {
+		respond_json_error(ch, 400, `{"error":"invalid JSON"}`)
+		return
+	}
+	// Stack: [body_parent]
+	if !lua_istable(L, -1) {
+		lua_pop(L, 1)
+		respond_json_error(ch, 400, `{"error":"body must be an object with content"}`)
+		return
+	}
+	lua_getfield(L, -1, "content")
+	// Stack: [body_parent, content]
+	if lua_isnil(L, -1) {
+		lua_pop(L, 1) // content (nil)
+		lua_pop(L, 1) // body_parent
+		respond_json_error(ch, 400, `{"error":"missing content field"}`)
+		return
+	}
+	body_idx := lua_gettop(L) // absolute index of content field
+	// Stack: [body_parent, content]  (body_idx == absolute index of content)
+
+	// 2. Find target node and validate — get last-push frame.
+	lua_getglobal(L, "require")
+	lua_pushstring(L, "view")
+	if lua_pcall(L, 1, 1, 0) != 0 {
+		lua_pop(L, 1) // error msg
+		lua_pop(L, 1) // content
+		lua_pop(L, 1) // body_parent
+		respond_json_error(ch, 500, `{"error":"lua error"}`)
+		return
+	}
+	lua_getfield(L, -1, "get-last-push")
+	lua_remove(L, -2) // remove view module, keep get-last-push fn
+	if lua_pcall(L, 0, 1, 0) != 0 {
+		lua_pop(L, 1) // error msg
+		lua_pop(L, 1) // content
+		lua_pop(L, 1) // body_parent
+		respond_json_error(ch, 500, `{"error":"lua error"}`)
+		return
+	}
+	// Stack: [body_parent, content, last_push]
+	last_push_idx := lua_gettop(L)
+
+	if !agent_find_by_id(L, last_push_idx, id) {
+		lua_pop(L, 1) // last_push
+		lua_pop(L, 1) // content
+		lua_pop(L, 1) // body_parent
+		respond_json_error(ch, 404, `{"error":"id not found"}`)
+		return
+	}
+	// Stack: [body_parent, content, last_push, found_node]
+
+	// 3. Read mode + tag from the found node.
+	tag := agent_node_tag(L)
+	mode := agent_node_attr_string(L, "agent")
+	if mode != "edit" && mode != ":edit" {
+		lua_pop(L, 1) // found node
+		lua_pop(L, 1) // last_push
+		lua_pop(L, 1) // content
+		lua_pop(L, 1) // body_parent
+		respond_json_error(ch, 403, `{"error":"node is not :agent :edit"}`)
+		return
+	}
+
+	// 4. Validate body shape against tag.
+	is_container := tag == "vbox" || tag == "hbox" || tag == "stack" ||
+	                tag == "popout" || tag == "modal"
+	body_is_table  := lua_istable(L, body_idx)
+	body_is_string := lua_isstring(L, body_idx)
+	if is_container {
+		if !body_is_table {
+			lua_pop(L, 1) // found node
+			lua_pop(L, 1) // last_push
+			lua_pop(L, 1) // content
+			lua_pop(L, 1) // body_parent
+			respond_json_error(ch, 400, `{"error":"container content must be an array"}`)
+			return
+		}
+	} else {
+		if !body_is_string {
+			lua_pop(L, 1) // found node
+			lua_pop(L, 1) // last_push
+			lua_pop(L, 1) // content
+			lua_pop(L, 1) // body_parent
+			respond_json_error(ch, 400, `{"error":"leaf content must be a string"}`)
+			return
+		}
+	}
+
+	// 5. Done with found_node and last_push.
+	lua_pop(L, 1) // found_node
+	lua_pop(L, 1) // last_push
+	// Stack: [body_parent, content]
+
+	// 6. Build and dispatch [:event/agent-edit {:id id :content <content>}].
+	lua_getglobal(L, "require")
+	lua_pushstring(L, "dataflow")
+	if lua_pcall(L, 1, 1, 0) != 0 {
+		lua_pop(L, 1) // error msg
+		lua_pop(L, 1) // content
+		lua_pop(L, 1) // body_parent
+		respond_json_error(ch, 500, `{"error":"lua error: dataflow"}`)
+		return
+	}
+	// Stack: [body_parent, content, dataflow]
+	lua_getfield(L, -1, "dispatch")
+	lua_remove(L, -2) // remove dataflow module, keep dispatch fn
+	// Stack: [body_parent, content, dispatch_fn]
+
+	// Build the event vector [event-name, payload-table] as a Lua table.
+	lua_createtable(L, 2, 0)
+	ev_idx := lua_gettop(L)
+	// Stack: [body_parent, content, dispatch_fn, ev_table]
+	lua_pushstring(L, "event/agent-edit")
+	lua_rawseti(L, ev_idx, 1)
+
+	lua_createtable(L, 0, 2)
+	payload_idx := lua_gettop(L)
+	// Stack: [body_parent, content, dispatch_fn, ev_table, payload_table]
+	lua_pushlstring(L, cstring(raw_data(id)), uint(len(id)))
+	lua_setfield(L, payload_idx, "id")
+	lua_pushvalue(L, body_idx) // copy of decoded content
+	lua_setfield(L, payload_idx, "content")
+	lua_rawseti(L, ev_idx, 2) // payload into ev_table[2]; pops payload_table
+	// Stack: [body_parent, content, dispatch_fn, ev_table]
+
+	// dispatch(ev_table) — pcall pops dispatch_fn + ev_table (1 arg), pushes 0 results on success.
+	if lua_pcall(L, 1, 0, 0) != 0 {
+		lua_pop(L, 1) // error msg
+		lua_pop(L, 1) // content
+		lua_pop(L, 1) // body_parent
+		respond_json_error(ch, 500, `{"error":"dispatch failed"}`)
+		return
+	}
+	// Stack: [body_parent, content]
+	lua_pop(L, 1) // content
+	lua_pop(L, 1) // body_parent
+	respond_json_ok(ch)
 }
 
 } // when REDIN_AGENT

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -569,6 +569,12 @@ process_request :: proc(ds: ^Dev_Server, req: ^Pending_Request) {
 	ch := req.response
 	switch req.method {
 	case "GET":
+		when REDIN_AGENT {
+			if req.path == "/agent/nodes" {
+				handle_get_agent_nodes(ds, ch)
+				return
+			}
+		}
 		if req.path == "/frames" {
 			handle_get_frames(ds, ch)
 		} else if req.path == "/state" {
@@ -791,6 +797,91 @@ frame_value_to_json :: proc(
 	}
 	strings.write_string(b, "]")
 }
+
+when REDIN_AGENT {
+
+// Walks a Fennel-shaped frame tree DFS and emits a JSON array of
+// {id, mode, type} for every node whose attrs include both :agent and :id.
+// Skips :canvas tag.
+agent_nodes_walker :: proc(b: ^strings.Builder, L: ^Lua_State, index: i32, first: ^bool) {
+	idx := index < 0 ? lua_gettop(L) + index + 1 : index
+	if !lua_istable(L, idx) do return
+
+	// Detect frame node: [tag-string, attrs-table, ...children]
+	lua_rawgeti(L, idx, 1)
+	is_node := lua_isstring(L, -1)
+	tag := ""
+	if is_node {
+		tag = string(lua_tostring_raw(L, -1))
+		if len(tag) == 0 do is_node = false
+	}
+	lua_pop(L, 1)
+	if !is_node do return
+
+	// attrs at slot 2
+	lua_rawgeti(L, idx, 2)
+	if lua_istable(L, -1) {
+		attrs_idx := lua_gettop(L)
+		// :agent
+		lua_getfield(L, attrs_idx, "agent")
+		mode := ""
+		if lua_isstring(L, -1) {
+			s := string(lua_tostring_raw(L, -1))
+			if s == "read" || s == ":read" do mode = "read"
+			if s == "edit" || s == ":edit" do mode = "edit"
+		}
+		lua_pop(L, 1)
+		// :id
+		lua_getfield(L, attrs_idx, "id")
+		id := ""
+		if lua_isstring(L, -1) {
+			id = string(lua_tostring_raw(L, -1))
+		}
+		lua_pop(L, 1)
+		if len(mode) > 0 && len(id) > 0 && tag != "canvas" {
+			if !first^ do strings.write_string(b, ",")
+			first^ = false
+			fmt.sbprintf(b, `{{"id":"%s","mode":"%s","type":"%s"}}`, id, mode, tag)
+		}
+	}
+	lua_pop(L, 1)
+
+	// Recurse into children at slots 3..n
+	n := lua_objlen(L, idx)
+	for i in 3..=n {
+		lua_rawgeti(L, idx, i32(i))
+		agent_nodes_walker(b, L, -1, first)
+		lua_pop(L, 1)
+	}
+}
+
+handle_get_agent_nodes :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
+	L := ds.bridge.L
+	lua_getglobal(L, "require")
+	lua_pushstring(L, "view")
+	if lua_pcall(L, 1, 1, 0) != 0 {
+		lua_pop(L, 1)
+		respond_json_error(ch, 500, `{"error":"lua error"}`)
+		return
+	}
+	lua_getfield(L, -1, "get-last-push")
+	lua_remove(L, -2)
+	if lua_pcall(L, 0, 1, 0) != 0 {
+		lua_pop(L, 1)
+		respond_json_error(ch, 500, `{"error":"lua error"}`)
+		return
+	}
+	b := strings.builder_make()
+	defer strings.builder_destroy(&b)
+	strings.write_string(&b, "[")
+	first := true
+	agent_nodes_walker(&b, L, -1, &first)
+	strings.write_string(&b, "]")
+	lua_pop(L, 1)
+	respond_json(ch, strings.to_string(b))
+}
+
+} // when REDIN_AGENT
 
 handle_get_state :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
 	L := ds.bridge.L

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -574,6 +574,10 @@ process_request :: proc(ds: ^Dev_Server, req: ^Pending_Request) {
 				handle_get_agent_nodes(ds, ch)
 				return
 			}
+			if strings.has_prefix(req.path, "/agent/content/") {
+				handle_get_agent_content(ds, ch, req.path[len("/agent/content/"):])
+				return
+			}
 		}
 		if req.path == "/frames" {
 			handle_get_frames(ds, ch)
@@ -878,6 +882,147 @@ handle_get_agent_nodes :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
 	agent_nodes_walker(&b, L, -1, &first)
 	strings.write_string(&b, "]")
 	lua_pop(L, 1)
+	respond_json(ch, strings.to_string(b))
+}
+
+// Walk the frame tree, push the matching [tag attrs ...children] table
+// onto the Lua stack at -1 if found and return true. Otherwise leaves
+// the stack unchanged and returns false. Caller must lua_pop(L, 1) on success.
+agent_find_by_id :: proc(L: ^Lua_State, index: i32, target_id: string) -> bool {
+	idx := index < 0 ? lua_gettop(L) + index + 1 : index
+	if !lua_istable(L, idx) do return false
+
+	// Inspect tag and id attr.
+	lua_rawgeti(L, idx, 1)
+	is_node := lua_isstring(L, -1)
+	lua_pop(L, 1)
+	if is_node {
+		lua_rawgeti(L, idx, 2)
+		if lua_istable(L, -1) {
+			lua_getfield(L, -1, "id")
+			id := ""
+			if lua_isstring(L, -1) do id = string(lua_tostring_raw(L, -1))
+			lua_pop(L, 1)
+			lua_pop(L, 1) // attrs
+			if id == target_id {
+				lua_pushvalue(L, idx)
+				return true
+			}
+		} else {
+			lua_pop(L, 1)
+		}
+	}
+
+	// Recurse into children.
+	n := lua_objlen(L, idx)
+	for i in 3..=n {
+		lua_rawgeti(L, idx, i32(i))
+		if agent_find_by_id(L, -1, target_id) {
+			// Move the found node up by 1 (replacing the child we pushed).
+			lua_remove(L, -2)
+			return true
+		}
+		lua_pop(L, 1)
+	}
+	return false
+}
+
+// Reads attr field from a node table at -1 and returns its string value.
+// Returns a temp-allocator slice -- valid only for the current frame.
+agent_node_attr_string :: proc(L: ^Lua_State, attr: cstring) -> string {
+	if !lua_istable(L, -1) do return ""
+	lua_rawgeti(L, -1, 2)
+	defer lua_pop(L, 1)
+	if !lua_istable(L, -1) do return ""
+	lua_getfield(L, -1, attr)
+	defer lua_pop(L, 1)
+	if !lua_isstring(L, -1) do return ""
+	return strings.clone(string(lua_tostring_raw(L, -1)), context.temp_allocator)
+}
+
+agent_node_tag :: proc(L: ^Lua_State) -> string {
+	if !lua_istable(L, -1) do return ""
+	lua_rawgeti(L, -1, 1)
+	defer lua_pop(L, 1)
+	if !lua_isstring(L, -1) do return ""
+	return strings.clone(string(lua_tostring_raw(L, -1)), context.temp_allocator)
+}
+
+agent_escape_json :: proc(s: string) -> string {
+	b := strings.builder_make(context.temp_allocator)
+	for r in s {
+		switch r {
+		case '"':  strings.write_string(&b, `\"`)
+		case '\\': strings.write_string(&b, `\\`)
+		case '\n': strings.write_string(&b, `\n`)
+		case '\t': strings.write_string(&b, `\t`)
+		case:      strings.write_rune(&b, r)
+		}
+	}
+	return strings.to_string(b)
+}
+
+// Emits {"content": ...} JSON for the node at -1 based on its tag.
+emit_agent_content :: proc(b: ^strings.Builder, L: ^Lua_State, tag: string) {
+	strings.write_string(b, `{"content":`)
+	switch tag {
+	case "input":
+		val := agent_node_attr_string(L, "value")
+		fmt.sbprintf(b, `"%s"`, agent_escape_json(val))
+	case "image":
+		val := agent_node_attr_string(L, "src")
+		fmt.sbprintf(b, `"%s"`, agent_escape_json(val))
+	case "vbox", "hbox", "stack", "popout", "modal":
+		strings.write_string(b, "[")
+		n := lua_objlen(L, -1)
+		first := true
+		for i in 3..=n {
+			lua_rawgeti(L, -1, i32(i))
+			if !first do strings.write_string(b, ",")
+			first = false
+			lua_value_to_json(b, L, -1)
+			lua_pop(L, 1)
+		}
+		strings.write_string(b, "]")
+	case:
+		// Default: leaf-text-like (text, button). Content is slot [3].
+		lua_rawgeti(L, -1, 3)
+		val := ""
+		if lua_isstring(L, -1) do val = string(lua_tostring_raw(L, -1))
+		lua_pop(L, 1)
+		fmt.sbprintf(b, `"%s"`, agent_escape_json(val))
+	}
+	strings.write_string(b, "}")
+}
+
+handle_get_agent_content :: proc(ds: ^Dev_Server, ch: ^Response_Channel, id: string) {
+	L := ds.bridge.L
+	lua_getglobal(L, "require")
+	lua_pushstring(L, "view")
+	if lua_pcall(L, 1, 1, 0) != 0 {
+		lua_pop(L, 1)
+		respond_json_error(ch, 500, `{"error":"lua error"}`)
+		return
+	}
+	lua_getfield(L, -1, "get-last-push")
+	lua_remove(L, -2)
+	if lua_pcall(L, 0, 1, 0) != 0 {
+		lua_pop(L, 1)
+		respond_json_error(ch, 500, `{"error":"lua error"}`)
+		return
+	}
+	defer lua_pop(L, 1) // last-push table
+
+	if !agent_find_by_id(L, -1, id) {
+		respond_json_error(ch, 404, `{"error":"id not found"}`)
+		return
+	}
+	defer lua_pop(L, 1) // found node
+
+	tag := agent_node_tag(L)
+	b := strings.builder_make()
+	defer strings.builder_destroy(&b)
+	emit_agent_content(&b, L, tag)
 	respond_json(ch, strings.to_string(b))
 }
 

--- a/src/runtime/agent.fnl
+++ b/src/runtime/agent.fnl
@@ -1,0 +1,81 @@
+;; agent.fnl -- Agent channel runtime.
+;;
+;; Stores agent-written content in db.agent[id]. Walks the view-fn's
+;; output before flattening to swap content of any node tagged
+;; `:agent :edit` (with an `:id`) for the value in db.agent[id], if
+;; present. `:agent :read` is observe-only -- no override applied.
+
+(local dataflow (require :dataflow))
+
+(local M {})
+
+(local content-attrs
+  ;; For these node tags, agent content goes into a specific attr.
+  {:input :value :image :src})
+
+(local container-tags
+  {:vbox true :hbox true :stack true :popout true :modal true})
+
+;; Detect a frame-node table: slot 1 is a non-empty string and slot 2 is a table.
+(fn vector? [v]
+  (and (= (type v) :table)
+       (= (type (. v 1)) :string)
+       (> (length (. v 1)) 0)
+       (= (type (. v 2)) :table)))
+
+(fn handle-edit [db ev]
+  (let [payload (. ev 2)
+        id (. payload :id)
+        content (. payload :content)]
+    (dataflow.assoc-in db [:agent id] content)))
+
+(fn M.install []
+  (dataflow.reg-handler :event/agent-edit handle-edit))
+
+(fn override-node [node db]
+  (when (vector? node)
+    (let [tag (. node 1)
+          attrs (. node 2)
+          id (. attrs :id)
+          mode (. attrs :agent)
+          override (and id (. (or (. db :agent) {}) id))]
+      (if (or (not id) (not= mode :edit) (= override nil))
+          node
+          (if (. content-attrs tag)
+              ;; Swap the named attr (value/src).
+              (let [k (. content-attrs tag)
+                    new-attrs (collect [ak av (pairs attrs)] ak av)
+                    out (icollect [_ v (ipairs node)] v)]
+                (tset new-attrs k override)
+                (tset out 2 new-attrs)
+                out)
+              (. container-tags tag)
+              ;; Replace children: keep [tag attrs], then splice override (a list).
+              (let [head [tag attrs]]
+                (each [_ child (ipairs override)]
+                  (table.insert head child))
+                head)
+              ;; Default: leaf text-like node, swap slot 3.
+              (let [out (icollect [_ v (ipairs node)] v)]
+                (tset out 3 override)
+                out))))))
+
+;; Recursively apply overrides to a frame tree.
+(fn walk [node db]
+  (if (vector? node)
+      (let [overridden (or (override-node node db) node)
+            out [(. overridden 1) (. overridden 2)]]
+        (for [i 3 (length overridden)]
+          (let [child (. overridden i)]
+            (table.insert out
+              (if (vector? child)
+                  (walk child db)
+                  child))))
+        out)
+      node))
+
+(fn M.apply-overrides [tree]
+  (let [db (or (dataflow.get-state) {})]
+    (walk tree db)))
+
+M

--- a/src/runtime/dataflow.fnl
+++ b/src/runtime/dataflow.fnl
@@ -219,6 +219,8 @@
   (tset _G "__fnl_global__reg_2dhandler" M.reg-handler)
   (tset _G "__fnl_global__reg_2dsub" M.reg-sub))
 
+(fn M.get-state [] raw-db)
+
 (fn M._get-changed-paths [] changed-paths)
 (fn M._get-raw-db [] raw-db)
 

--- a/src/runtime/init.fnl
+++ b/src/runtime/init.fnl
@@ -16,6 +16,9 @@
 ;; Wire effect handler: dataflow dispatch -> effect execute
 (dataflow.set-effect-handler effect.execute)
 
+;; Install agent event handler
+((. (require :agent) :install))
+
 ;; Bridge-facing globals (called by Odin host each frame)
 (set _G.redin_render_tick view.render-tick)
 (set _G.redin_events view.deliver-events)

--- a/src/runtime/view.fnl
+++ b/src/runtime/view.fnl
@@ -16,7 +16,8 @@
     (dataflow.flush)
     (let [view-fn _G.main_view]
       (when view-fn
-        (let [result (view-fn)]
+        (let [result (view-fn)
+              result (let [agent (require :agent)] (agent.apply-overrides result))]
           (when result
             (let [flattened (frame.flatten result)]
               (set last-push flattened)

--- a/test/lua/test_agent.fnl
+++ b/test/lua/test_agent.fnl
@@ -1,0 +1,60 @@
+(local dataflow (require :dataflow))
+(local agent    (require :agent))
+
+(local t {})
+
+(fn t.test-handler-stores-content []
+  (dataflow.init {})
+  (agent.install)
+  (dataflow.dispatch [:event/agent-edit {:id :reply :content "hello"}])
+  (dataflow.flush)
+  (assert (= "hello" (. (dataflow.get-state) :agent :reply))
+          "agent.reply should be 'hello' after :event/agent-edit"))
+
+(fn t.test-apply-overrides-text []
+  (dataflow.init {:agent {:reply "actual"}})
+  (let [tree [:text {:id :reply :agent :edit} "..."]
+        out  (agent.apply-overrides tree)]
+    (assert (= "actual" (. out 3))
+            "text content should be replaced when db.agent.reply present")))
+
+(fn t.test-apply-overrides-falls-through []
+  (dataflow.init {})
+  (let [tree [:text {:id :reply :agent :edit} "fallback"]
+        out  (agent.apply-overrides tree)]
+    (assert (= "fallback" (. out 3))
+            "text content should fall through when db.agent.reply missing")))
+
+(fn t.test-apply-overrides-input-value []
+  (dataflow.init {:agent {:user-input "typed"}})
+  (let [tree [:input {:id :user-input :agent :edit :value "x"}]
+        out  (agent.apply-overrides tree)
+        attrs (. out 2)]
+    (assert (= "typed" (. attrs :value))
+            "input :value should be replaced when db.agent.user-input present")))
+
+(fn t.test-apply-overrides-container-children []
+  (dataflow.init {:agent {:cards [[:text {} "from agent"]]}})
+  (let [tree [:vbox {:id :cards :agent :edit}
+                [:text {} "literal child"]]
+        out  (agent.apply-overrides tree)]
+    (assert (= "from agent" (. (. out 3) 3))
+            "vbox children should be replaced when db.agent.cards present")))
+
+(fn t.test-apply-overrides-recurses []
+  (dataflow.init {:agent {:reply "deep"}})
+  (let [tree [:vbox {}
+                [:text {:id :reply :agent :edit} "..."]]
+        out  (agent.apply-overrides tree)
+        text-node (. out 3)]
+    (assert (= "deep" (. text-node 3))
+            "deeply-nested :agent :edit text should be overridden")))
+
+(fn t.test-read-mode-no-override []
+  (dataflow.init {:agent {:reply "ignored"}})
+  (let [tree [:text {:id :reply :agent :read} "literal"]
+        out  (agent.apply-overrides tree)]
+    (assert (= "literal" (. out 3))
+            ":agent :read must not override content")))
+
+t

--- a/test/ui/agent_app.fnl
+++ b/test/ui/agent_app.fnl
@@ -1,0 +1,21 @@
+;; UI test fixture for /agent/* endpoints. Built for the test_agent.bb
+;; suite. Needs the binary to be built with -define:REDIN_AGENT=true;
+;; otherwise the test runner skips itself.
+
+(local dataflow (require :dataflow))
+
+(dataflow.init {:typed ""})
+
+(reg-handler :event/typed (fn [db ev] (let [ctx (. ev 2)] (assoc db :typed (or ctx.value "")))))
+(reg-sub     :sub/typed   (fn [db] (get db :typed "")))
+
+(fn _G.main_view []
+  [:vbox {:id :root}
+    [:text  {:id :reply       :agent :edit} "default-reply"]
+    [:text  {:id :ro-text     :agent :read} "read-only-text"]
+    [:input {:id :user-input  :agent :read
+             :value (subscribe :sub/typed)
+             :change :event/typed} ""]
+    [:button {:id :ro-button  :agent :read} "click me"]
+    [:vbox  {:id :region      :agent :edit}
+      [:text {} "default-child"]]])

--- a/test/ui/redin_test.bb
+++ b/test/ui/redin_test.bb
@@ -417,4 +417,41 @@
   [ms]
   (Thread/sleep ms))
 
+;; ---------------------------------------------------------------------------
+;; Agent channel (only meaningful when binary built with -define:REDIN_AGENT=true)
+;; ---------------------------------------------------------------------------
+
+(defn agent-supported?
+  "Returns true if the binary exposes the agent endpoints (REDIN_AGENT compiled in)."
+  []
+  (try
+    (let [resp (http/get (str (base-url) "/agent/nodes")
+                         {:headers (auth-headers)
+                          :throw false})]
+      (= 200 (:status resp)))
+    (catch Exception _ false)))
+
+(defn agent-nodes
+  "GET /agent/nodes -> seq of {:id :mode :type} maps."
+  []
+  (get-json "/agent/nodes"))
+
+(defn agent-get-content
+  "GET /agent/content/<id> -> map with :content key."
+  [id]
+  (get-json (str "/agent/content/" (name id))))
+
+(defn agent-put-content
+  "PUT /agent/content/<id>. body is {:content <string-or-vector>}.
+   Returns {:status :body} so tests can assert on status code directly."
+  [id body]
+  (let [resp (http/put (str (base-url) "/agent/content/" (name id))
+                       {:headers (merge {"Content-Type" "application/json"}
+                                        (auth-headers))
+                        :body (json/generate-string body)
+                        :throw false})]
+    {:status (:status resp)
+     :body (try (json/parse-string (:body resp) true)
+                (catch Exception _ (:body resp)))}))
+
 (println "redin-test library loaded")

--- a/test/ui/test_agent.bb
+++ b/test/ui/test_agent.bb
@@ -1,0 +1,84 @@
+(require '[redin-test :refer :all]
+         '[babashka.http-client :as http]
+         '[cheshire.core :as json])
+
+(when-not (agent-supported?)
+  (println "[skip] /agent/* not compiled in (need -define:REDIN_AGENT=true)")
+  (System/exit 0))
+
+;; -- Discovery --
+
+(deftest agent-nodes-discovers-tagged-nodes
+  (let [nodes (agent-nodes)
+        ids (set (map :id nodes))]
+    (assert (contains? ids "reply")       "reply present")
+    (assert (contains? ids "user-input")  "user-input present")
+    (assert (contains? ids "ro-text")     "ro-text present")
+    (assert (contains? ids "region")      "region present")
+    (assert (contains? ids "ro-button")   "ro-button present")))
+
+(deftest agent-nodes-marks-modes
+  (let [nodes (agent-nodes)
+        by-id (into {} (map (juxt :id :mode) nodes))]
+    (assert (= "edit" (by-id "reply"))      "reply is :edit")
+    (assert (= "read" (by-id "user-input")) "user-input is :read")
+    (assert (= "edit" (by-id "region"))     "region is :edit")
+    (assert (= "read" (by-id "ro-text"))    "ro-text is :read")
+    (assert (= "read" (by-id "ro-button"))  "ro-button is :read")))
+
+;; -- GET --
+
+(deftest agent-get-text
+  (let [r (agent-get-content :reply)]
+    (assert (= "default-reply" (:content r))
+            (str "expected default-reply, got " (:content r)))))
+
+(deftest agent-get-button-label
+  (let [r (agent-get-content :ro-button)]
+    (assert (= "click me" (:content r))
+            (str "expected click me, got " (:content r)))))
+
+(deftest agent-get-input-value
+  (dispatch ["event/typed" {:value "abc"}])
+  (wait-ms 100)
+  (let [r (agent-get-content :user-input)]
+    (assert (= "abc" (:content r)) (str "got " (:content r)))))
+
+(deftest agent-get-missing-id-404
+  (let [resp (http/get (str (base-url) "/agent/content/no-such")
+                       {:headers (auth-headers) :throw false})]
+    (assert (= 404 (:status resp)) (str "expected 404, got " (:status resp)))))
+
+;; -- PUT --
+
+(deftest agent-put-text-replaces-content
+  (let [resp (agent-put-content :reply {:content "from-agent"})]
+    (assert (= 200 (:status resp))
+            (str "expected 200, got " (:status resp))))
+  (wait-ms 200)
+  ;; Verify by reading back through the GET endpoint.
+  (let [r (agent-get-content :reply)]
+    (assert (= "from-agent" (:content r))
+            (str "expected from-agent, got " (:content r)))))
+
+(deftest agent-put-read-mode-403
+  (let [resp (agent-put-content :user-input {:content "x"})]
+    (assert (= 403 (:status resp))
+            (str "expected 403, got " (:status resp)))))
+
+(deftest agent-put-wrong-shape-400
+  (let [resp (agent-put-content :reply {:content [1 2]})]
+    (assert (= 400 (:status resp))
+            (str "expected 400 for array body to text node, got " (:status resp)))))
+
+(deftest agent-put-container-replaces-children
+  (let [resp (agent-put-content :region
+               {:content [["text" {} "agent-row-1"]
+                          ["text" {} "agent-row-2"]]})]
+    (assert (= 200 (:status resp))))
+  (wait-ms 200)
+  ;; Verify in /frames that the region's children include the new texts.
+  (let [frame-json (get-json "/frames")
+        flat (pr-str frame-json)]
+    (assert (re-find #"agent-row-1" flat) "region should now contain agent-row-1")
+    (assert (re-find #"agent-row-2" flat) "region should now contain agent-row-2")))


### PR DESCRIPTION
## Summary

Adds a compile-time-gated channel that lets an external agent read and write content of redin nodes by `:id`. Apps mark nodes `:agent :read` (agent observes) or `:agent :edit` (agent writes). The framework auto-renders agent-written content from `db.agent[id]` at view-tick time, so apps "just work" without extra wiring.

The whole feature is gated by `-define:REDIN_AGENT=true` — default release builds carry zero agent code.

- New attribute `:agent` (`:read` / `:edit`) on every node type except `:canvas`.
- Three endpoints (only when `REDIN_AGENT` is compiled):
  - `GET /agent/nodes` — discovery, returns `[{id, mode, type}, ...]`.
  - `GET /agent/content/<id>` — reads content (string for text/input/button/image, array for containers).
  - `PUT /agent/content/<id>` — writes content; validates id exists, mode is `:edit`, body shape matches tag.
- HTTP listener now starts under either `--dev` or `REDIN_AGENT`, so a production-shipped agent-build serves the channel without dev tools.
- Fennel runtime: `agent.fnl` registers `:event/agent-edit` handler and applies a frame-tree override pass between view-fn and `frame.flatten`.
- CI: new `test-agent` job builds with the flag and runs the full UI suite under xvfb.
- Release: extra `redin-vX.Y.Z-agent-linux-amd64.tar.gz` artifact per release.

Markdown rendering for agent-written text is tracked separately as #100.

## One thing to flag before merge

Existing dev endpoints (`/state`, `/click`, `/aspects`, `/screenshot`, etc.) have no per-route `b.dev_mode` check in `process_request` — they were effectively gated only at listener lifecycle. Widening the listener gate to also start under `REDIN_AGENT` means agent-only builds also expose those dev routes (still Bearer-token + Host protected, so local-only). The spec implied agent-only builds would expose just `/agent/*`; reality is: all current routes are exposed. Easy follow-up if we want stricter separation.

## Test plan

- [x] Default build clean (`odin build ...`)
- [x] Agent build clean (`odin build ... -define:REDIN_AGENT=true`)
- [x] Fennel runtime tests: 129/129 (122 existing + 7 new)
- [x] Odin parser tests: 26/26
- [x] Odin input tests: 22/22
- [x] UI suite under headless xvfb: all suites green including 10/10 new agent tests
- [x] Memory check clean under `--track-mem`
- [x] Local smoke tests for every endpoint and every error path (404 / 403 / 400)
- [x] Container subtree round-trip: PUT children list → /frames shows new children

## Spec / plan

- Spec: `docs/superpowers/specs/2026-05-01-agent-channel-design.md` (gitignored)
- Plan: `docs/superpowers/plans/2026-05-01-agent-channel.md` (gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)