### PR TITLE
feat(markdown): headings, nested styles, per-style theme overrides (closes #105)

### DIFF
--- a/docs/core-api.md
+++ b/docs/core-api.md
@@ -183,7 +183,7 @@ The flattening is a single pass when the frame enters the pipeline. No fragment 
 | `click`    | event vector            | button (dispatched on click) |
 | `change`   | event vector            | input (dispatched on text change) |
 | `key`      | event vector            | input (dispatched on key press) |
-| `markdown` | boolean                 | text (default `false`; when `true`, content is parsed as inline markdown — v1 supports `**bold**`, `_italic_` / `*italic*`, `` `inline code` ``, paragraph breaks via blank line, soft line breaks via two-space EOL; headings, lists, links, images, tables, and code blocks are not supported in v1) |
+| `markdown` | boolean                 | text (default `false`; when `true`, content is parsed as inline markdown — supports `**bold**`, `_italic_` / `*italic*`, `` `inline code` ``, nested emphasis like `**bold _italic_**`, headings (`#`–`######`), paragraph breaks via blank line, and soft line breaks via two-space EOL. Per-aspect `:bold` / `:italic` / `:code` sub-tables and `:h1`–`:h6` aspects control rendering — see [theme reference](reference/theme.md). Lists, links, images, tables, and triple-backtick code blocks are not yet supported) |
 | `mode`     | `"mouse"` `"fixed"`     | popout (positioning mode) |
 | `x`        | number                  | popout (fixed position x) |
 | `y`        | number                  | popout (fixed position y) |
@@ -670,6 +670,6 @@ The framework dispatches `:event/agent-edit {id "reply" content "**Answer:** 4"}
 the Fennel handler stores it in `db.agent.reply`, and the next render
 shows it in the `:reply` text node. Set `:markdown true` on the text node
 to have the content rendered as inline markdown (see `:markdown` in the
-attribute table above; v1 supported syntax: bold, italic, inline code,
-paragraphs, soft breaks). Extended syntax (headings, lists, links, images,
-tables, code blocks) is tracked in issue #100.
+attribute table above; supported syntax: bold, italic, nested emphasis,
+inline code, headings (`#`–`######`), paragraphs, soft breaks). Lists,
+links, images, tables, and triple-backtick code blocks are not yet supported.

--- a/docs/reference/theme.md
+++ b/docs/reference/theme.md
@@ -208,3 +208,36 @@ Validation is implemented in `src/runtime/theme.fnl`. Checks include:
 | Numeric types | `font-size`, `radius`, `border-width`, `line-height`, `scrollbar-width`, `scrollbar-radius` must be numbers |
 | Shadow format | `shadow` must be `[x y blur [r g b a]]` |
 | Padding format | `padding` must be a number, `[v h]`, or `[t r b l]` |
+
+---
+
+## Markdown style overrides
+
+Aspects consumed by `:text {:markdown true}` accept three optional sub-tables that override per-style rendering:
+
+```fennel
+{:body {:font-size 14 :color [216 222 233]
+        :bold   {:color [255 255 255]}
+        :italic {:color [180 180 220]}
+        :code   {:bg [40 40 50] :color [220 220 220]}}}
+```
+
+- `:bold` and `:italic` only honor `:color`.
+- `:code` honors `:color` and `:bg`. The default code background (when unset) is `[60 60 70 255]`.
+- `Bold_Italic` spans (e.g. `**bold _italic_**`) use the `:bold` override; a separate sub-table can be added later if needed.
+
+Sub-tables that aren't provided fall through to the host aspect's `:color`. An unset `:code :bg` keeps the hardcoded fallback.
+
+---
+
+## Heading aspects
+
+Headings rendered from markdown (`# h1`–`###### h6`) look up `:h1`–`:h6` on the theme map. Each entry honors `:font-size` and `:line-height`; non-zero fields override the host aspect, zero fields inherit. Color and weight inherit from the host aspect — `:h<N>` `:color` / `:weight` are not read in v1. When `:h<N>` is absent entirely, the heading font size is the host aspect's `:font-size` × a level scale of `[2.0, 1.7, 1.4, 1.2, 1.1, 1.0]`.
+
+```fennel
+{:body {:font-size 14 :color [216 222 233]}
+ :h1   {:font-size 28}
+ :h2   {:font-size 22}}
+```
+
+In this example, `h1` overrides size; `h2` overrides size; `h3`–`h6` use the scale fallback (`14 × 1.4 = 19.6`, etc.). All four levels use `:body`'s color.

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -1504,6 +1504,9 @@ lua_to_theme :: proc(L: ^Lua_State, index: i32) -> map[string]types.Theme {
 			t.opacity = lua_get_number_field(L, props_idx, "opacity")
 			t.shadow = lua_get_shadow_field(L, props_idx, "shadow")
 			t.selection = lua_get_rgba_field(L, props_idx, "selection")
+			t.bold   = lua_get_style_override(L, props_idx, "bold")
+			t.italic = lua_get_style_override(L, props_idx, "italic")
+			t.code   = lua_get_style_override(L, props_idx, "code")
 
 			lua_getfield(L, props_idx, "weight")
 			if lua_isnumber(L, -1) {
@@ -1599,6 +1602,18 @@ lua_get_shadow_field :: proc(L: ^Lua_State, index: i32, field: cstring) -> types
 	}
 	lua_pop(L, 1)
 	return s
+}
+
+lua_get_style_override :: proc(L: ^Lua_State, index: i32, field: cstring) -> types.Style_Override {
+	lua_getfield(L, index, field)
+	defer lua_pop(L, 1)
+	if !lua_istable(L, -1) do return {}
+	abs := lua_gettop(L)
+	out: types.Style_Override
+	out.set = true
+	out.color = lua_get_rgb_field(L, abs, "color")
+	out.bg = lua_get_rgba_field(L, abs, "bg")
+	return out
 }
 
 lua_get_padding_field :: proc(L: ^Lua_State, index: i32, field: cstring) -> [4]u8 {

--- a/src/redin/font/font.odin
+++ b/src/redin/font/font.odin
@@ -6,6 +6,7 @@ Font_Style :: enum {
 	Regular,
 	Bold,
 	Italic,
+	Bold_Italic,
 }
 
 Font_Key :: struct {
@@ -40,6 +41,12 @@ register :: proc(name: string, style: Font_Style, f: rl.Font) {
 get :: proc(name: string, style: Font_Style) -> rl.Font {
 	if f, ok := fonts[Font_Key{name, style}]; ok {
 		return f
+	}
+	// Bold_Italic falls back to Bold first (closer visual match than Regular).
+	if style == .Bold_Italic {
+		if f, ok := fonts[Font_Key{name, .Bold}]; ok {
+			return f
+		}
 	}
 	if style != .Regular {
 		if f, ok := fonts[Font_Key{name, .Regular}]; ok {

--- a/src/redin/markdown/parser.odin
+++ b/src/redin/markdown/parser.odin
@@ -9,26 +9,50 @@ Span :: struct {
 	text:  string,
 }
 
-Block_Kind :: enum u8 { Paragraph }
+Block_Kind :: enum u8 { Paragraph, Heading }
 
 Block :: struct {
 	kind:  Block_Kind,
+	level: u8,        // 1..6 for Heading; 0 for Paragraph
 	spans: []Span,
 }
 
-// Parse markdown source into a list of paragraph blocks. Each block holds
-// inline spans (Regular / Bold / Italic / Code). Allocations come from
-// the supplied allocator.
+// Parse markdown source into a list of blocks. Each block holds inline spans
+// (Regular / Bold / Italic / Code). Allocations come from the supplied allocator.
 parse :: proc(src: string, allocator := context.allocator) -> []Block {
 	context.allocator = allocator
 
 	blocks: [dynamic]Block
 	paragraphs := split_paragraphs(src)
 	for p in paragraphs {
-		spans := parse_inline(p)
-		append(&blocks, Block{kind = .Paragraph, spans = spans})
+		if level, body, is_h := detect_heading(p); is_h {
+			spans := parse_inline(body)
+			append(&blocks, Block{kind = .Heading, level = level, spans = spans})
+		} else {
+			spans := parse_inline(p)
+			append(&blocks, Block{kind = .Paragraph, spans = spans})
+		}
 	}
 	return blocks[:]
+}
+
+// Returns (level, trimmed-body, true) if `p` opens with 1..6 `#` followed
+// by a space. Trailing `#` runs and surrounding whitespace are stripped.
+detect_heading :: proc(p: string) -> (level: u8, body: string, ok: bool) {
+	i := 0
+	for i < len(p) && p[i] == '#' do i += 1
+	if i == 0 || i > 6 do return 0, "", false
+	if i >= len(p) || p[i] != ' ' do return 0, "", false
+	rest := p[i + 1:]
+	// Trim leading whitespace.
+	start := 0
+	for start < len(rest) && (rest[start] == ' ' || rest[start] == '\t') do start += 1
+	// Trim trailing whitespace + a closing run of `#`s + the space before it.
+	end := len(rest)
+	for end > start && (rest[end - 1] == ' ' || rest[end - 1] == '\t') do end -= 1
+	for end > start && rest[end - 1] == '#' do end -= 1
+	for end > start && (rest[end - 1] == ' ' || rest[end - 1] == '\t') do end -= 1
+	return u8(i), rest[start:end], true
 }
 
 split_paragraphs :: proc(src: string) -> []string {

--- a/src/redin/markdown/parser.odin
+++ b/src/redin/markdown/parser.odin
@@ -2,7 +2,7 @@ package markdown
 
 import "core:strings"
 
-Span_Style :: enum u8 { Regular, Bold, Italic, Code }
+Span_Style :: enum u8 { Regular, Bold, Italic, Bold_Italic, Code }
 
 Span :: struct {
 	style: Span_Style,
@@ -110,47 +110,58 @@ process_soft_breaks :: proc(s: string) -> string {
 parse_inline :: proc(src: string) -> []Span {
 	pre := process_soft_breaks(src)
 	out: [dynamic]Span
+	parse_inline_into(&out, pre, .Regular)
+	return out[:]
+}
+
+// Walk `text` emitting spans into `out`, merging each emitted span's style
+// with `outer` per the merge table in the spec. Recurses on emphasis bodies.
+parse_inline_into :: proc(out: ^[dynamic]Span, text: string, outer: Span_Style) {
 	current := strings.builder_make()
+	defer strings.builder_destroy(&current)
 	i := 0
 
-	flush_regular :: proc(out: ^[dynamic]Span, b: ^strings.Builder) {
+	flush_regular :: proc(out: ^[dynamic]Span, b: ^strings.Builder, outer: Span_Style) {
 		if strings.builder_len(b^) > 0 {
 			cloned := strings.clone(strings.to_string(b^))
-			append(out, Span{style = .Regular, text = cloned})
+			append(out, Span{style = outer, text = cloned})
 			strings.builder_reset(b)
 		}
 	}
 
-	for i < len(pre) {
-		c := pre[i]
-		// `**...**` first (greedy).
-		if c == '*' && i + 1 < len(pre) && pre[i+1] == '*' {
-			if close_idx := find_close_double(pre, i + 2, '*'); close_idx >= 0 {
-				flush_regular(&out, &current)
-				append(&out, Span{style = .Bold, text = pre[i+2:close_idx]})
+	for i < len(text) {
+		c := text[i]
+		// `**...**` greedy bold.
+		if c == '*' && i + 1 < len(text) && text[i + 1] == '*' {
+			if close_idx := find_close_double(text, i + 2, '*'); close_idx >= 0 {
+				flush_regular(out, &current, outer)
+				inner := text[i + 2:close_idx]
+				parse_inline_into(out, inner, merge_style(outer, .Bold))
 				i = close_idx + 2
 				continue
 			}
-			// Bold delimiter unmatched — emit both stars as literal text.
 			strings.write_byte(&current, '*')
 			strings.write_byte(&current, '*')
 			i += 2
 			continue
 		}
-		// `*...*` or `_..._` italic.
+		// `*…*` / `_…_` italic.
 		if c == '*' || c == '_' {
-			if close_idx := find_close_single(pre, i + 1, c); close_idx >= 0 {
-				flush_regular(&out, &current)
-				append(&out, Span{style = .Italic, text = pre[i+1:close_idx]})
+			if close_idx := find_close_single(text, i + 1, c); close_idx >= 0 {
+				flush_regular(out, &current, outer)
+				inner := text[i + 1:close_idx]
+				parse_inline_into(out, inner, merge_style(outer, .Italic))
 				i = close_idx + 1
 				continue
 			}
 		}
-		// Backtick code.
+		// Backtick code (leaf).
 		if c == '`' {
-			if close_idx := find_close_single(pre, i + 1, '`'); close_idx >= 0 {
-				flush_regular(&out, &current)
-				append(&out, Span{style = .Code, text = pre[i+1:close_idx]})
+			if close_idx := find_close_single(text, i + 1, '`'); close_idx >= 0 {
+				flush_regular(out, &current, outer)
+				inner := text[i + 1:close_idx]
+				cloned := strings.clone(inner)
+				append(out, Span{style = .Code, text = cloned})
 				i = close_idx + 1
 				continue
 			}
@@ -158,8 +169,23 @@ parse_inline :: proc(src: string) -> []Span {
 		strings.write_byte(&current, c)
 		i += 1
 	}
-	flush_regular(&out, &current)
-	return out[:]
+	flush_regular(out, &current, outer)
+}
+
+// Combine outer + inner per the table in the spec.
+// Code always wins. Bold_Italic absorbs further Bold/Italic.
+merge_style :: proc(outer, inner: Span_Style) -> Span_Style {
+	if inner == .Code do return .Code
+	if outer == .Regular do return inner
+	if inner == .Regular do return outer
+	if outer == inner do return outer
+	if outer == .Bold_Italic do return .Bold_Italic
+	if inner == .Bold_Italic do return .Bold_Italic
+	// Bold ⊕ Italic (in either order) → Bold_Italic.
+	if (outer == .Bold && inner == .Italic) || (outer == .Italic && inner == .Bold) {
+		return .Bold_Italic
+	}
+	return inner
 }
 
 // Find the next occurrence of two consecutive `delim` chars at or after `from`.

--- a/src/redin/markdown/parser_test.odin
+++ b/src/redin/markdown/parser_test.odin
@@ -114,3 +114,52 @@ test_regular_spans_dont_alias :: proc(t: ^testing.T) {
 	testing.expect_value(t, blocks[0].spans[3].text, "C")
 	testing.expect_value(t, blocks[0].spans[4].text, " ccc")
 }
+
+@(test)
+test_heading_h1 :: proc(t: ^testing.T) {
+	blocks := parse("# hello", context.temp_allocator)
+	testing.expect_value(t, len(blocks), 1)
+	testing.expect_value(t, blocks[0].kind, Block_Kind.Heading)
+	testing.expect_value(t, blocks[0].level, u8(1))
+	testing.expect_value(t, len(blocks[0].spans), 1)
+	testing.expect_value(t, blocks[0].spans[0].text, "hello")
+}
+
+@(test)
+test_heading_h6 :: proc(t: ^testing.T) {
+	blocks := parse("###### six", context.temp_allocator)
+	testing.expect_value(t, blocks[0].kind, Block_Kind.Heading)
+	testing.expect_value(t, blocks[0].level, u8(6))
+}
+
+@(test)
+test_heading_seven_hashes_is_paragraph :: proc(t: ^testing.T) {
+	blocks := parse("####### x", context.temp_allocator)
+	testing.expect_value(t, blocks[0].kind, Block_Kind.Paragraph)
+}
+
+@(test)
+test_heading_strips_trailing_hashes :: proc(t: ^testing.T) {
+	blocks := parse("## foo ##", context.temp_allocator)
+	testing.expect_value(t, blocks[0].kind, Block_Kind.Heading)
+	testing.expect_value(t, blocks[0].level, u8(2))
+	testing.expect_value(t, blocks[0].spans[0].text, "foo")
+}
+
+@(test)
+test_heading_with_inline_bold :: proc(t: ^testing.T) {
+	blocks := parse("# **bold** title", context.temp_allocator)
+	testing.expect_value(t, blocks[0].kind, Block_Kind.Heading)
+	testing.expect_value(t, blocks[0].level, u8(1))
+	testing.expect_value(t, len(blocks[0].spans), 2)
+	testing.expect_value(t, blocks[0].spans[0].style, Span_Style.Bold)
+	testing.expect_value(t, blocks[0].spans[0].text, "bold")
+	testing.expect_value(t, blocks[0].spans[1].style, Span_Style.Regular)
+	testing.expect_value(t, blocks[0].spans[1].text, " title")
+}
+
+@(test)
+test_heading_no_space_after_hash :: proc(t: ^testing.T) {
+	blocks := parse("#foo", context.temp_allocator)
+	testing.expect_value(t, blocks[0].kind, Block_Kind.Paragraph)
+}

--- a/src/redin/markdown/parser_test.odin
+++ b/src/redin/markdown/parser_test.odin
@@ -74,12 +74,16 @@ test_unmatched_delimiter :: proc(t: ^testing.T) {
 }
 
 @(test)
-test_no_nesting_v1 :: proc(t: ^testing.T) {
+test_nesting_bold_outer_italic_inner :: proc(t: ^testing.T) {
+	// With recursive parsing, **outer _inner_** emits two spans:
+	// Bold "outer " and Bold_Italic "inner".
 	blocks := parse("**outer _inner_**", context.temp_allocator)
 	testing.expect_value(t, len(blocks), 1)
-	testing.expect_value(t, len(blocks[0].spans), 1)
+	testing.expect_value(t, len(blocks[0].spans), 2)
 	testing.expect_value(t, blocks[0].spans[0].style, Span_Style.Bold)
-	testing.expect_value(t, blocks[0].spans[0].text, "outer _inner_")
+	testing.expect_value(t, blocks[0].spans[0].text, "outer ")
+	testing.expect_value(t, blocks[0].spans[1].style, Span_Style.Bold_Italic)
+	testing.expect_value(t, blocks[0].spans[1].text, "inner")
 }
 
 @(test)
@@ -162,4 +166,36 @@ test_heading_with_inline_bold :: proc(t: ^testing.T) {
 test_heading_no_space_after_hash :: proc(t: ^testing.T) {
 	blocks := parse("#foo", context.temp_allocator)
 	testing.expect_value(t, blocks[0].kind, Block_Kind.Paragraph)
+}
+
+@(test)
+test_bold_with_inner_italic :: proc(t: ^testing.T) {
+	blocks := parse("**a _b_ c**", context.temp_allocator)
+	testing.expect_value(t, len(blocks[0].spans), 3)
+	testing.expect_value(t, blocks[0].spans[0].style, Span_Style.Bold)
+	testing.expect_value(t, blocks[0].spans[0].text, "a ")
+	testing.expect_value(t, blocks[0].spans[1].style, Span_Style.Bold_Italic)
+	testing.expect_value(t, blocks[0].spans[1].text, "b")
+	testing.expect_value(t, blocks[0].spans[2].style, Span_Style.Bold)
+	testing.expect_value(t, blocks[0].spans[2].text, " c")
+}
+
+@(test)
+test_italic_with_inner_bold :: proc(t: ^testing.T) {
+	blocks := parse("_a **b** c_", context.temp_allocator)
+	testing.expect_value(t, len(blocks[0].spans), 3)
+	testing.expect_value(t, blocks[0].spans[0].style, Span_Style.Italic)
+	testing.expect_value(t, blocks[0].spans[1].style, Span_Style.Bold_Italic)
+	testing.expect_value(t, blocks[0].spans[1].text, "b")
+	testing.expect_value(t, blocks[0].spans[2].style, Span_Style.Italic)
+}
+
+@(test)
+test_bold_with_inner_code :: proc(t: ^testing.T) {
+	blocks := parse("**a `b` c**", context.temp_allocator)
+	testing.expect_value(t, len(blocks[0].spans), 3)
+	testing.expect_value(t, blocks[0].spans[0].style, Span_Style.Bold)
+	testing.expect_value(t, blocks[0].spans[1].style, Span_Style.Code)
+	testing.expect_value(t, blocks[0].spans[1].text, "b")
+	testing.expect_value(t, blocks[0].spans[2].style, Span_Style.Bold)
 }

--- a/src/redin/markdown/render.odin
+++ b/src/redin/markdown/render.odin
@@ -5,6 +5,13 @@ import "../font"
 import text_pkg "../text"
 import rl "vendor:raylib"
 
+// Per-block render parameters resolved by the caller from the theme map.
+// One entry per Block; blocks[i] uses entries[i].
+Block_Params :: struct {
+	font_size:   f32,
+	line_height: f32,    // ratio
+}
+
 Span_Box :: struct {
 	style:  Span_Style,
 	text:   string,
@@ -35,17 +42,17 @@ font_for :: proc(style: Span_Style, base_name: string) -> rl.Font {
 // line-fill. Allocations come from the supplied allocator.
 layout :: proc(
 	blocks: []Block,
+	params: []Block_Params,
 	base_font_name: string,
-	base_font_size: f32,
-	line_height_ratio: f32,
 	max_width: f32,
 	allocator := context.allocator,
 ) -> []Laid_Block {
 	context.allocator = allocator
-	lh := text_pkg.line_height(base_font_size, line_height_ratio)
 	out: [dynamic]Laid_Block
 
-	for blk in blocks {
+	for blk, blk_idx in blocks {
+		bp := params[blk_idx]
+		lh := text_pkg.line_height(bp.font_size, bp.line_height)
 		boxes: [dynamic]Span_Box
 		cursor_x: f32 = 0
 		cursor_y: f32 = 0
@@ -84,7 +91,7 @@ layout :: proc(
 					// Flush pending word.
 					if i > start {
 						emit(&boxes, span.style, text[start:i], fnt,
-							base_font_size, lh, &cursor_x, &cursor_y, max_width,
+							bp.font_size, lh, &cursor_x, &cursor_y, max_width,
 							&first_unit_on_line)
 					}
 					// Forced break.
@@ -98,7 +105,7 @@ layout :: proc(
 				if ch == ' ' || ch == '\t' {
 					if i > start {
 						emit(&boxes, span.style, text[start:i], fnt,
-							base_font_size, lh, &cursor_x, &cursor_y, max_width,
+							bp.font_size, lh, &cursor_x, &cursor_y, max_width,
 							&first_unit_on_line)
 					}
 					ws := text[i:i+1]
@@ -108,7 +115,7 @@ layout :: proc(
 						start = i
 						continue
 					}
-					emit(&boxes, span.style, ws, fnt, base_font_size, lh,
+					emit(&boxes, span.style, ws, fnt, bp.font_size, lh,
 						&cursor_x, &cursor_y, max_width, &first_unit_on_line)
 					start = i
 					continue
@@ -116,7 +123,7 @@ layout :: proc(
 				i += 1
 			}
 			if start < len(text) {
-				emit(&boxes, span.style, text[start:], fnt, base_font_size, lh,
+				emit(&boxes, span.style, text[start:], fnt, bp.font_size, lh,
 					&cursor_x, &cursor_y, max_width, &first_unit_on_line)
 			}
 		}
@@ -141,12 +148,13 @@ free_laid :: proc(laid: []Laid_Block) {
 
 // Draw a laid-out markdown tree into `rect` using `color` for non-code spans.
 // Code spans get a subtle dark bg fill.
-draw :: proc(laid: []Laid_Block, rect: rl.Rectangle, color: rl.Color, base_font_size: f32, base_font_name: string, line_height_ratio: f32) {
-	lh := text_pkg.line_height(base_font_size, line_height_ratio)
+draw :: proc(laid: []Laid_Block, params: []Block_Params, rect: rl.Rectangle, color: rl.Color, base_font_name: string) {
 	code_bg := rl.Color{60, 60, 70, 255}
 
 	block_y_offset: f32 = 0
 	for blk, blk_idx in laid {
+		bp := params[blk_idx]
+		lh := text_pkg.line_height(bp.font_size, bp.line_height)
 		for span in blk.spans {
 			x := rect.x + span.x
 			y := rect.y + block_y_offset + span.y
@@ -157,7 +165,7 @@ draw :: proc(laid: []Laid_Block, rect: rl.Rectangle, color: rl.Color, base_font_
 			}
 
 			cstr := strings.clone_to_cstring(span.text, context.temp_allocator)
-			rl.DrawTextEx(fnt, cstr, rl.Vector2{x, y}, base_font_size, 0, color)
+			rl.DrawTextEx(fnt, cstr, rl.Vector2{x, y}, bp.font_size, 0, color)
 		}
 		block_y_offset += blk.total_height
 		if blk_idx + 1 < len(laid) {

--- a/src/redin/markdown/render.odin
+++ b/src/redin/markdown/render.odin
@@ -21,10 +21,11 @@ Laid_Block :: struct {
 
 font_for :: proc(style: Span_Style, base_name: string) -> rl.Font {
 	switch style {
-	case .Regular: return font.get(base_name, .Regular)
-	case .Bold:    return font.get(base_name, .Bold)
-	case .Italic:  return font.get(base_name, .Italic)
-	case .Code:    return font.get("mono", .Regular)
+	case .Regular:     return font.get(base_name, .Regular)
+	case .Bold:        return font.get(base_name, .Bold)
+	case .Italic:      return font.get(base_name, .Italic)
+	case .Bold_Italic: return font.get(base_name, .Bold_Italic)
+	case .Code:        return font.get("mono", .Regular)
 	}
 	return font.get(base_name, .Regular)
 }

--- a/src/redin/markdown/render.odin
+++ b/src/redin/markdown/render.odin
@@ -12,6 +12,16 @@ Block_Params :: struct {
 	line_height: f32,    // ratio
 }
 
+// Resolved per-style colors. Caller fills this from the host aspect's
+// :bold / :italic / :code sub-tables (with parent fallbacks).
+Style_Theme :: struct {
+	base_color:   rl.Color,
+	bold_color:   rl.Color,
+	italic_color: rl.Color,
+	code_color:   rl.Color,
+	code_bg:      rl.Color,
+}
+
 Span_Box :: struct {
 	style:  Span_Style,
 	text:   string,
@@ -146,11 +156,9 @@ free_laid :: proc(laid: []Laid_Block) {
 	delete(laid)
 }
 
-// Draw a laid-out markdown tree into `rect` using `color` for non-code spans.
-// Code spans get a subtle dark bg fill.
-draw :: proc(laid: []Laid_Block, params: []Block_Params, rect: rl.Rectangle, color: rl.Color, base_font_name: string) {
-	code_bg := rl.Color{60, 60, 70, 255}
-
+// Draw a laid-out markdown tree into `rect` using `style` for per-span colors.
+// Code spans get a bg fill from style.code_bg.
+draw :: proc(laid: []Laid_Block, params: []Block_Params, rect: rl.Rectangle, style: Style_Theme, base_font_name: string) {
 	block_y_offset: f32 = 0
 	for blk, blk_idx in laid {
 		bp := params[blk_idx]
@@ -161,11 +169,19 @@ draw :: proc(laid: []Laid_Block, params: []Block_Params, rect: rl.Rectangle, col
 			fnt := font_for(span.style, base_font_name)
 
 			if span.style == .Code {
-				rl.DrawRectangleRec(rl.Rectangle{x, y, span.width, lh}, code_bg)
+				rl.DrawRectangleRec(rl.Rectangle{x, y, span.width, lh}, style.code_bg)
+			}
+
+			span_color: rl.Color
+			switch span.style {
+			case .Regular:                            span_color = style.base_color
+			case .Bold, .Bold_Italic:                 span_color = style.bold_color
+			case .Italic:                             span_color = style.italic_color
+			case .Code:                               span_color = style.code_color
 			}
 
 			cstr := strings.clone_to_cstring(span.text, context.temp_allocator)
-			rl.DrawTextEx(fnt, cstr, rl.Vector2{x, y}, bp.font_size, 0, color)
+			rl.DrawTextEx(fnt, cstr, rl.Vector2{x, y}, bp.font_size, 0, span_color)
 		}
 		block_y_offset += blk.total_height
 		if blk_idx + 1 < len(laid) {

--- a/src/redin/render.odin
+++ b/src/redin/render.odin
@@ -1378,17 +1378,20 @@ build_markdown_style :: proc(
 	}
 	host, ok := theme[host_aspect]
 	if !ok do return out
-	if host.bold.set && (host.bold.color != {}) {
+	// `set` says "the sub-table was provided" but inner fields can still be
+	// absent (e.g. `:bold {}` leaves :color zeroed). For inner field
+	// absence we fall back to the same zero-sentinel convention used
+	// elsewhere in the renderer: zero RGB / RGBA = inherit.
+	if host.bold.set && host.bold.color != {} {
 		out.bold_color = rl.Color{host.bold.color[0], host.bold.color[1], host.bold.color[2], 255}
 	}
-	if host.italic.set && (host.italic.color != {}) {
+	if host.italic.set && host.italic.color != {} {
 		out.italic_color = rl.Color{host.italic.color[0], host.italic.color[1], host.italic.color[2], 255}
 	}
 	if host.code.set {
 		if host.code.color != {} {
 			out.code_color = rl.Color{host.code.color[0], host.code.color[1], host.code.color[2], 255}
 		}
-		// {0,0,0,0} → inherit; any non-zero byte → explicit bg.
 		if host.code.bg != {} {
 			out.code_bg = rl.Color{host.code.bg[0], host.code.bg[1], host.code.bg[2], host.code.bg[3]}
 		}

--- a/src/redin/render.odin
+++ b/src/redin/render.odin
@@ -1328,6 +1328,38 @@ draw_button :: proc(rect: rl.Rectangle, n: types.NodeButton, theme: map[string]t
 	}
 }
 
+// Resolve per-block font params for a markdown text node. Headings consult
+// :h1..:h6 aspects; missing aspects use a hardcoded scale table.
+build_markdown_params :: proc(
+	blocks: []markdown.Block,
+	theme: map[string]types.Theme,
+	base_font_size: f32,
+	base_lh: f32,
+	allocator := context.allocator,
+) -> []markdown.Block_Params {
+	context.allocator = allocator
+	heading_scale := [6]f32{2.0, 1.7, 1.4, 1.2, 1.1, 1.0}
+	out := make([]markdown.Block_Params, len(blocks))
+	for blk, idx in blocks {
+		size := base_font_size
+		lh := base_lh
+		if blk.kind == .Heading {
+			level := int(blk.level)
+			if level < 1 do level = 1
+			if level > 6 do level = 6
+			h_key := fmt.tprintf("h%d", level)
+			if h, ok := theme[h_key]; ok {
+				if h.font_size > 0 do size = f32(h.font_size)
+				if h.line_height > 0 do lh = h.line_height
+			} else {
+				size = base_font_size * heading_scale[level - 1]
+			}
+		}
+		out[idx] = markdown.Block_Params{font_size = size, line_height = lh}
+	}
+	return out
+}
+
 draw_text :: proc(idx: int, rect: rl.Rectangle, n: types.NodeText, theme: map[string]types.Theme) {
 	if len(n.content) == 0 do return
 
@@ -1349,8 +1381,9 @@ draw_text :: proc(idx: int, rect: rl.Rectangle, n: types.NodeText, theme: map[st
 
 	if n.markdown {
 		blocks := markdown.parse(n.content, context.temp_allocator)
-		laid := markdown.layout(blocks, font_name, font_size, lh_ratio, rect.width, context.temp_allocator)
-		markdown.draw(laid, rect, text_color, font_size, font_name, lh_ratio)
+		params := build_markdown_params(blocks, theme, font_size, lh_ratio, context.temp_allocator)
+		laid := markdown.layout(blocks, params, font_name, rect.width, context.temp_allocator)
+		markdown.draw(laid, params, rect, text_color, font_name)
 		return
 	}
 

--- a/src/redin/render.odin
+++ b/src/redin/render.odin
@@ -1360,6 +1360,42 @@ build_markdown_params :: proc(
 	return out
 }
 
+// Resolve markdown per-style colors from the host aspect's overrides.
+// Defaults: base_color = the text color the caller already computed;
+// bold/italic/code colors fall back to base_color when not set; code_bg
+// falls back to {60, 60, 70, 255}.
+build_markdown_style :: proc(
+	theme: map[string]types.Theme,
+	host_aspect: string,
+	base_color: rl.Color,
+) -> markdown.Style_Theme {
+	out := markdown.Style_Theme{
+		base_color   = base_color,
+		bold_color   = base_color,
+		italic_color = base_color,
+		code_color   = base_color,
+		code_bg      = rl.Color{60, 60, 70, 255},
+	}
+	host, ok := theme[host_aspect]
+	if !ok do return out
+	if host.bold.set && (host.bold.color != {}) {
+		out.bold_color = rl.Color{host.bold.color[0], host.bold.color[1], host.bold.color[2], 255}
+	}
+	if host.italic.set && (host.italic.color != {}) {
+		out.italic_color = rl.Color{host.italic.color[0], host.italic.color[1], host.italic.color[2], 255}
+	}
+	if host.code.set {
+		if host.code.color != {} {
+			out.code_color = rl.Color{host.code.color[0], host.code.color[1], host.code.color[2], 255}
+		}
+		// {0,0,0,0} → inherit; any non-zero byte → explicit bg.
+		if host.code.bg != {} {
+			out.code_bg = rl.Color{host.code.bg[0], host.code.bg[1], host.code.bg[2], host.code.bg[3]}
+		}
+	}
+	return out
+}
+
 draw_text :: proc(idx: int, rect: rl.Rectangle, n: types.NodeText, theme: map[string]types.Theme) {
 	if len(n.content) == 0 do return
 
@@ -1382,8 +1418,9 @@ draw_text :: proc(idx: int, rect: rl.Rectangle, n: types.NodeText, theme: map[st
 	if n.markdown {
 		blocks := markdown.parse(n.content, context.temp_allocator)
 		params := build_markdown_params(blocks, theme, font_size, lh_ratio, context.temp_allocator)
+		style := build_markdown_style(theme, n.aspect, text_color)
 		laid := markdown.layout(blocks, params, font_name, rect.width, context.temp_allocator)
-		markdown.draw(laid, params, rect, text_color, font_name)
+		markdown.draw(laid, params, rect, style, font_name)
 		return
 	}
 

--- a/src/redin/types/theme.odin
+++ b/src/redin/types/theme.odin
@@ -7,10 +7,15 @@ Shadow :: struct {
 	color: [4]u8,
 }
 
+// Per-style override on a Theme entry. Three independent absence-sentinels:
+//   `set`        false → the sub-table itself was not provided.
+//   `color`      (0,0,0) inside a present sub-table → :color field absent.
+//   `bg`         (0,0,0,0) → :bg field absent (only :code consumes :bg).
+// The renderer treats any absent field as "inherit from the host aspect."
 Style_Override :: struct {
-	color: [3]u8,    // (0,0,0) → inherit unless `set` is true
-	bg:    [4]u8,    // (0,0,0,0) → inherit; meaningful only for code
-	set:   bool,     // explicit "this sub-table was provided"
+	color: [3]u8,
+	bg:    [4]u8,
+	set:   bool,
 }
 
 Text_Align :: enum u8 {

--- a/src/redin/types/theme.odin
+++ b/src/redin/types/theme.odin
@@ -7,6 +7,12 @@ Shadow :: struct {
 	color: [4]u8,
 }
 
+Style_Override :: struct {
+	color: [3]u8,    // (0,0,0) → inherit unless `set` is true
+	bg:    [4]u8,    // (0,0,0,0) → inherit; meaningful only for code
+	set:   bool,     // explicit "this sub-table was provided"
+}
+
 Text_Align :: enum u8 {
 	Auto   = 0, // single-line → Center, multi-line → Top
 	Top    = 1,
@@ -29,4 +35,7 @@ Theme :: struct {
 	opacity:      f32,
 	shadow:       Shadow,
 	selection:    [4]u8,   // RGBA; {0,0,0,0} = unset, use render default
+	bold:         Style_Override,
+	italic:       Style_Override,
+	code:         Style_Override,
 }

--- a/test/ui/markdown_app.fnl
+++ b/test/ui/markdown_app.fnl
@@ -3,7 +3,12 @@
 
 (theme.set-theme
   {:surface {:bg [30 33 42] :padding [16 16 16 16]}
-   :body    {:font-size 24 :color [240 240 240] :line-height 1.5}})
+   :body    {:font-size 24 :color [240 240 240] :line-height 1.5
+             :bold   {:color [255 255 255]}
+             :italic {:color [180 180 220]}
+             :code   {:bg [40 40 50] :color [220 220 220]}}
+   :h1      {:font-size 40 :weight 1 :color [255 255 255]}
+   :h2      {:font-size 32 :weight 1 :color [240 240 240]}})
 
 (dataflow.init {})
 
@@ -14,4 +19,10 @@
 
 Second paragraph after a blank line.
 Soft break here
-on the next line."]])
+on the next line."]
+    [:text {:id :md-extended :markdown true :aspect :body}
+           "# Heading 1
+
+## Heading 2
+
+Plain paragraph with **bold _and italic_** plus `code`."]])

--- a/test/ui/test_markdown.bb
+++ b/test/ui/test_markdown.bb
@@ -17,3 +17,14 @@
   (ensure-artifacts-dir)
   (wait-ms 100)
   (screenshot "test/ui/artifacts/markdown_render.png"))
+
+(deftest md-extended-renders
+  (let [el (find-element {:id :md-extended})]
+    (assert el "md-extended must exist in /frames")
+    (let [r (rect-of el)]
+      (assert r "md-extended must have a :rect")
+      ;; H1 (font-size 40 × line-height 1.5 = 60px) + H2 (32 × 1.5 = 48px)
+      ;; + paragraph (24 × 1.5 = 36px) + paragraph spacing -> >= ~120px.
+      ;; Use a conservative threshold of 80 to allow font-metric variance.
+      (assert (>= (:h r) 80)
+              (str "md-extended rect height should be >= 80, got " (:h r))))))


### PR DESCRIPTION
Tier-1 follow-ups from #102, scoped via #105.

## Summary

- **Headings:** `#`, `##`, …, `######` (1–6 `#` followed by space) become Heading blocks. Trailing `#` runs and surrounding whitespace stripped per CommonMark.
- **Nested inline styles:** `parse_inline` recurses into emphasis bodies. `**bold _italic_**` produces three spans (Bold, Bold_Italic, Bold). Code stays a leaf. New `Span_Style.Bold_Italic` falls back to Bold via `font.get`'s style chain — no new .ttf assets.
- **Per-style theme overrides:** Aspects gain optional `:bold` / `:italic` / `:code` sub-tables. Bold/italic honor `:color`; code honors `:color` and `:bg`. Inheritance: absent sub-table → parent aspect color; absent inner field → same.
- **Heading sizing:** `:h1`–`:h6` aspects override `font_size` and `line_height` per level. When the aspect is absent, the heading scales the host's font_size by `[2.0, 1.7, 1.4, 1.2, 1.1, 1.0]`.

## Implementation

8 commits, one per planned task:

1. `81ad10b` — `font.get` Bold_Italic→Bold fallback.
2. `94f293b` — Heading block parsing + 6 unit tests.
3. `75f6fa5` — Recursive `parse_inline` + `merge_style` + 3 unit tests.
4. `eb3445c` — Per-block `Block_Params` threaded through `markdown.layout` / `markdown.draw`; `build_markdown_params` resolves heading sizes from theme.
5. `f060cf7` — `Style_Override` on Theme + `lua_get_style_override` bridge helper.
6. `cb5b4ba` — `Style_Theme` + `build_markdown_style` resolves per-style colors from host aspect.
7. `963c7c7` — `:md-extended` UI sample + `md-extended-renders` test.
8. `d1b5cf5` — Docs (`docs/core-api.md`, `docs/reference/theme.md`).
9. `394e3df` — Comment cleanup on `Style_Override` absence sentinels (review feedback).

## Out of scope (still under #102)

Lists, code blocks, links, images, tables, per-idx markdown layout cache, CJK breaking, streaming agent writes.

## Known gap (filed as #106)

Heading aspects' `:color` and `:weight` are documented as not-honored in v1, and headings render at Regular weight (no automatic bold). Both are tracked in #106 as a single follow-up; the docs in this PR honestly call out the limitation.

## Test plan

- [x] `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin` clean
- [x] `odin test src/redin/markdown -collection:lib=lib -collection:luajit=vendor/luajit` — 20/20
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 129/129
- [x] `bash test/ui/run-all.sh --headless` (default build) — all suites pass
- [x] `odin build … -define:REDIN_AGENT=true …` + `bash test/ui/run-all.sh --headless` — all suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)