### PR TITLE
feat: compile-time flags for dev / profile / track-mem

### DIFF
--- a/.claude/skills/redin-dev/SKILL.md
+++ b/.claude/skills/redin-dev/SKILL.md
@@ -11,7 +11,7 @@ Use this skill when building redin apps (Fennel or Lua) or extending the framewo
 
 ```
 src/cmd/redin/      Thin CLI entry (package main)
-  main.odin         Arg parsing, --track-mem setup, calls redin.run
+  main.odin         Arg parsing (app file only), tracker setup gated on REDIN_TRACK_MEM, calls redin.run
 src/redin/          Importable framework (package redin)
   runtime.odin      Public API: set_window/set_size/set_title, on_init/
                     on_input/on_frame/on_shutdown hooks, run, request_shutdown
@@ -19,7 +19,7 @@ src/redin/          Importable framework (package redin)
   bridge/           Lua/Fennel bridge
     bridge.odin     Host callbacks, Lua<->Odin conversion, canvas draw execution
     lua_api.odin    LuaJIT FFI bindings
-    devserver.odin  HTTP dev server (--dev mode)
+    devserver.odin  HTTP dev server (gated on REDIN_DEV / REDIN_AGENT)
     hotreload.odin  File watcher for hot reload
     loader.odin     App file loading (.fnl via fennel.dofile, .lua via luaL_dofile)
   canvas/           Canvas provider system
@@ -226,7 +226,7 @@ canvas.register("my-provider", my_provider)
      :dispatch-later {:ms 1000 :dispatch [:event/timeout]}}))
 ```
 
-## Dev server (--dev mode, default port 8800)
+## Dev server (built with `-define:REDIN_DEV=true` or `./build-dev.sh`, default port 8800)
 
 Authenticated: every non-OPTIONS request needs `Authorization: Bearer <token>`, where the token is written to `./.redin-token` on startup (0600, deleted on shutdown). The `Host` header must also be `localhost:<port>` or `127.0.0.1:<port>`. Bound port is in `./.redin-port`.
 
@@ -259,7 +259,7 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:$PORT/state
 
 ### Agent channel (`REDIN_AGENT`)
 
-The agent channel is compiled in only when the binary is built with `-define:REDIN_AGENT=true`. Default release builds carry zero agent code. When the flag is set, the dev-server listener starts even without `--dev` and the `/agent/*` endpoints are active. Any node type except `:canvas` accepts an `:agent :read` or `:agent :edit` attribute (combined with `:id`) to make it addressable. Writes dispatch `:event/agent-edit {id "<id>" content <value>}` into the Fennel event queue; the runtime stores the value in `db.agent[id]` and applies overrides at view-render time. App code can also subscribe via `(subscribe [:agent <id>])`.
+The agent channel is compiled in only when the binary is built with `-define:REDIN_AGENT=true`. Default release builds carry zero agent code. When the flag is set, the dev-server listener starts even without `REDIN_DEV` and the `/agent/*` endpoints are active. Any node type except `:canvas` accepts an `:agent :read` or `:agent :edit` attribute (combined with `:id`) to make it addressable. Writes dispatch `:event/agent-edit {id "<id>" content <value>}` into the Fennel event queue; the runtime stores the value in `db.agent[id]` and applies overrides at view-render time. App code can also subscribe via `(subscribe [:agent <id>])`.
 
 ```bash
 odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
@@ -275,9 +275,10 @@ luajit test/lua/runner.lua test/lua/test_*.fnl
 
 Pattern: `(local t {}) (fn t.test-name [] (assert ...)) t`
 
-### UI integration tests (requires --dev mode)
+### UI integration tests (requires dev-mode binary)
 ```bash
-./build/redin --dev test/ui/<component>_app.fnl &
+./build-dev.sh
+./build/redin test/ui/<component>_app.fnl &
 bb test/ui/run.bb test/ui/test_<component>.bb
 
 # Or run the whole suite:
@@ -411,13 +412,8 @@ main :: proc() {
     redin.on_frame(per_frame_tick)
 
     cfg: redin.Config
-    cfg.app = "main.fnl"
     for arg in os.args[1:] {
-        switch arg {
-        case "--dev":     cfg.dev = true
-        case "--profile": cfg.profile = true
-        case:             cfg.app = arg
-        }
+        cfg.app = arg
     }
     redin.run(cfg)
 }
@@ -426,10 +422,9 @@ main :: proc() {
 ### Running
 
 ```bash
-./redinw --dev main.fnl          # dev server + hot reload
-./redinw main.fnl                # normal mode
-./redinw --track-mem main.fnl    # memory leak tracking
-./build.sh                        # (--native only) rebuild after editing app.odin
+./build-dev.sh                    # rebuild with REDIN_DEV=true (dev server enabled)
+./build/redin main.fnl            # built with REDIN_DEV → dev server starts
+./build.sh                        # (--native only) rebuild after editing app.odin (release build)
 ```
 
 ## Key conventions

--- a/.claude/skills/redin-maintenance/SKILL.md
+++ b/.claude/skills/redin-maintenance/SKILL.md
@@ -45,7 +45,8 @@ Builds redin, then for each pair: starts dev server, runs tests, shuts down. Req
 ### Run one
 
 ```bash
-./build/redin --dev test/ui/<component>_app.fnl &
+./build-dev.sh
+./build/redin test/ui/<component>_app.fnl &
 bb test/ui/run.bb test/ui/test_<component>.bb
 PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
@@ -68,20 +69,19 @@ Drag tests exercise the real input pipeline through the `/input/takeover` / `/in
 
 ## Memory leak detection
 
-Add `--track-mem` to enable the tracking allocator:
+Build with `./build-dev.sh` to enable the tracking allocator (REDIN_TRACK_MEM is baked in):
 
 ```bash
-./build/redin --dev --track-mem test/ui/<component>_app.fnl
+./build-dev.sh
+./build/redin test/ui/<component>_app.fnl
 ```
 
 On shutdown, the tracking allocator reports outstanding allocations. Check stderr/stdout for lines containing `leak` or `outstanding`.
 
-To run all integration tests with memory tracking:
+To run all integration tests with memory tracking, the tracker is already active in the dev build — just run:
 
 ```bash
-# Modify run-all.sh's server start line to include --track-mem:
-#   "$BINARY" --dev --track-mem "$app_file" &
-# Or run manually per-component as above.
+bash test/ui/run-all.sh --headless
 ```
 
 ## Verification checklist
@@ -92,7 +92,7 @@ After changes to the framework, verify in this order:
 2. **Runtime tests** — `luajit test/lua/runner.lua test/lua/test_*.fnl`
 3. **Integration tests** — `bash test/ui/run-all.sh`
 4. **Visual check** — for rendering changes, take a screenshot via `GET /screenshot` on the dev server and inspect
-5. **Memory check** — for allocation/bridge changes, run with `--track-mem` and verify no leaks on shutdown
+5. **Memory check** — for allocation/bridge changes, use `./build-dev.sh && bash test/ui/run-all.sh` (tracker is built in) and verify no leaks on shutdown
 6. **Docs + skills** — see below
 
 ## Keeping docs and skills in sync
@@ -133,7 +133,7 @@ If a contract was described incorrectly (not just incompletely), fix the doc eve
 | `src/redin/types/` | Yes | - | Yes | - |
 | `src/redin/text/` | Yes | - | Yes (multiline) | - |
 | `src/redin/canvas/` | Yes | - | Yes (canvas) | - |
-| `src/cmd/redin/` (CLI flags, --track-mem) | Yes | - | - | Yes |
+| `src/cmd/redin/` (top-level main, REDIN_TRACK_MEM gating) | Yes | - | - | Yes |
 
 ## Agent channel build
 
@@ -141,8 +141,7 @@ The agent channel feature is gated by `-define:REDIN_AGENT=true`. To
 run its UI test suite, build with the flag:
 
 ```bash
-odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
-    -define:REDIN_AGENT=true -out:build/redin
+./build-dev.sh -define:REDIN_AGENT=true
 bash test/ui/run-all.sh --headless
 ```
 
@@ -179,7 +178,7 @@ The release workflow runs `scripts/smoke-native.sh <tarball>` after packaging an
 2. Copy the local checkout's `src/redin/.` into `<tmp>/.redin/src/redin/` (simulates redin-cli's `fetch-source`).
 3. Drop a project-root `app.odin` (with `import redin "./.redin/src/redin"`) and `build.sh`.
 4. Run `./build.sh` from project root (uses `-collection:lib=.redin/lib -collection:luajit=.redin/vendor/luajit`).
-5. Launch the resulting binary under `--dev`, assert `/frames` contains a sentinel string from `main.fnl`. The sentinel check is what catches broken runtime lookup — just polling `/state` returns 200 even when Fennel fails to load.
+5. Launch the resulting binary, assert `/frames` contains a sentinel string from `main.fnl`. The sentinel check is what catches broken runtime lookup — just polling `/state` returns 200 even when Fennel fails to load.
 
 Run it locally before a release:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,10 @@ jobs:
         run: |
           luajit test/lua/runner.lua test/lua/test_*.fnl
           mkdir -p build
-          odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+          ./build-dev.sh
 
       - name: Build release binary
-        run: odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin -o:speed
+        run: ./build-dev.sh -o:speed
 
       - name: AOT compile Fennel runtime
         run: |
@@ -97,6 +97,7 @@ jobs:
           rm -rf dist-agent
           mkdir -p dist-agent
           odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
+            -define:REDIN_DEV=true -define:REDIN_PROFILE=true -define:REDIN_TRACK_MEM=true \
             -define:REDIN_AGENT=true -out:dist-agent/redin -o:speed
 
       - name: Package agent release
@@ -146,14 +147,15 @@ jobs:
           files: artifacts/**/*.tar.gz
           body: |
             ## What's included
-            - `redin` binary (Linux x86_64, LuaJIT statically linked)
+            - `redin` binary (Linux x86_64, LuaJIT statically linked,
+              built with REDIN_DEV / REDIN_PROFILE / REDIN_TRACK_MEM)
             - AOT-compiled Fennel runtime
-            - Fennel compiler (for --dev mode hot reload)
+            - Fennel compiler (for hot reload)
             - Developer documentation (guides + reference)
             - Claude Code skill for redin development
 
             ## Quick start
             ```
             redin-cli new-fnl my-app
-            cd my-app && ./redinw --dev main.fnl
+            cd my-app && ./redinw main.fnl
             ```

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build redin
         run: |
           mkdir -p build
-          odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+          ./build-dev.sh
 
   test-agent:
     runs-on: ubuntu-latest
@@ -67,8 +67,7 @@ jobs:
       - name: Build redin (REDIN_AGENT=true)
         run: |
           mkdir -p build
-          odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
-            -define:REDIN_AGENT=true -out:build/redin
+          ./build-dev.sh -define:REDIN_AGENT=true
 
       - name: Run UI tests under xvfb (includes agent suite)
         run: bash test/ui/run-all.sh --headless

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,45 +18,55 @@ These docs are the source of truth. When implementing, follow them exactly.
 
 - **Host/renderer:** Odin + Raylib
 - **Scripting:** LuaJIT (Lua 5.1 API) with Fennel compiled to Lua 5.1 target
-- **AI interface:** localhost HTTP dev server (`--dev` mode). Default port 8800; if busy, walks upward to the next free port. Bound port is written to `./.redin-port`; a per-run random auth token is written to `./.redin-token` (mode 0600). Both files are removed on shutdown. Every non-`OPTIONS` request must include `Authorization: Bearer <contents of .redin-token>`; the server also rejects requests whose `Host` header isn't `localhost:<port>` or `127.0.0.1:<port>` (DNS-rebinding defence). Optional `--profile` flag adds a 5-phase frame-timing ring buffer exposed at `/profile` and an F3-togglable on-screen overlay.
+- **AI interface:** localhost HTTP dev server (compile with `-define:REDIN_DEV=true`, or use `./build-dev.sh`). Default port 8800; if busy, walks upward to the next free port. Bound port is written to `./.redin-port`; a per-run random auth token is written to `./.redin-token` (mode 0600). Both files are removed on shutdown. Every non-`OPTIONS` request must include `Authorization: Bearer <contents of .redin-token>`; the server also rejects requests whose `Host` header isn't `localhost:<port>` or `127.0.0.1:<port>` (DNS-rebinding defence). Build with `-define:REDIN_PROFILE=true` to add a 5-phase frame-timing ring buffer exposed at `/profile` and an F3-togglable on-screen overlay. Build with `-define:REDIN_TRACK_MEM=true` to enable the tracking allocator and a leak dump on shutdown.
 
 ## Building
 
-Default build:
+Release-stripped build (no dev server, no profile, no tracker):
 
 ```bash
 odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 ```
 
-With the agent channel feature:
+Dev build (REDIN_DEV + REDIN_PROFILE + REDIN_TRACK_MEM all baked in):
 
 ```bash
-odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
-    -define:REDIN_AGENT=true -out:build/redin
+./build-dev.sh
+```
+
+Add the agent channel:
+
+```bash
+./build-dev.sh -define:REDIN_AGENT=true
 ```
 
 When `REDIN_AGENT` is set, the dev-server listener starts in any run
-(not just `--dev`) and exposes the `/agent/*` endpoints. Default
-release builds carry zero agent code.
+(even without `REDIN_DEV`) and exposes the `/agent/*` endpoints.
+Default release builds carry zero agent code, zero dev-server code,
+zero profile instrumentation, and zero tracking-allocator overhead.
 
 ## Running
 
 ```bash
-./build/redin examples/kitchen-sink.fnl        # normal mode
-./build/redin --dev examples/kitchen-sink.fnl   # dev server + hot reload
+./build/redin examples/kitchen-sink.fnl
 ```
+
+Whether the dev server starts depends on the build flags. A binary
+built with `./build-dev.sh` starts the dev server unconditionally; a
+bare `odin build` binary never does. There are no runtime CLI flags.
 
 ## Testing
 
 ```bash
-# Fennel runtime tests (95 tests)
+# Fennel runtime tests
 luajit test/lua/runner.lua test/lua/test_*.fnl
 
-# UI integration tests (requires running dev server)
-./build/redin --dev test/ui/<app>.fnl &
+# UI integration tests (run the dev binary)
+./build-dev.sh
+./build/redin test/ui/<app>.fnl &
 bb test/ui/run.bb test/ui/test_<name>.bb
 
-# Build check
+# Release build check
 odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 ```
 
@@ -72,7 +82,7 @@ Existing UI tests: `test_smoke` (basic dispatch/state), `test_input` (input chan
 
 ```
 src/cmd/redin/      Thin CLI entry (package main)
-  main.odin         Arg parsing, --track-mem setup, calls redin.run
+  main.odin         Arg parsing (app file only), tracker setup gated on REDIN_TRACK_MEM, calls redin.run
 src/redin/          Importable framework package (package redin)
   runtime.odin      Public API: set_window/set_size/set_title, on_* hooks, run, request_shutdown
   render.odin       Raylib renderer (node_rects for hit testing)
@@ -81,7 +91,7 @@ src/redin/          Importable framework package (package redin)
     lua_api.odin    LuaJIT FFI bindings (statically linked)
     http_client.odin  Async HTTP via threads
     json.odin       JSON encode/decode for Lua
-    devserver.odin  HTTP dev server (--dev mode only)
+    devserver.odin  HTTP dev server (gated on REDIN_DEV / REDIN_AGENT)
     hotreload.odin  File watcher for .fnl hot reload
     loader.odin     App file loading (Fennel via fennel.dofile, Lua via luaL_dofile)
   input/            Input handling package
@@ -101,7 +111,13 @@ src/runtime/        Fennel runtime (loaded by bridge at startup)
 
 ## Dev server HTTP API
 
-Available when running with `--dev`. Listens on port 8800 by default; walks upward (8801, 8802, ...) if busy, and writes the bound port to `./.redin-port`. A per-run random auth token is written to `./.redin-token` (0600). Every non-`OPTIONS` request must carry `Authorization: Bearer <token>`, and the `Host` header must be `localhost:<port>` / `127.0.0.1:<port>`.
+Available when the binary was built with `-define:REDIN_DEV=true`
+(or `-define:REDIN_AGENT=true`). Listens on port 8800 by default;
+walks upward (8801, 8802, ...) if busy, and writes the bound port to
+`./.redin-port`. A per-run random auth token is written to
+`./.redin-token` (0600). Every non-`OPTIONS` request must carry
+`Authorization: Bearer <token>`, and the `Host` header must be
+`localhost:<port>` / `127.0.0.1:<port>`.
 
 | Method | Path | Description |
 |--------|------|-------------|
@@ -109,7 +125,7 @@ Available when running with `--dev`. Listens on port 8800 by default; walks upwa
 | `GET` | `/state` | Full app state |
 | `GET` | `/state/<dot.path>` | Nested state lookup (e.g. `/state/form.name`) |
 | `GET` | `/aspects` | Current theme map |
-| `GET` | `/profile` | Ring-buffered frame timings (requires `--profile`) |
+| `GET` | `/profile` | Ring-buffered frame timings (requires `-define:REDIN_PROFILE=true`) |
 | `GET` | `/screenshot` | PNG screenshot of the window |
 | `POST` | `/events` | Dispatch an event (JSON body: `[:event-name, payload]`) |
 | `POST` | `/click` | Inject a mouse click (JSON body: `{"x":N,"y":N}`) |

--- a/build-dev.sh
+++ b/build-dev.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# build-dev.sh — build the redin binary with all dev features compiled in.
+#
+# This is the everyday dev build. The release-stripped variant is just
+# `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin`
+# without any -define flags.
+#
+# Forwards "$@" so callers can append extra flags, e.g.:
+#   ./build-dev.sh -define:REDIN_AGENT=true     # dev + agent channel
+#   ./build-dev.sh -o:speed                     # optimized dev build
+set -e
+exec odin build src/cmd/redin \
+    -collection:lib=lib -collection:luajit=vendor/luajit \
+    -define:REDIN_DEV=true \
+    -define:REDIN_PROFILE=true \
+    -define:REDIN_TRACK_MEM=true \
+    -out:build/redin "$@"

--- a/docs/core-api.md
+++ b/docs/core-api.md
@@ -86,11 +86,11 @@ For most apps this is fine — the app author chose the URL. If your app embeds 
 
 A 16 MiB cap on response bodies is enforced by the host (oversized announcements fail fast with a "Response body too large" error). Per-request wall-clock timeout is not yet wired through to the worker thread; the `:timeout` field on the effect is currently advisory.
 
-### Dev server (`--dev`)
+### Dev server (built with `-define:REDIN_DEV=true`)
 
 The dev server is the one place redin actively defends against external callers. It binds loopback only and requires a per-run Bearer token written to `./.redin-token` (mode 0600) plus a matching `Host` header to defend against DNS rebinding. See [Dev server](#dev-server-http) below for details.
 
-Production builds (no `--dev`) don't run the server at all and have no listening sockets.
+Production builds (built without `-define:REDIN_DEV=true`) don't run the server at all and have no listening sockets.
 
 ---
 
@@ -552,7 +552,7 @@ Providers register in Odin via `canvas.register(name, provider)`. See the [canva
 
 ## Dev server (HTTP)
 
-Runs on `localhost:8800` when started with `--dev` flag. All responses are JSON unless noted.
+Runs on `localhost:8800` when the binary was built with `-define:REDIN_DEV=true` (or `-define:REDIN_AGENT=true`). All responses are JSON unless noted.
 
 **Authentication.** Every non-`OPTIONS` request must include `Authorization: Bearer <token>`, where the token is read from `./.redin-token` (generated on startup, mode 0600, removed on shutdown). The server also verifies the `Host` header is `localhost:<port>` or `127.0.0.1:<port>` (DNS-rebinding defence). Missing token → `401`, bad Host → `403`, `OPTIONS` → `405` (CORS preflight not served — the endpoint is for local tools, not browsers). See [dev-server reference](../reference/dev-server.md) for usage examples.
 
@@ -654,7 +654,7 @@ odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
 ```
 
 Default release builds carry zero agent code. When the flag is set,
-the dev-server listener starts even without `--dev` and exposes the
+the dev-server listener starts automatically and exposes the
 `/agent/*` endpoints.
 
 The `/frames` endpoint shape is unchanged when `REDIN_AGENT` is on.

--- a/docs/guide/lua-guide.md
+++ b/docs/guide/lua-guide.md
@@ -236,13 +236,15 @@ Then run your Lua app:
 ./build/redin todo.lua
 ```
 
-Dev mode starts the HTTP dev server (picks port 8800 by default; walks upward if busy):
+To enable the dev server, build with `-define:REDIN_DEV=true`:
 
 ```sh
-./build/redin --dev todo.lua
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
+    -define:REDIN_DEV=true -out:build/redin-dev
+./build/redin-dev todo.lua
 ```
 
-The bound port is written to `./.redin-port` and a per-run bearer token to `./.redin-token`:
+The HTTP dev server picks port 8800 by default (walks upward if busy) and writes the bound port to `./.redin-port` plus a per-run bearer token to `./.redin-token`:
 
 ```sh
 PORT=$(cat .redin-port)

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -89,11 +89,15 @@ The window opens. Click the button -- the counter increments.
 
 ### Dev mode
 
+Build with the dev server enabled:
+
 ```sh
-./build/redin --dev counter.fnl
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
+    -define:REDIN_DEV=true -out:build/redin-dev
+./build/redin-dev counter.fnl
 ```
 
-`--dev` enables the HTTP dev server. It picks port 8800 by default (walks upward if busy) and writes the bound port to `./.redin-port` plus a per-run bearer token to `./.redin-token`.
+The HTTP dev server picks port 8800 by default (walks upward if busy) and writes the bound port to `./.redin-port` plus a per-run bearer token to `./.redin-token`.
 
 ```sh
 PORT=$(cat .redin-port)

--- a/docs/reference/dev-server.md
+++ b/docs/reference/dev-server.md
@@ -6,7 +6,7 @@ HTTP server for inspecting and driving redin apps from external tools.
 
 ## Overview
 
-Starts when the app is launched with `--dev`. Listens on `localhost:8800` (walks upward if busy).
+Starts when the binary was built with `-define:REDIN_DEV=true` (or `-define:REDIN_AGENT=true`). Listens on `localhost:8800` (walks upward if busy).
 
 Read endpoints reflect the last state pushed to the host. Write endpoints queue events into the main input channel as if they came from real user input.
 
@@ -32,7 +32,7 @@ AUTH="Authorization: Bearer $TOKEN"
 
 ### Runtime caveats
 
-**`--dev` trusts its filesystem.** The hot-reload watcher re-requires `src/runtime/*.fnl` whenever their mtimes advance. Anyone who can write to `src/runtime` gets code execution in the running process on the next tick. Don't run `--dev` from a world-writable directory, and don't leave `--dev` enabled in production.
+**When built with `-define:REDIN_DEV=true`, the framework trusts its filesystem.** The hot-reload watcher re-requires `src/runtime/*.fnl` whenever their mtimes advance. Anyone who can write to `src/runtime` gets code execution in the running process on the next tick. Don't run a dev build from a world-writable directory, and don't ship dev builds in production.
 
 **The bearer token is a capability.** Any holder can dispatch events, which means any app-registered `:shell` or `:http` effect is one authenticated POST away from arbitrary shell execution or network access in the user's context. The token is 0600 and per-run, so this only matters if the token leaks — but plan accordingly when wiring `:shell` handlers.
 
@@ -74,7 +74,7 @@ Response: full theme as JSON object (serialized from host-side `Theme` structs).
 
 ### `GET /profile` -- frame timing ring buffer
 
-Returns frame-timing samples from the ring buffer. Requires `--dev` (for the server) and `--profile` (to enable collection). When the host is started without `--profile`, the route returns `404 "profile not enabled"`.
+Returns frame-timing samples from the ring buffer. Requires the binary to be built with `-define:REDIN_DEV=true` (for the server) and `-define:REDIN_PROFILE=true` (to enable collection). When the binary was built without `-define:REDIN_PROFILE=true`, the route returns `404 "profile not enabled"`.
 
 **Example response:**
 
@@ -99,7 +99,7 @@ Returns frame-timing samples from the ring buffer. Requires `--dev` (for the ser
 
 The sum of `phase_us` may be less than `total_us` because glue code between phases (event bookkeeping, temp_allocator reset, hotreload check) and the Raylib vsync wait inside `EndDrawing` are not attributed to any phase.
 
-**CLI flag:** `--profile` activates collection and the on-screen overlay (top-right corner). Press `F3` at runtime to hide/show the overlay without restarting. The overlay is independent of `--dev` -- you can run `--profile` alone for local eyeballing or `--profile --dev` to expose the endpoint.
+**Build flag:** `-define:REDIN_PROFILE=true` activates collection and the on-screen overlay (top-right corner). Press `F3` at runtime to hide/show the overlay without restarting. The overlay is independent of `-define:REDIN_DEV=true` -- you can build with `-define:REDIN_PROFILE=true` alone for local eyeballing or combine both flags to expose the endpoint.
 
 ### `GET /screenshot` -- PNG capture
 
@@ -238,8 +238,7 @@ curl -sH "$H" -X POST http://localhost:$PORT/input/release
 
 These endpoints are compiled in only when the binary is built with
 `-define:REDIN_AGENT=true`. Without that flag the routes return 404.
-When the flag is set, the dev-server listener starts even without
-`--dev`.
+When the flag is set, the dev-server listener starts automatically.
 
 ```bash
 odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \

--- a/docs/reference/native-bridge.md
+++ b/docs/reference/native-bridge.md
@@ -24,7 +24,7 @@ my_signal :: proc(L: ^bridge.Lua_State) -> i32 {
 
 main :: proc() {
     bridge.register_cfunc("my_signal", my_signal)
-    redin.run({app = "main.fnl", dev = true})
+    redin.run({app = "main.fnl"})
 }
 ```
 
@@ -32,7 +32,7 @@ From Fennel: `(redin.my_signal 42)`. From Lua: `redin.my_signal(42)`.
 
 **Timing:** safe before *or* after `bridge.init`. Registrations made before `redin.run` (which is when `bridge.init` runs) are buffered and flushed inside init, after the `redin` Lua global is created.
 
-**Duplicate names:** silent replace. In dev mode (`Config.dev == true`), logs a stderr warning before replacing — same policy as `canvas.register`.
+**Duplicate names:** silent replace. When the binary was built with `-define:REDIN_DEV=true`, logs a stderr warning before replacing — same policy as `canvas.register`.
 
 ### `bridge.register_cfunc_raw(name: cstring, fn: Lua_CFunction)`
 

--- a/docs/superpowers/plans/2026-05-03-compile-time-flags.md
+++ b/docs/superpowers/plans/2026-05-03-compile-time-flags.md
@@ -1,0 +1,2092 @@
+# Compile-time flags for dev / profile / track-mem — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the runtime CLI flags `--dev`, `--profile`, and `--track-mem` into compile-time `-define` constants matching the existing `REDIN_AGENT` pattern, so release binaries strip the dev server, profile instrumentation, and tracking allocator to zero bytes.
+
+**Architecture:** Each feature gets a `#config(REDIN_*, false)` constant declared in the package(s) that consume it. Bodies of the gated procs live inside `when REDIN_* { ... }` blocks. CLI flag parsing is removed; the `redin.Config` struct shrinks to `{app: string}`. A new top-level `./build-dev.sh` bakes in all three flags for the everyday dev workflow. Bare `odin build` stays as the release-stripped path.
+
+**Tech Stack:** Odin (`#config` + `when`), bash (`./build-dev.sh`), GitHub Actions (workflows), Babashka (test scripts unchanged), no new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-05-03-compile-time-flags-design.md`
+
+---
+
+## File Structure
+
+**Modified:**
+
+- `src/redin/bridge/bridge.odin` — add `REDIN_DEV` constant (next to existing `REDIN_AGENT`), drop `Bridge.dev_mode` field, drop `dev_mode` parameter from `init`, replace `if dev_mode || REDIN_AGENT` patterns with `when REDIN_DEV || REDIN_AGENT`
+- `src/redin/bridge/devserver.odin` — wrap `devserver_init`/`destroy`/`poll` callers' guard logic at use sites (already `when REDIN_AGENT`-aware in places)
+- `src/redin/canvas/canvas.odin` — declare `REDIN_DEV`, drop `g_dev_mode` + `set_dev_mode`, replace `if g_dev_mode` with `when REDIN_DEV`
+- `src/redin/profile/profile.odin` — declare `REDIN_PROFILE`, replace `init(bool)` body with `when REDIN_PROFILE`-gated initialization, gate every public proc's body in `when REDIN_PROFILE`
+- `src/redin/profile/overlay.odin` — gate body in `when REDIN_PROFILE`
+- `src/redin/runtime.odin` — drop `Config.dev` and `Config.profile` fields, drop `canvas.set_dev_mode` call, simplify `bridge.init` and `profile.init` calls
+- `src/cmd/redin/main.odin` — declare `REDIN_TRACK_MEM`, drop `--dev` / `--profile` / `--track-mem` arg parsing, wrap tracker setup in `when REDIN_TRACK_MEM`
+- `test/ui/run-all.sh` — call `./build-dev.sh` instead of inline `odin build`, drop `--dev` from binary invocation
+- `.github/workflows/test.yml` — same swap; agent test job uses `./build-dev.sh -define:REDIN_AGENT=true`
+- `.github/workflows/release.yml` — main build uses `./build-dev.sh`; agent build appends `-define:REDIN_AGENT=true`
+- `release.sh` — call `./build-dev.sh`
+- `scripts/smoke-native.sh` — update inline `app.odin` template (drop `cfg.dev`), update inline `build.sh` template (add `-define:REDIN_DEV=true` etc.), drop `--dev` from binary invocation
+- `CLAUDE.md` — Building, Running, Dev server sections
+- `docs/core-api.md` — `--dev` / `--profile` / `--track-mem` references
+- `docs/reference/dev-server.md` — gating model
+- `docs/reference/native-bridge.md` — `Config.dev` reference
+- `.claude/skills/redin-dev/SKILL.md` — Running, Dev server, native scaffold sections
+- `.claude/skills/redin-maintenance/SKILL.md` — Build, UI tests, `--track-mem`, agent build sections
+
+**Created:**
+
+- `build-dev.sh` — top-level script that wraps `odin build` with the three `-define` flags; forwards `"$@"` for additional flags
+
+**Deleted:** none.
+
+---
+
+### Task 1: Add `REDIN_DEV`, `REDIN_PROFILE`, `REDIN_TRACK_MEM` constants
+
+**Files:**
+- Modify: `src/redin/bridge/bridge.odin:1-7` (add `REDIN_DEV` next to `REDIN_AGENT`)
+- Modify: `src/redin/canvas/canvas.odin:1-12` (add `REDIN_DEV` declaration)
+- Modify: `src/redin/profile/profile.odin:1-7` (add `REDIN_PROFILE`)
+- Modify: `src/cmd/redin/main.odin:1-7` (add `REDIN_TRACK_MEM`)
+
+These declarations are no-ops (they don't gate any code yet). Adding them first lets every later task reference the constant from its package without a separate "introduce constant" step.
+
+- [ ] **Step 1: Add `REDIN_DEV` to bridge package**
+
+Open `src/redin/bridge/bridge.odin`. The file starts with:
+
+```odin
+package bridge
+
+// Compile-time flag enabling the agent channel feature. Default is false;
+// set with `odin build ... -define:REDIN_AGENT=true`. When false, the
+// agent endpoints, walker, and listener-gate widening all compile out
+// to zero bytes.
+REDIN_AGENT :: #config(REDIN_AGENT, false)
+```
+
+Add after the `REDIN_AGENT` line:
+
+```odin
+// Compile-time flag enabling the dev server, hot reload, and dev-only
+// canvas warnings. Default is false; set with `odin build ... -define:REDIN_DEV=true`
+// (or use `./build-dev.sh`). When false, the listener thread, file watcher,
+// port/token files, and dev-only HTTP handlers compile out to zero bytes.
+REDIN_DEV :: #config(REDIN_DEV, false)
+```
+
+- [ ] **Step 2: Add `REDIN_DEV` to canvas package**
+
+Open `src/redin/canvas/canvas.odin`. The file starts with:
+
+```odin
+// src/redin/canvas/canvas.odin
+package canvas
+
+import "core:fmt"
+import rl "vendor:raylib"
+```
+
+Add after the `package canvas` line (before imports):
+
+```odin
+// src/redin/canvas/canvas.odin
+package canvas
+
+// Same compile-time flag declared in bridge — Odin's `#config` reads
+// the same -define value regardless of which package declares it, so
+// this stays in lockstep without a cross-package import.
+REDIN_DEV :: #config(REDIN_DEV, false)
+
+import "core:fmt"
+import rl "vendor:raylib"
+```
+
+- [ ] **Step 3: Add `REDIN_PROFILE` to profile package**
+
+Open `src/redin/profile/profile.odin`. The file starts with:
+
+```odin
+package profile
+
+import "core:sync"
+import "core:time"
+```
+
+Insert the constant declaration:
+
+```odin
+package profile
+
+// Compile-time flag enabling frame-timing instrumentation, the F3
+// overlay, and the /profile HTTP endpoint. Default is false; set with
+// `odin build ... -define:REDIN_PROFILE=true`. When false, every public
+// proc body in this package compiles out to zero bytes.
+REDIN_PROFILE :: #config(REDIN_PROFILE, false)
+
+import "core:sync"
+import "core:time"
+```
+
+- [ ] **Step 4: Add `REDIN_TRACK_MEM` to main**
+
+Open `src/cmd/redin/main.odin`. The file starts with:
+
+```odin
+package main
+
+import "core:fmt"
+import "core:mem"
+import "core:os"
+import redin "../../redin"
+```
+
+Insert the constant declaration:
+
+```odin
+package main
+
+// Compile-time flag enabling the tracking allocator. Default is false;
+// set with `odin build ... -define:REDIN_TRACK_MEM=true`. When false,
+// the tracker setup and leak dump compile out to zero bytes.
+REDIN_TRACK_MEM :: #config(REDIN_TRACK_MEM, false)
+
+import "core:fmt"
+import "core:mem"
+import "core:os"
+import redin "../../redin"
+```
+
+- [ ] **Step 5: Verify build**
+
+Run:
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+```
+
+Expected: clean build, no output. The constants are declared but unused yet.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/redin/bridge/bridge.odin src/redin/canvas/canvas.odin \
+        src/redin/profile/profile.odin src/cmd/redin/main.odin
+git commit -m "$(cat <<'EOF'
+feat(config): declare REDIN_DEV / REDIN_PROFILE / REDIN_TRACK_MEM constants
+
+Foundation for converting --dev / --profile / --track-mem CLI flags to
+compile-time -define constants. These declarations are no-ops on their
+own; subsequent commits gate code paths behind `when` blocks reading
+these flags. Same shape as the existing REDIN_AGENT pattern.
+EOF
+)"
+```
+
+---
+
+### Task 2: Create `./build-dev.sh`
+
+**Files:**
+- Create: `build-dev.sh`
+
+The dev binary becomes a one-line script. Tests in later tasks switch to it; without it, removing the runtime CLI flags would leave us unable to build a dev binary.
+
+- [ ] **Step 1: Write the script**
+
+Create `build-dev.sh`:
+
+```bash
+#!/usr/bin/env bash
+# build-dev.sh — build the redin binary with all dev features compiled in.
+#
+# This is the everyday dev build. The release-stripped variant is just
+# `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin`
+# without any -define flags.
+#
+# Forwards "$@" so callers can append extra flags, e.g.:
+#   ./build-dev.sh -define:REDIN_AGENT=true     # dev + agent channel
+#   ./build-dev.sh -o:speed                     # optimized dev build
+set -e
+exec odin build src/cmd/redin \
+    -collection:lib=lib -collection:luajit=vendor/luajit \
+    -define:REDIN_DEV=true \
+    -define:REDIN_PROFILE=true \
+    -define:REDIN_TRACK_MEM=true \
+    -out:build/redin "$@"
+```
+
+- [ ] **Step 2: Make executable**
+
+```bash
+chmod +x build-dev.sh
+```
+
+- [ ] **Step 3: Run it to verify it builds equivalently**
+
+```bash
+./build-dev.sh
+```
+
+Expected: clean build, no output. Resulting `build/redin` behaves identically to the previous release binary because the constants don't gate anything yet.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add build-dev.sh
+git commit -m "$(cat <<'EOF'
+feat(build): add ./build-dev.sh for the everyday dev binary
+
+One-line wrapper around `odin build` that bakes in REDIN_DEV / REDIN_PROFILE
+/ REDIN_TRACK_MEM. Forwards "$@" so callers can append extra flags
+(REDIN_AGENT, optimization level, etc.). Bare `odin build` stays as the
+release-stripped path.
+EOF
+)"
+```
+
+---
+
+### Task 3: Migrate canvas package's dev gate
+
+**Files:**
+- Modify: `src/redin/canvas/canvas.odin:29-36, 38-46`
+- Modify: `src/redin/runtime.odin:156`
+
+The canvas package logs a warning when `register` is called with a duplicate name. The warning is suppressed unless `g_dev_mode` is true. Replace the runtime bool with a compile-time `when REDIN_DEV` gate, then drop `set_dev_mode` and its caller.
+
+- [ ] **Step 1: Replace `g_dev_mode` + `set_dev_mode` with `when REDIN_DEV`**
+
+In `src/redin/canvas/canvas.odin`, find:
+
+```odin
+@(private = "file")
+g_dev_mode: bool
+
+// Toggle dev-mode warnings. Called by redin.run; user code shouldn't need
+// this directly.
+set_dev_mode :: proc(dev: bool) {
+	g_dev_mode = dev
+}
+
+register :: proc(name: string, provider: Canvas_Provider) {
+	if existing, ok := entries[name]; ok {
+		if g_dev_mode {
+			fmt.eprintfln("redin: warn: canvas.register(%q) replaces an existing provider", name)
+		}
+		if existing.provider.stop != nil {
+			existing.provider.stop()
+		}
+	}
+```
+
+Replace with:
+
+```odin
+register :: proc(name: string, provider: Canvas_Provider) {
+	if existing, ok := entries[name]; ok {
+		when REDIN_DEV {
+			fmt.eprintfln("redin: warn: canvas.register(%q) replaces an existing provider", name)
+		}
+		if existing.provider.stop != nil {
+			existing.provider.stop()
+		}
+	}
+```
+
+The `g_dev_mode` variable, the `set_dev_mode` proc, and the `@(private = "file")` line above `g_dev_mode` all go.
+
+- [ ] **Step 2: Drop the `canvas.set_dev_mode` caller**
+
+In `src/redin/runtime.odin`, find around line 156:
+
+```odin
+	canvas.set_dev_mode(cfg.dev)
+```
+
+Delete the line entirely. The line above (`profile.init(cfg.profile)`) stays for now; Task 4 handles it.
+
+- [ ] **Step 3: Verify build**
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+```
+
+Expected: clean build. Without `-define:REDIN_DEV=true`, the canvas warning compiles out — the `fmt` import is still in use elsewhere in the file (`fmt.eprintfln` is still present in the `when` block), so no import errors.
+
+- [ ] **Step 4: Run UI tests**
+
+```bash
+./build-dev.sh
+bash test/ui/run-all.sh --headless
+```
+
+Expected: all suites pass. Canvas test exercises `register` so this proves the warning still fires in dev builds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/redin/canvas/canvas.odin src/redin/runtime.odin
+git commit -m "$(cat <<'EOF'
+feat(canvas): gate duplicate-register warning on REDIN_DEV at compile time
+
+Drop the runtime g_dev_mode bool and set_dev_mode proc. The duplicate-name
+warning is now wrapped in `when REDIN_DEV { ... }` so release builds
+strip the warning entirely and runtime.run no longer threads cfg.dev
+into the canvas package.
+EOF
+)"
+```
+
+---
+
+### Task 4: Migrate profile package to `REDIN_PROFILE`
+
+**Files:**
+- Modify: `src/redin/profile/profile.odin:29, 40-85`
+- Modify: `src/redin/profile/overlay.odin` (entire body)
+- Modify: `src/redin/runtime.odin:154`
+
+Today `profile.init(true)` flips the runtime `enabled_flag`; every begin/end checks it and bails. After this task the bool parameter goes, `enabled_flag` becomes a compile-time-gated initialization, and every public proc body lives inside `when REDIN_PROFILE`.
+
+- [ ] **Step 1: Drop `enabled_flag`, gate proc bodies on `REDIN_PROFILE`**
+
+In `src/redin/profile/profile.odin`, find:
+
+```odin
+@(private) enabled_flag: bool
+@(private) visible_flag: bool
+@(private) ring:         Ring
+@(private) snapshot_mu:  sync.Mutex
+```
+
+Replace with:
+
+```odin
+@(private) visible_flag: bool
+@(private) ring:         Ring
+@(private) snapshot_mu:  sync.Mutex
+```
+
+Then find:
+
+```odin
+is_enabled :: proc() -> bool { return enabled_flag }
+
+overlay_visible :: proc() -> bool { return visible_flag }
+set_overlay_visible :: proc(v: bool) { visible_flag = v }
+
+init :: proc(enabled: bool) {
+    enabled_flag = enabled
+    visible_flag = enabled
+    ring = {}
+    frame_start = {}
+    phase_scratch = {}
+}
+
+begin_frame :: proc() {
+    if !enabled_flag do return
+    frame_start = time.tick_now()
+    phase_scratch = {}
+}
+
+end_frame :: proc() {
+    if !enabled_flag do return
+    total := time.tick_diff(frame_start, time.tick_now())
+```
+
+Replace with:
+
+```odin
+is_enabled :: proc() -> bool {
+    when REDIN_PROFILE { return true }
+    return false
+}
+
+overlay_visible :: proc() -> bool { return visible_flag }
+set_overlay_visible :: proc(v: bool) { visible_flag = v }
+
+init :: proc() {
+    when REDIN_PROFILE {
+        visible_flag = true
+        ring = {}
+        frame_start = {}
+        phase_scratch = {}
+    }
+}
+
+begin_frame :: proc() {
+    when !REDIN_PROFILE do return
+    frame_start = time.tick_now()
+    phase_scratch = {}
+}
+
+end_frame :: proc() {
+    when !REDIN_PROFILE do return
+    total := time.tick_diff(frame_start, time.tick_now())
+```
+
+Then find:
+
+```odin
+begin :: proc(p: Phase) -> Scope {
+    if !enabled_flag do return Scope{}
+    return Scope{phase = p, start = time.tick_now(), live = true}
+}
+
+end :: proc(s: Scope) {
+    if !s.live do return
+    phase_scratch[s.phase] += i64(time.tick_diff(s.start, time.tick_now()))
+}
+```
+
+Replace with:
+
+```odin
+begin :: proc(p: Phase) -> Scope {
+    when !REDIN_PROFILE do return Scope{}
+    return Scope{phase = p, start = time.tick_now(), live = true}
+}
+
+end :: proc(s: Scope) {
+    when !REDIN_PROFILE do return
+    if !s.live do return
+    phase_scratch[s.phase] += i64(time.tick_diff(s.start, time.tick_now()))
+}
+```
+
+The `Scope.live` field stays — it's the per-call gate that already correctly distinguishes a real Scope from the zero-valued no-op return.
+
+- [ ] **Step 2: Gate `overlay.odin`**
+
+Open `src/redin/profile/overlay.odin`. Read the full file:
+
+```bash
+cat src/redin/profile/overlay.odin
+```
+
+Wrap the body of any `draw_overlay` (or similarly named) proc in `when REDIN_PROFILE { ... }`. If the file declares helpers used only by the overlay, leave them — Odin doesn't error on unused private procs in non-test builds. The goal is that calls from `runtime.odin` collapse to no-ops in release builds.
+
+Concretely, for each public proc declared in `overlay.odin`, add at the top of its body:
+
+```odin
+when !REDIN_PROFILE do return
+```
+
+If a proc returns a non-default value (e.g., `bool`), use a `when REDIN_PROFILE { ... }` wrapper around the whole body and a `return false` (or zero-value) outside.
+
+- [ ] **Step 3: Update `profile.init` caller in runtime.odin**
+
+In `src/redin/runtime.odin`, find:
+
+```odin
+	profile.init(cfg.profile)
+```
+
+Replace with:
+
+```odin
+	profile.init()
+```
+
+- [ ] **Step 4: Verify build**
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+```
+
+Expected: clean build (release variant; profile gates compile out).
+
+```bash
+./build-dev.sh
+```
+
+Expected: clean build (dev variant; profile compiled in).
+
+- [ ] **Step 5: Run UI tests**
+
+```bash
+bash test/ui/run-all.sh --headless
+```
+
+Expected: all suites pass. The `test_profile.bb` suite specifically exercises the profile path — it must build redin via `./build-dev.sh` (the run-all.sh swap happens in Task 6, but for this verification step run the suite manually so REDIN_PROFILE is on for the profile test).
+
+If `test_profile.bb` fails because run-all.sh still calls plain `odin build`, override the `BINARY` it sees by editing run-all.sh's `BINARY=...` line locally for this verification only — Task 6 finalizes the swap.
+
+- [ ] **Step 6: Run profile package's own tests**
+
+```bash
+odin test src/redin/profile -collection:lib=lib -collection:luajit=vendor/luajit -define:REDIN_PROFILE=true -define:ODIN_TEST_THREADS=1
+```
+
+Expected: all profile_test.odin tests pass when `REDIN_PROFILE=true`.
+
+```bash
+odin test src/redin/profile -collection:lib=lib -collection:luajit=vendor/luajit -define:ODIN_TEST_THREADS=1
+```
+
+Expected: tests still pass (they assert no-op behavior when REDIN_PROFILE is off, OR they fail gracefully — read the test file first; if any test assumes `init(true)`, mark it `when REDIN_PROFILE` only). If a test fails because it expects runtime-enabled profiling without the define, gate that test with `when REDIN_PROFILE { ... }` around its body.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/redin/profile/profile.odin src/redin/profile/overlay.odin src/redin/runtime.odin
+git commit -m "$(cat <<'EOF'
+feat(profile): gate package on REDIN_PROFILE at compile time
+
+Drop the runtime enabled_flag and the bool parameter from profile.init.
+Every public proc body is now wrapped in `when REDIN_PROFILE { ... }`,
+so release builds strip the ring buffer, frame instrumentation, and
+overlay rendering to zero bytes. Callers in runtime.run stay unchanged.
+EOF
+)"
+```
+
+---
+
+### Task 5: Migrate bridge package's `dev_mode`
+
+**Files:**
+- Modify: `src/redin/bridge/bridge.odin:25-46, 51-54, 97-156`
+- Modify: `src/redin/runtime.odin:159`
+
+The bridge holds a runtime `dev_mode` bool. After this task the field is gone, the parameter is gone, and every guard that today reads `b.dev_mode || REDIN_AGENT` reads `REDIN_DEV || REDIN_AGENT` at compile time.
+
+- [ ] **Step 1: Drop `Bridge.dev_mode` field**
+
+In `src/redin/bridge/bridge.odin`, find the `Bridge` struct ending:
+
+```odin
+	frame_changed:   bool,
+	dev_mode:        bool,
+}
+```
+
+Replace with:
+
+```odin
+	frame_changed:   bool,
+}
+```
+
+- [ ] **Step 2: Drop `dev_mode` parameter from `init`**
+
+In the same file, find:
+
+```odin
+init :: proc(b: ^Bridge, dev_mode: bool) {
+	g_bridge = b
+	g_context = context
+	b.dev_mode = dev_mode
+	http_client_init(&b.http_client)
+```
+
+Replace with:
+
+```odin
+init :: proc(b: ^Bridge) {
+	g_bridge = b
+	g_context = context
+	http_client_init(&b.http_client)
+```
+
+Then find further down in `init`:
+
+```odin
+	needs_listener := dev_mode
+	when REDIN_AGENT {
+		needs_listener = true
+	}
+	if needs_listener {
+		devserver_init(&b.dev_server, b)
+	}
+	if dev_mode {
+		hotreload_init(&b.hot_reload)
+	}
+}
+```
+
+Replace with:
+
+```odin
+	when REDIN_DEV || REDIN_AGENT {
+		devserver_init(&b.dev_server, b)
+	}
+	when REDIN_DEV {
+		hotreload_init(&b.hot_reload)
+	}
+}
+```
+
+- [ ] **Step 3: Update `destroy`, `poll_devserver`, `is_shutdown_requested`, `check_hotreload`**
+
+In the same file, find `destroy`:
+
+```odin
+destroy :: proc(b: ^Bridge) {
+	needs_listener := b.dev_mode
+	when REDIN_AGENT {
+		needs_listener = true
+	}
+	if needs_listener {
+		devserver_destroy(&b.dev_server)
+	}
+	if b.dev_mode {
+		hotreload_destroy(&b.hot_reload)
+	}
+```
+
+Replace the gating block with:
+
+```odin
+destroy :: proc(b: ^Bridge) {
+	when REDIN_DEV || REDIN_AGENT {
+		devserver_destroy(&b.dev_server)
+	}
+	when REDIN_DEV {
+		hotreload_destroy(&b.hot_reload)
+	}
+```
+
+Find `poll_devserver`:
+
+```odin
+poll_devserver :: proc(b: ^Bridge, events: ^[dynamic]types.InputEvent, node_rects: []rl.Rectangle) {
+	needs_poll := b.dev_mode
+	when REDIN_AGENT {
+		needs_poll = true
+	}
+	if !needs_poll do return
+	b.dev_server.current_rects = node_rects
+	devserver_poll(&b.dev_server)
+	devserver_drain_events(&b.dev_server, events)
+	b.dev_server.current_rects = nil
+}
+```
+
+Replace with:
+
+```odin
+poll_devserver :: proc(b: ^Bridge, events: ^[dynamic]types.InputEvent, node_rects: []rl.Rectangle) {
+	when !(REDIN_DEV || REDIN_AGENT) do return
+	b.dev_server.current_rects = node_rects
+	devserver_poll(&b.dev_server)
+	devserver_drain_events(&b.dev_server, events)
+	b.dev_server.current_rects = nil
+}
+```
+
+Find `is_shutdown_requested`:
+
+```odin
+is_shutdown_requested :: proc(b: ^Bridge) -> bool {
+	needs_listener := b.dev_mode
+	when REDIN_AGENT {
+		needs_listener = true
+	}
+	return needs_listener && b.dev_server.shutdown_requested
+}
+```
+
+Replace with:
+
+```odin
+is_shutdown_requested :: proc(b: ^Bridge) -> bool {
+	when REDIN_DEV || REDIN_AGENT {
+		return b.dev_server.shutdown_requested
+	}
+	return false
+}
+```
+
+Find `check_hotreload`:
+
+```odin
+check_hotreload :: proc(b: ^Bridge) {
+	if !b.dev_mode do return
+	if hotreload_check(&b.hot_reload) {
+		hotreload_execute(b)
+		b.frame_changed = true
+	}
+}
+```
+
+Replace with:
+
+```odin
+check_hotreload :: proc(b: ^Bridge) {
+	when !REDIN_DEV do return
+	if hotreload_check(&b.hot_reload) {
+		hotreload_execute(b)
+		b.frame_changed = true
+	}
+}
+```
+
+- [ ] **Step 4: Sweep for remaining `b.dev_mode` references**
+
+Run:
+
+```bash
+grep -rn "b\.dev_mode\|dev_mode:" src/redin/
+```
+
+Expected: zero results. If anything remains (e.g., another consumer in input/ or runtime/), replace it with the same `when REDIN_DEV { ... }` pattern. The struct field is gone, so any leftover reference is a compile error anyway.
+
+- [ ] **Step 5: Update `bridge.init` caller**
+
+In `src/redin/runtime.odin`, find:
+
+```odin
+	bridge.init(&b, cfg.dev)
+```
+
+Replace with:
+
+```odin
+	bridge.init(&b)
+```
+
+- [ ] **Step 6: Verify both build flavors**
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+```
+
+Expected: clean build (release; dev server stripped).
+
+```bash
+./build-dev.sh
+```
+
+Expected: clean build (dev; dev server compiled in).
+
+- [ ] **Step 7: Smoke test the dev variant**
+
+```bash
+./build-dev.sh
+DISPLAY= xvfb-run -a ./build/redin test/ui/markdown_app.fnl &
+disown
+until [ -f .redin-port ] && [ -f .redin-token ]; do sleep 0.2; done
+echo "dev server up — port=$(cat .redin-port)"
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -s -X POST -H "Authorization: Bearer $TOKEN" "http://localhost:$PORT/shutdown" > /dev/null
+sleep 1
+```
+
+Expected: `.redin-port` / `.redin-token` appear, the curl shutdown succeeds. Note: the binary is invoked WITHOUT `--dev` because the runtime CLI flag still exists and would still be accepted as a no-op (the flag goes in Task 7); we omit it here to confirm the dev server starts purely from compile-time gating.
+
+- [ ] **Step 8: Smoke test the release variant has no dev server**
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+DISPLAY= xvfb-run -a ./build/redin test/ui/markdown_app.fnl &
+PID=$!
+disown
+sleep 2
+ls .redin-port .redin-token 2>&1
+kill -9 $PID 2>/dev/null || true
+```
+
+Expected: `.redin-port` / `.redin-token` do NOT appear (release binary has no dev server). The `ls` lines should both report "No such file or directory".
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/redin/bridge/bridge.odin src/redin/runtime.odin
+git commit -m "$(cat <<'EOF'
+feat(bridge): gate dev_mode on REDIN_DEV at compile time
+
+Drop Bridge.dev_mode field, drop the bool parameter from bridge.init.
+Every guard that read `b.dev_mode || REDIN_AGENT` now reads
+`REDIN_DEV || REDIN_AGENT` at compile time, and the dev-only branches
+in destroy / poll_devserver / is_shutdown_requested / check_hotreload
+move from `if` to `when`. Release builds strip the listener thread,
+hot-reload watcher, and dev HTTP handlers entirely.
+EOF
+)"
+```
+
+---
+
+### Task 6: Update `test/ui/run-all.sh` to use `./build-dev.sh`
+
+**Files:**
+- Modify: `test/ui/run-all.sh:46-49, 92-95`
+
+The test suite needs the dev server. After Task 5 the dev server is gated on `REDIN_DEV`, which only `./build-dev.sh` enables. Switch run-all.sh now (BEFORE removing the `--dev` CLI flag in Task 7), so that today's `--dev` argv is already irrelevant.
+
+- [ ] **Step 1: Replace inline `odin build` with `./build-dev.sh`**
+
+In `test/ui/run-all.sh`, find lines 46-49:
+
+```bash
+# Build
+echo "=== Building redin ==="
+odin build "$ROOT_DIR/src/cmd/redin" -collection:lib="$ROOT_DIR/lib" -collection:luajit="$ROOT_DIR/vendor/luajit" -out:"$BINARY"
+echo ""
+```
+
+Replace with:
+
+```bash
+# Build
+echo "=== Building redin ==="
+( cd "$ROOT_DIR" && ./build-dev.sh )
+echo ""
+```
+
+The `( cd … && … )` subshell ensures `./build-dev.sh` runs from the repo root regardless of where the test was invoked from.
+
+- [ ] **Step 2: Drop `--dev` from the binary invocation**
+
+Find line 94:
+
+```bash
+  "${LAUNCHER[@]}" "$BINARY" --dev "${extra_flags[@]}" "$app_file" &
+```
+
+Replace with:
+
+```bash
+  "${LAUNCHER[@]}" "$BINARY" "${extra_flags[@]}" "$app_file" &
+```
+
+The dev binary now starts the dev server purely because it was compiled with `REDIN_DEV=true` — no runtime flag needed.
+
+- [ ] **Step 3: Verify the suite still runs**
+
+```bash
+bash test/ui/run-all.sh --headless
+```
+
+Expected: `=== Building redin ===` shows `./build-dev.sh` runs (will be silent on success), then every test suite passes. The `test_profile.bb` suite in particular validates that `REDIN_PROFILE=true` is now baked into the test binary.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/ui/run-all.sh
+git commit -m "$(cat <<'EOF'
+test(ui): build via ./build-dev.sh and drop --dev argv from invocations
+
+run-all.sh now calls ./build-dev.sh (which bakes in REDIN_DEV /
+REDIN_PROFILE / REDIN_TRACK_MEM) and starts the binary with no --dev
+flag. The dev server starts purely from the compile-time gate.
+Prepares the suite for the upcoming removal of the --dev CLI flag.
+EOF
+)"
+```
+
+---
+
+### Task 7: Drop `Config.dev` / `Config.profile` + CLI flag parsing + tracker hoist
+
+**Files:**
+- Modify: `src/redin/runtime.odin:16-20, 153-155`
+- Modify: `src/cmd/redin/main.odin` (entire file)
+
+After this task the binary no longer recognises `--dev`, `--profile`, or `--track-mem`. Order matters: run-all.sh has already been updated (Task 6), so removing the runtime parsing won't break the integration suite.
+
+- [ ] **Step 1: Shrink the `Config` struct**
+
+In `src/redin/runtime.odin`, find:
+
+```odin
+Config :: struct {
+	app:     string,
+	dev:     bool,
+	profile: bool,
+}
+```
+
+Replace with:
+
+```odin
+Config :: struct {
+	app: string,
+}
+```
+
+- [ ] **Step 2: Drop `cfg.dev` references in run() docstring**
+
+In the same file, find:
+
+```odin
+// Block until the window closes or `request_shutdown` is called. Sets up
+// the window, bridge, and dev server (if cfg.dev), then runs the loop.
+//
+// Per-frame call order:
+//   poll_input -> on_input(filter) -> bridge tick -> on_frame -> render
+```
+
+Replace with:
+
+```odin
+// Block until the window closes or `request_shutdown` is called. Sets up
+// the window, bridge, and dev server (when built with -define:REDIN_DEV=true),
+// then runs the loop.
+//
+// Per-frame call order:
+//   poll_input -> on_input(filter) -> bridge tick -> on_frame -> render
+```
+
+- [ ] **Step 3: Verify runtime.odin builds**
+
+```bash
+./build-dev.sh
+```
+
+Expected: clean build. Confirms `cfg.dev` and `cfg.profile` are no longer referenced anywhere in the redin package (callers were already updated in Tasks 3-5).
+
+- [ ] **Step 4: Rewrite `src/cmd/redin/main.odin`**
+
+Replace the entire file with:
+
+```odin
+package main
+
+// Compile-time flag enabling the tracking allocator. Default is false;
+// set with `odin build ... -define:REDIN_TRACK_MEM=true`. When false,
+// the tracker setup and leak dump compile out to zero bytes.
+REDIN_TRACK_MEM :: #config(REDIN_TRACK_MEM, false)
+
+import "core:fmt"
+import "core:mem"
+import "core:os"
+import redin "../../redin"
+
+main :: proc() {
+	cfg: redin.Config
+	for arg in os.args[1:] {
+		cfg.app = arg
+	}
+
+	when REDIN_TRACK_MEM {
+		track: mem.Tracking_Allocator
+		mem.tracking_allocator_init(&track, context.allocator)
+		fmt.eprintln("Memory tracking enabled (REDIN_TRACK_MEM)")
+		// Assign at proc scope. Odin's `context` is block-scoped: setting
+		// context.allocator inside a `when` block reverts when the block
+		// ends, so the tracker would never reach `redin.run`. Hoisting
+		// the assignment out of the conditional fixes it.
+		context.allocator = mem.tracking_allocator(&track)
+		defer {
+			if len(track.allocation_map) > 0 {
+				fmt.eprintf("=== %v allocations not freed: ===\n", len(track.allocation_map))
+				for _, entry in track.allocation_map {
+					fmt.eprintf("- %v bytes @ %v\n", entry.size, entry.location)
+				}
+			}
+			if len(track.bad_free_array) > 0 {
+				fmt.eprintf("=== %v incorrect frees: ===\n", len(track.bad_free_array))
+				for entry in track.bad_free_array {
+					fmt.eprintf("- %p @ %v\n", entry.memory, entry.location)
+				}
+			}
+			mem.tracking_allocator_destroy(&track)
+		}
+	}
+
+	redin.run(cfg)
+}
+```
+
+Note: `when REDIN_TRACK_MEM` wraps the entire tracker block — `track`, the init, the `context.allocator =` hoist, and the `defer`. When the flag is off, the entire block compiles out and `mem` becomes unused (which Odin doesn't error on for top-level imports). If `fmt` ends up unused too in non-track builds, that's also fine — Odin doesn't error on unused imports.
+
+The assignment loop `for arg in os.args[1:] { cfg.app = arg }` keeps the existing semantic that the LAST non-flag argv wins (matches today's behavior).
+
+- [ ] **Step 5: Verify both build flavors**
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+```
+
+Expected: clean release build.
+
+```bash
+./build-dev.sh
+```
+
+Expected: clean dev build.
+
+- [ ] **Step 6: Verify behavior**
+
+```bash
+./build-dev.sh
+DISPLAY= xvfb-run -a ./build/redin test/ui/markdown_app.fnl &
+disown
+until [ -f .redin-port ] && [ -f .redin-token ]; do sleep 0.2; done
+echo "dev binary started server"
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -s -X POST -H "Authorization: Bearer $TOKEN" "http://localhost:$PORT/shutdown" > /dev/null
+sleep 1
+```
+
+Expected: dev server comes up. Then run the same test against a release binary:
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+DISPLAY= xvfb-run -a ./build/redin test/ui/markdown_app.fnl &
+PID=$!
+disown
+sleep 2
+ls .redin-port .redin-token 2>&1
+kill -9 $PID 2>/dev/null || true
+```
+
+Expected: release binary does NOT create `.redin-port` / `.redin-token`.
+
+- [ ] **Step 7: Verify track-mem behavior**
+
+```bash
+./build-dev.sh
+DISPLAY= xvfb-run -a ./build/redin test/ui/markdown_app.fnl > /tmp/track.log 2>&1 &
+disown
+until [ -f .redin-port ] && [ -f .redin-token ]; do sleep 0.2; done
+sleep 1
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -s -X POST -H "Authorization: Bearer $TOKEN" "http://localhost:$PORT/shutdown" > /dev/null
+sleep 2
+grep "Memory tracking enabled" /tmp/track.log
+```
+
+Expected: "Memory tracking enabled (REDIN_TRACK_MEM)" line appears (dev binary has REDIN_TRACK_MEM baked in, so the tracker is active without any runtime flag).
+
+- [ ] **Step 8: Run the full UI suite**
+
+```bash
+bash test/ui/run-all.sh --headless
+```
+
+Expected: all suites pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/redin/runtime.odin src/cmd/redin/main.odin
+git commit -m "$(cat <<'EOF'
+feat(cli): drop --dev / --profile / --track-mem CLI flags
+
+Removes the runtime CLI flag parsing and the cfg.dev / cfg.profile
+fields on redin.Config (now {app: string} only). All three features
+are now gated purely by their compile-time -define constants. The
+tracker setup is wrapped in `when REDIN_TRACK_MEM { ... }` so
+release builds strip both the allocator and the leak-dump defer.
+
+BREAKING CHANGE: `./redin --dev main.fnl` no longer recognises --dev;
+the argv is treated as a missing file path. Use `./build-dev.sh`
+to produce a binary with the dev server compiled in (then run it
+without --dev). --native projects' app.odin must drop cfg.dev and
+cfg.profile assignments.
+EOF
+)"
+```
+
+---
+
+### Task 8: Update CI workflows (`test.yml`, `release.yml`)
+
+**Files:**
+- Modify: `.github/workflows/test.yml:39, 67-71`
+- Modify: `.github/workflows/release.yml:48, 51, 99-100, 151, 158`
+
+CI builds need to switch to `./build-dev.sh` for the test job and the release tarball (the redin binary in the release tarball is itself a dev tool — its target audience needs the dev server). The agent build appends `-define:REDIN_AGENT=true` to `./build-dev.sh "$@"`.
+
+- [ ] **Step 1: Update `test.yml` main build**
+
+In `.github/workflows/test.yml`, find around line 38:
+
+```yaml
+      - name: Build redin
+        run: |
+          mkdir -p build
+          odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+```
+
+Replace with:
+
+```yaml
+      - name: Build redin
+        run: |
+          mkdir -p build
+          ./build-dev.sh
+```
+
+- [ ] **Step 2: Update `test.yml` agent build**
+
+In the same file, find around line 67-71:
+
+```yaml
+      - name: Build redin (REDIN_AGENT=true)
+        run: |
+          mkdir -p build
+          odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
+            -define:REDIN_AGENT=true -out:build/redin
+```
+
+Replace with:
+
+```yaml
+      - name: Build redin (REDIN_AGENT=true)
+        run: |
+          mkdir -p build
+          ./build-dev.sh -define:REDIN_AGENT=true
+```
+
+- [ ] **Step 3: Update `release.yml` test-step build**
+
+In `.github/workflows/release.yml`, find around line 44-48:
+
+```yaml
+      - name: Run tests
+        run: |
+          luajit test/lua/runner.lua test/lua/test_*.fnl
+          mkdir -p build
+          odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+```
+
+Replace with:
+
+```yaml
+      - name: Run tests
+        run: |
+          luajit test/lua/runner.lua test/lua/test_*.fnl
+          mkdir -p build
+          ./build-dev.sh
+```
+
+- [ ] **Step 4: Update `release.yml` release-binary build**
+
+In the same file, find around line 50-51:
+
+```yaml
+      - name: Build release binary
+        run: odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin -o:speed
+```
+
+Replace with:
+
+```yaml
+      - name: Build release binary
+        run: ./build-dev.sh -o:speed
+```
+
+The redin binary in the tarball needs the dev server (its consumers run AI-driven workflows that depend on it). `-o:speed` is forwarded via `"$@"`.
+
+- [ ] **Step 5: Update `release.yml` agent build**
+
+In the same file, find around line 95-100:
+
+```yaml
+      - name: Build agent binary
+        run: |
+          rm -rf dist-agent
+          mkdir -p dist-agent
+          odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
+            -define:REDIN_AGENT=true -out:dist-agent/redin -o:speed
+```
+
+Replace with:
+
+```yaml
+      - name: Build agent binary
+        run: |
+          rm -rf dist-agent
+          mkdir -p dist-agent
+          ./build-dev.sh -define:REDIN_AGENT=true -o:speed -out:dist-agent/redin
+```
+
+`./build-dev.sh` accepts a trailing `-out:` because `"$@"` is passed AFTER the script's hard-coded `-out:build/redin`, so the second `-out:` overrides. Verify this assumption by reading the script: `-out:build/redin "$@"` means the second `-out:` from `"$@"` overrides. Test locally:
+
+```bash
+./build-dev.sh -out:build/redin-test
+ls build/redin-test
+```
+
+Expected: `build/redin-test` exists. Delete it:
+
+```bash
+rm build/redin-test
+```
+
+- [ ] **Step 6: Update the release-notes "What's included" block**
+
+In `release.yml` around lines 147-159:
+
+```yaml
+          body: |
+            ## What's included
+            - `redin` binary (Linux x86_64, LuaJIT statically linked)
+            - AOT-compiled Fennel runtime
+            - Fennel compiler (for --dev mode hot reload)
+            - Developer documentation (guides + reference)
+            - Claude Code skill for redin development
+
+            ## Quick start
+            ```
+            redin-cli new-fnl my-app
+            cd my-app && ./redinw --dev main.fnl
+            ```
+```
+
+Replace with:
+
+```yaml
+          body: |
+            ## What's included
+            - `redin` binary (Linux x86_64, LuaJIT statically linked,
+              built with REDIN_DEV / REDIN_PROFILE / REDIN_TRACK_MEM)
+            - AOT-compiled Fennel runtime
+            - Fennel compiler (for hot reload)
+            - Developer documentation (guides + reference)
+            - Claude Code skill for redin development
+
+            ## Quick start
+            ```
+            redin-cli new-fnl my-app
+            cd my-app && ./redinw main.fnl
+            ```
+```
+
+- [ ] **Step 7: Verify the workflows parse**
+
+```bash
+# Quick lint via Python (yaml is in the standard lib).
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"
+```
+
+Expected: no output (parse succeeds).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .github/workflows/test.yml .github/workflows/release.yml
+git commit -m "$(cat <<'EOF'
+ci: switch test + release workflows to ./build-dev.sh
+
+The test job builds via ./build-dev.sh (REDIN_DEV / REDIN_PROFILE /
+REDIN_TRACK_MEM all on); the agent test job appends
+`-define:REDIN_AGENT=true` to that. The release tarball binary is
+also built via ./build-dev.sh because its consumers (AI workflow
+drivers) need the dev server compiled in. The agent release binary
+appends -define:REDIN_AGENT=true and -out:dist-agent/redin via "$@".
+Drops `--dev` from the quick-start example in release notes.
+EOF
+)"
+```
+
+---
+
+### Task 9: Update `release.sh` and `scripts/smoke-native.sh`
+
+**Files:**
+- Modify: `release.sh:10`
+- Modify: `scripts/smoke-native.sh:6, 48-58, 62-71, 92-93`
+
+`release.sh` is a manual local-release helper paralleling `release.yml`. `scripts/smoke-native.sh` inlines its own copies of the `app.odin` and `build.sh` templates that mirror redin-cli's `app-odin-fnl` and `build-sh-native` constants — the maintenance skill calls out this parity rule explicitly.
+
+- [ ] **Step 1: Update `release.sh`**
+
+In `release.sh`, find around line 10:
+
+```bash
+echo "Building redin ${VERSION}..."
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+```
+
+Replace with:
+
+```bash
+echo "Building redin ${VERSION}..."
+./build-dev.sh
+```
+
+- [ ] **Step 2: Update `smoke-native.sh` header comment**
+
+In `scripts/smoke-native.sh`, find line 6:
+
+```bash
+# ./build.sh → launch binary under --dev → curl /state.
+```
+
+Replace with:
+
+```bash
+# ./build.sh → launch binary → curl /state.
+```
+
+- [ ] **Step 3: Update inline `app.odin` template**
+
+In `scripts/smoke-native.sh`, find around lines 48-59:
+
+```bash
+cat > "$PROJECT/app.odin" <<'APP_ODIN'
+package main
+
+import redin "./.redin/src/redin"
+
+main :: proc() {
+	cfg: redin.Config
+	cfg.dev = true
+	cfg.app = "main.fnl"
+	redin.run(cfg)
+}
+APP_ODIN
+```
+
+Replace with:
+
+```bash
+cat > "$PROJECT/app.odin" <<'APP_ODIN'
+package main
+
+import redin "./.redin/src/redin"
+
+main :: proc() {
+	cfg: redin.Config
+	cfg.app = "main.fnl"
+	redin.run(cfg)
+}
+APP_ODIN
+```
+
+`cfg.dev = true` is gone — Config no longer has the field. The dev server is now compile-time gated; the `build.sh` template (next step) bakes in `-define:REDIN_DEV=true`.
+
+- [ ] **Step 4: Update inline `build.sh` template**
+
+In `scripts/smoke-native.sh`, find around lines 62-70:
+
+```bash
+cat > "$PROJECT/build.sh" <<'BUILD_SH'
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$SCRIPT_DIR/build"
+odin build "$SCRIPT_DIR" \
+  -collection:lib="$SCRIPT_DIR/.redin/lib" \
+  -collection:luajit="$SCRIPT_DIR/.redin/vendor/luajit" \
+  -out:"$SCRIPT_DIR/build/redin"
+BUILD_SH
+```
+
+Replace with:
+
+```bash
+cat > "$PROJECT/build.sh" <<'BUILD_SH'
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$SCRIPT_DIR/build"
+odin build "$SCRIPT_DIR" \
+  -collection:lib="$SCRIPT_DIR/.redin/lib" \
+  -collection:luajit="$SCRIPT_DIR/.redin/vendor/luajit" \
+  -define:REDIN_DEV=true \
+  -define:REDIN_PROFILE=true \
+  -define:REDIN_TRACK_MEM=true \
+  -out:"$SCRIPT_DIR/build/redin"
+BUILD_SH
+```
+
+The smoke check exercises a `--native` project's typical dev build, so it bakes in all three flags. This must mirror redin-cli's `build-sh-native` constant — when redin-cli's PR ships, its constant gets the same flags.
+
+- [ ] **Step 5: Update binary-launch line**
+
+In `scripts/smoke-native.sh`, find around lines 92-93:
+
+```bash
+echo "=== 4/5 launching build/redin --dev ==="
+"${LAUNCHER[@]}" "$PROJECT/build/redin" --dev main.fnl &
+```
+
+Replace with:
+
+```bash
+echo "=== 4/5 launching build/redin ==="
+"${LAUNCHER[@]}" "$PROJECT/build/redin" main.fnl &
+```
+
+- [ ] **Step 6: Test `release.sh` locally**
+
+```bash
+./release.sh v0.1.X-test
+```
+
+Expected: builds the binary via `./build-dev.sh`, packages a tarball into `dist/`. Inspect the tarball to confirm the binary has REDIN_DEV baked in (next step).
+
+- [ ] **Step 7: Run the smoke check against the freshly-built tarball**
+
+```bash
+bash scripts/smoke-native.sh dist/redin-v0.1.X-test-linux-amd64.tar.gz
+```
+
+Expected: smoke check completes with "smoke check PASSED". Confirms:
+- App.odin without `cfg.dev = true` builds (Config no longer has the field).
+- build.sh with `-define:REDIN_DEV=true` produces a binary that starts the dev server.
+- `/frames` polling sees the sentinel string.
+
+Clean up:
+
+```bash
+rm -rf dist
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add release.sh scripts/smoke-native.sh
+git commit -m "$(cat <<'EOF'
+build: switch release.sh + smoke-native templates to compile-time flags
+
+release.sh now calls ./build-dev.sh (matches release.yml). The smoke
+script's inline app.odin drops `cfg.dev = true` (Config has no dev
+field anymore) and its inline build.sh adds the three -define:REDIN_*
+flags so the smoke check exercises the same defaults a fresh
+`--native` project will get.
+EOF
+)"
+```
+
+---
+
+### Task 10: Update `CLAUDE.md`
+
+**Files:**
+- Modify: `CLAUDE.md:21, 25-39, 41-58, 75, 84, 102-126`
+
+CLAUDE.md is the project's top-level orientation document — the AI agent's first stop. Every reference to `--dev`, `--profile`, `--track-mem` needs the new mental model.
+
+- [ ] **Step 1: Read the current top section**
+
+```bash
+sed -n '1,90p' CLAUDE.md
+```
+
+Note the sections that reference flags:
+- "AI interface" line (mentions `--dev` and `--profile`)
+- "Building" code blocks (basic build + REDIN_AGENT build)
+- "Running" examples
+- "Testing" UI integration test recipe
+- "Architecture" tree comments referencing `--track-mem` and `--dev`
+- "Dev server HTTP API" intro line and the `/profile` row
+
+- [ ] **Step 2: Update the AI-interface paragraph**
+
+In `CLAUDE.md`, find the "AI interface" line:
+
+```markdown
+- **AI interface:** localhost HTTP dev server (`--dev` mode). Default port 8800; … Optional `--profile` flag adds a 5-phase frame-timing ring buffer exposed at `/profile` and an F3-togglable on-screen overlay.
+```
+
+Replace with:
+
+```markdown
+- **AI interface:** localhost HTTP dev server (compile with `-define:REDIN_DEV=true`, or use `./build-dev.sh`). Default port 8800; if busy, walks upward to the next free port. Bound port is written to `./.redin-port`; a per-run random auth token is written to `./.redin-token` (mode 0600). Both files are removed on shutdown. Every non-`OPTIONS` request must include `Authorization: Bearer <contents of .redin-token>`; the server also rejects requests whose `Host` header isn't `localhost:<port>` or `127.0.0.1:<port>` (DNS-rebinding defence). Build with `-define:REDIN_PROFILE=true` to add a 5-phase frame-timing ring buffer exposed at `/profile` and an F3-togglable on-screen overlay. Build with `-define:REDIN_TRACK_MEM=true` to enable the tracking allocator and a leak dump on shutdown.
+```
+
+- [ ] **Step 3: Replace the Building section**
+
+Find the "Building" section (around line 25):
+
+```markdown
+## Building
+
+Default build:
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+```
+
+With the agent channel feature:
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
+    -define:REDIN_AGENT=true -out:build/redin
+```
+
+When `REDIN_AGENT` is set, the dev-server listener starts in any run
+(not just `--dev`) and exposes the `/agent/*` endpoints. Default
+release builds carry zero agent code.
+```
+
+Replace with:
+
+```markdown
+## Building
+
+Release-stripped build (no dev server, no profile, no tracker):
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+```
+
+Dev build (REDIN_DEV + REDIN_PROFILE + REDIN_TRACK_MEM all baked in):
+
+```bash
+./build-dev.sh
+```
+
+Add the agent channel:
+
+```bash
+./build-dev.sh -define:REDIN_AGENT=true
+```
+
+When `REDIN_AGENT` is set, the dev-server listener starts in any run
+(even without `REDIN_DEV`) and exposes the `/agent/*` endpoints.
+Default release builds carry zero agent code, zero dev-server code,
+zero profile instrumentation, and zero tracking-allocator overhead.
+```
+
+- [ ] **Step 4: Replace the Running section**
+
+Find the "Running" section (around line 41):
+
+```markdown
+## Running
+
+```bash
+./build/redin examples/kitchen-sink.fnl        # normal mode
+./build/redin --dev examples/kitchen-sink.fnl   # dev server + hot reload
+```
+```
+
+Replace with:
+
+```markdown
+## Running
+
+```bash
+./build/redin examples/kitchen-sink.fnl
+```
+
+Whether the dev server starts depends on the build flags. A binary
+built with `./build-dev.sh` starts the dev server unconditionally; a
+bare `odin build` binary never does. There are no runtime CLI flags.
+```
+
+- [ ] **Step 5: Replace the Testing section**
+
+Find the "Testing" section (around line 50):
+
+```markdown
+## Testing
+
+```bash
+# Fennel runtime tests (95 tests)
+luajit test/lua/runner.lua test/lua/test_*.fnl
+
+# UI integration tests (requires running dev server)
+./build/redin --dev test/ui/<app>.fnl &
+bb test/ui/run.bb test/ui/test_<name>.bb
+
+# Build check
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+```
+```
+
+Replace with:
+
+```markdown
+## Testing
+
+```bash
+# Fennel runtime tests
+luajit test/lua/runner.lua test/lua/test_*.fnl
+
+# UI integration tests (run the dev binary, no --dev flag needed)
+./build-dev.sh
+./build/redin test/ui/<app>.fnl &
+bb test/ui/run.bb test/ui/test_<name>.bb
+
+# Release build check
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+```
+```
+
+- [ ] **Step 6: Update the architecture tree comments**
+
+Find around line 75:
+
+```markdown
+  main.odin         Arg parsing, --track-mem setup, calls redin.run
+```
+
+Replace with:
+
+```markdown
+  main.odin         Arg parsing (app file only), tracker setup gated on REDIN_TRACK_MEM, calls redin.run
+```
+
+Find around line 84:
+
+```markdown
+    devserver.odin  HTTP dev server (--dev mode only)
+```
+
+Replace with:
+
+```markdown
+    devserver.odin  HTTP dev server (gated on REDIN_DEV / REDIN_AGENT)
+```
+
+- [ ] **Step 7: Update the Dev server HTTP API intro**
+
+Find around line 102-104:
+
+```markdown
+## Dev server HTTP API
+
+Available when running with `--dev`. Listens on port 8800 by default; walks upward (8801, 8802, ...) if busy, and writes the bound port to `./.redin-port`. A per-run random auth token is written to `./.redin-token` (0600). Every non-`OPTIONS` request must carry `Authorization: Bearer <token>`, and the `Host` header must be `localhost:<port>` / `127.0.0.1:<port>`.
+```
+
+Replace with:
+
+```markdown
+## Dev server HTTP API
+
+Available when the binary was built with `-define:REDIN_DEV=true`
+(or `-define:REDIN_AGENT=true`). Listens on port 8800 by default;
+walks upward (8801, 8802, ...) if busy, and writes the bound port to
+`./.redin-port`. A per-run random auth token is written to
+`./.redin-token` (0600). Every non-`OPTIONS` request must carry
+`Authorization: Bearer <token>`, and the `Host` header must be
+`localhost:<port>` / `127.0.0.1:<port>`.
+```
+
+- [ ] **Step 8: Update the `/profile` row**
+
+Find around line 112:
+
+```markdown
+| `GET` | `/profile` | Ring-buffered frame timings (requires `--profile`) |
+```
+
+Replace with:
+
+```markdown
+| `GET` | `/profile` | Ring-buffered frame timings (requires `-define:REDIN_PROFILE=true`) |
+```
+
+- [ ] **Step 9: Verify the markdown still renders**
+
+```bash
+# Quick visual check of the changed sections.
+sed -n '20,50p' CLAUDE.md
+sed -n '70,90p' CLAUDE.md
+sed -n '95,130p' CLAUDE.md
+```
+
+Expected: clean prose, no leftover `--dev` / `--profile` / `--track-mem` references that should have been updated. Run a final grep:
+
+```bash
+grep -n "\-\-dev\|\-\-profile\|\-\-track-mem" CLAUDE.md
+```
+
+Expected: zero results.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs(CLAUDE.md): update for compile-time flag gating
+
+Replace --dev / --profile / --track-mem CLI flag references with the
+REDIN_DEV / REDIN_PROFILE / REDIN_TRACK_MEM compile-time model.
+Building section now contrasts release-stripped (`odin build`) and dev
+(`./build-dev.sh`) variants. Running and Testing sections drop the
+runtime --dev argv. Architecture tree and Dev-server HTTP API intro
+get matching wording updates.
+EOF
+)"
+```
+
+---
+
+### Task 11: Update `docs/core-api.md`, `docs/reference/dev-server.md`, `docs/reference/native-bridge.md`
+
+**Files:**
+- Modify: `docs/core-api.md` (every `--dev` / `--profile` / `--track-mem` reference)
+- Modify: `docs/reference/dev-server.md:9` and any other flag references
+- Modify: `docs/reference/native-bridge.md:35` (`Config.dev == true` reference)
+
+These are the public reference docs that ship in the release tarball. Their wording must match CLAUDE.md's new model.
+
+- [ ] **Step 1: Sweep `docs/core-api.md` for `--dev` / `--profile` / `--track-mem`**
+
+```bash
+grep -n "\-\-dev\|\-\-profile\|\-\-track-mem" docs/core-api.md
+```
+
+For each match, replace the runtime-flag wording with the compile-time-flag wording. Common patterns:
+- `running with --dev` → `built with -define:REDIN_DEV=true (or via ./build-dev.sh)`
+- `the --profile flag` → `building with -define:REDIN_PROFILE=true`
+- `--track-mem` → `-define:REDIN_TRACK_MEM=true`
+
+If a sentence introduces the dev server with "available when running with `--dev`", change to "available when the binary was built with `-define:REDIN_DEV=true` (or `-define:REDIN_AGENT=true`)".
+
+After each edit, re-run the grep — fix until zero matches remain (excluding any deliberately-historical mentions, which should be quoted or in a "before" context).
+
+- [ ] **Step 2: Update `docs/reference/dev-server.md` line 9**
+
+Find:
+
+```markdown
+Starts when the app is launched with `--dev`. Listens on `localhost:8800` (walks upward if busy).
+```
+
+Replace with:
+
+```markdown
+Starts when the binary was built with `-define:REDIN_DEV=true` (or `-define:REDIN_AGENT=true`). Listens on `localhost:8800` (walks upward if busy).
+```
+
+Sweep the rest of the file:
+
+```bash
+grep -n "\-\-dev\|\-\-profile\|\-\-track-mem" docs/reference/dev-server.md
+```
+
+For each match, apply the same pattern.
+
+- [ ] **Step 3: Update `docs/reference/native-bridge.md`**
+
+Find around line 35:
+
+```markdown
+**Duplicate names:** silent replace. In dev mode (`Config.dev == true`), logs a stderr warning before replacing — same policy as `canvas.register`.
+```
+
+Replace with:
+
+```markdown
+**Duplicate names:** silent replace. When the binary was built with `-define:REDIN_DEV=true`, logs a stderr warning before replacing — same policy as `canvas.register`.
+```
+
+Sweep the rest:
+
+```bash
+grep -n "\-\-dev\|\-\-profile\|\-\-track-mem\|cfg\.dev\|cfg\.profile\|Config\.dev\|Config\.profile" docs/reference/native-bridge.md
+```
+
+For each match, update accordingly. Note that `Config` no longer has `dev` or `profile` fields — any code example that sets them must be updated to drop those lines.
+
+- [ ] **Step 4: Final grep across `docs/`**
+
+```bash
+grep -rn "\-\-dev\b\|\-\-profile\b\|\-\-track-mem\b\|cfg\.dev\|cfg\.profile\|Config\.dev\|Config\.profile" docs/
+```
+
+Expected: zero results outside historical/spec files (`docs/superpowers/specs/*` and `docs/superpowers/plans/*` are frozen and should NOT be updated).
+
+If any `docs/guide/*.md` files surface, update them too (sweep the same way).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/core-api.md docs/reference/dev-server.md docs/reference/native-bridge.md
+# Also stage any docs/guide/*.md files the sweep updated.
+git commit -m "$(cat <<'EOF'
+docs(reference): swap CLI flag wording for compile-time -define wording
+
+docs/core-api.md, docs/reference/dev-server.md, and
+docs/reference/native-bridge.md no longer reference --dev / --profile
+/ --track-mem runtime flags or Config.dev / Config.profile fields.
+Dev server availability is now described as "built with
+-define:REDIN_DEV=true" throughout.
+EOF
+)"
+```
+
+---
+
+### Task 12: Update `.claude/skills/redin-dev/SKILL.md` and `.claude/skills/redin-maintenance/SKILL.md`
+
+**Files:**
+- Modify: `.claude/skills/redin-dev/SKILL.md:14, 22, 229, 262, 278-280, 417-431` (and any others surfaced by grep)
+- Modify: `.claude/skills/redin-maintenance/SKILL.md:48, 71-95, 136, 140-145, 182` (and any others)
+
+The skills are part of the contract: they ship in the release tarball and are loaded into AI agents working on redin projects. Their command examples must match the new model exactly.
+
+- [ ] **Step 1: Sweep redin-dev**
+
+```bash
+grep -n "\-\-dev\|\-\-profile\|\-\-track-mem\|cfg\.dev\|cfg\.profile" .claude/skills/redin-dev/SKILL.md
+```
+
+Address each match:
+
+- The architecture tree comments (lines ~14, 22): match the CLAUDE.md updates from Task 10.
+- The "Dev server (--dev mode, default port 8800)" header (~line 229): change to "Dev server (built with `-define:REDIN_DEV=true` or `./build-dev.sh`, default port 8800)".
+- The Agent channel section's "starts even without `--dev`" (~line 262): change to "starts even without `REDIN_DEV`".
+- The UI integration tests example (~lines 278-280): switch the command sequence to `./build-dev.sh` then `./build/redin test/ui/<component>_app.fnl &`.
+- The native scaffolding example (~lines 417-431): the `app.odin` template currently shows `cfg.dev = true` and a `case "--dev"` in arg parsing. The new shape:
+
+  ```odin
+  package main
+
+  import "core:os"
+  import redin "./.redin/src/redin"
+  import "./.redin/src/redin/canvas"
+
+  main :: proc() {
+      redin.set_window(1920, 1080, "my game", {.WINDOW_RESIZABLE})
+
+      canvas.register("my-bg", my_bg_provider)
+      redin.on_frame(per_frame_tick)
+
+      cfg: redin.Config
+      for arg in os.args[1:] {
+          cfg.app = arg
+      }
+      redin.run(cfg)
+  }
+  ```
+
+  And the run examples (~line 429-431):
+
+  ```bash
+  ./redinw main.fnl                # built with REDIN_DEV → dev server starts
+  ./redinw main.fnl                # built without REDIN_DEV → no dev server
+  ./build.sh                        # rebuild after editing app.odin
+  ```
+
+  Drop the `--dev` / `--track-mem` argv lines.
+
+After all edits, re-grep:
+
+```bash
+grep -n "\-\-dev\|\-\-profile\|\-\-track-mem" .claude/skills/redin-dev/SKILL.md
+```
+
+Expected: zero matches.
+
+- [ ] **Step 2: Sweep redin-maintenance**
+
+```bash
+grep -n "\-\-dev\|\-\-profile\|\-\-track-mem" .claude/skills/redin-maintenance/SKILL.md
+```
+
+Address each match. Notable rewrites:
+
+- The basic build command (line ~10 area): contrast `odin build ...` (release) vs `./build-dev.sh` (dev).
+- The "Run one" example (~line 48): change `./build/redin --dev test/ui/<component>_app.fnl &` to `./build/redin test/ui/<component>_app.fnl &` (binary built via `./build-dev.sh`).
+- The Memory leak detection section (~lines 71-95): explain that REDIN_TRACK_MEM is baked in by `./build-dev.sh`. The recipe `./build/redin --dev --track-mem test/ui/<component>_app.fnl` becomes `./build-dev.sh && ./build/redin test/ui/<component>_app.fnl` — the tracker is on by virtue of REDIN_TRACK_MEM being compiled in.
+- The "Modify run-all.sh's server start line to include --track-mem" tip: that approach is obsolete. Replace with: "track-mem is baked into ./build-dev.sh's binary, so run-all.sh already exercises it."
+- The change-area table row `src/cmd/redin/ (CLI flags, --track-mem)` (~line 136): change to `src/cmd/redin/ (top-level main, REDIN_TRACK_MEM gating)`.
+- The Agent channel build section (~line 140-145):
+
+  ```bash
+  ./build-dev.sh -define:REDIN_AGENT=true
+  bash test/ui/run-all.sh --headless
+  ```
+
+- The smoke check section (~line 182): the description "Launch the resulting binary under `--dev`" becomes "Launch the resulting binary".
+
+After all edits, re-grep:
+
+```bash
+grep -n "\-\-dev\|\-\-profile\|\-\-track-mem" .claude/skills/redin-maintenance/SKILL.md
+```
+
+Expected: zero matches.
+
+- [ ] **Step 3: Final grep across `.claude/`**
+
+```bash
+grep -rn "\-\-dev\|\-\-profile\|\-\-track-mem\|cfg\.dev\|cfg\.profile\|Config\.dev\|Config\.profile" .claude/
+```
+
+Expected: zero matches.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/redin-dev/SKILL.md .claude/skills/redin-maintenance/SKILL.md
+git commit -m "$(cat <<'EOF'
+skills: update redin-dev / redin-maintenance for compile-time flags
+
+Both skills lose every --dev / --profile / --track-mem reference.
+Build commands now contrast `odin build` (release) vs ./build-dev.sh
+(dev). The native scaffolding example drops cfg.dev assignment and
+the case "--dev" arg-parsing branch. Memory-leak detection drops the
+old run-all.sh tip and explains that ./build-dev.sh already bakes in
+REDIN_TRACK_MEM. Agent build recipe uses ./build-dev.sh -define:....
+EOF
+)"
+```
+
+---
+
+### Task 13: Final verification
+
+**Files:** none (this is a verification-only task; no commit unless something failed).
+
+Confirm both build flavors work end-to-end and that the strip claims hold.
+
+- [ ] **Step 1: Clean build, all variants**
+
+```bash
+rm -f build/redin
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+ls -lh build/redin
+```
+
+Note the size of the release binary.
+
+```bash
+./build-dev.sh
+ls -lh build/redin
+```
+
+Note the size of the dev binary. Expected: dev binary larger than release binary (dev server, hot reload, profile ring buffer, tracking allocator all add bytes).
+
+- [ ] **Step 2: Strip check**
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin-release
+nm build/redin-release | grep -ci 'devserver_\|hotreload_' || true
+```
+
+Expected: 0 (release binary has no devserver / hotreload symbols). If non-zero, identify the leaking symbol — every `devserver_` / `hotreload_` proc body must be inside a `when REDIN_DEV || REDIN_AGENT` block (or the calling site must be).
+
+```bash
+./build-dev.sh -out:build/redin-dev
+nm build/redin-dev | grep -ci 'devserver_\|hotreload_'
+```
+
+Expected: non-zero (dev binary has the symbols).
+
+```bash
+rm -f build/redin-release build/redin-dev
+```
+
+- [ ] **Step 3: Behavioral test — release binary runs, no dev server**
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+rm -f .redin-port .redin-token
+DISPLAY= xvfb-run -a ./build/redin test/ui/markdown_app.fnl &
+PID=$!
+disown
+sleep 3
+ls .redin-port .redin-token 2>&1
+kill -9 $PID 2>/dev/null || true
+sleep 1
+```
+
+Expected: both `ls` lines say "No such file or directory". Release binary cannot start the dev server.
+
+- [ ] **Step 4: Behavioral test — dev binary runs and starts dev server**
+
+```bash
+./build-dev.sh
+rm -f .redin-port .redin-token
+DISPLAY= xvfb-run -a ./build/redin test/ui/markdown_app.fnl &
+disown
+until [ -f .redin-port ] && [ -f .redin-token ]; do sleep 0.2; done
+echo "dev server: port=$(cat .redin-port)"
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -s -H "Authorization: Bearer $TOKEN" "http://localhost:$PORT/state" | head -c 80
+echo
+curl -s -X POST -H "Authorization: Bearer $TOKEN" "http://localhost:$PORT/shutdown" > /dev/null
+sleep 1
+```
+
+Expected: port/token files appear, `/state` returns valid JSON, shutdown succeeds.
+
+- [ ] **Step 5: Track-mem behavioral test**
+
+```bash
+./build-dev.sh
+DISPLAY= xvfb-run -a ./build/redin test/ui/markdown_app.fnl > /tmp/track.log 2>&1 &
+disown
+until [ -f .redin-port ] && [ -f .redin-token ]; do sleep 0.2; done
+sleep 1
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -s -X POST -H "Authorization: Bearer $TOKEN" "http://localhost:$PORT/shutdown" > /dev/null
+sleep 2
+grep -E "Memory tracking enabled|allocations not freed" /tmp/track.log
+```
+
+Expected: at least the "Memory tracking enabled (REDIN_TRACK_MEM)" line. The leak count line may or may not appear depending on whether anything leaked (today's baseline is 23 long-lived global allocations).
+
+- [ ] **Step 6: Full Fennel + Odin unit test sweep**
+
+```bash
+luajit test/lua/runner.lua test/lua/test_*.fnl
+echo ---
+odin test src/redin/markdown -collection:lib=lib -collection:luajit=vendor/luajit -define:ODIN_TEST_THREADS=1
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit -define:ODIN_TEST_THREADS=1
+odin test src/redin/parser -collection:lib=lib -collection:luajit=vendor/luajit -define:ODIN_TEST_THREADS=1
+odin test src/redin/input -collection:lib=lib -collection:luajit=vendor/luajit -define:ODIN_TEST_THREADS=1
+odin test src/redin/profile -collection:lib=lib -collection:luajit=vendor/luajit -define:REDIN_PROFILE=true -define:ODIN_TEST_THREADS=1
+```
+
+Expected: all suites green.
+
+- [ ] **Step 7: Full UI integration suite**
+
+```bash
+bash test/ui/run-all.sh --headless
+```
+
+Expected: "All test suites passed".
+
+- [ ] **Step 8: Smoke-native check (dry run against a fresh tarball)**
+
+```bash
+./release.sh v0.1.X-test
+bash scripts/smoke-native.sh dist/redin-v0.1.X-test-linux-amd64.tar.gz
+rm -rf dist
+```
+
+Expected: "smoke check PASSED". Confirms the `--native` template path stays viable end-to-end.
+
+- [ ] **Step 9: No commit needed**
+
+If every step above passed, the implementation is complete. The branch is ready for PR.
+
+If any step failed, fix the underlying issue in the relevant earlier task and re-run the failing step. Don't paper over a failure here — Task 13's job is to catch regressions before they ship.
+
+---
+
+## Self-review (post-write)
+
+**1. Spec coverage:** Every section of the spec maps to tasks:
+
+- "New compile-time constants" → Task 1
+- "CLI flags removed" → Task 7 step 4
+- "`redin.Config` shrinks" → Task 7 step 1
+- "Per-package code changes" `main.odin` → Task 7
+- `runtime.odin` → Tasks 3 step 2, 4 step 3, 5 step 5, 7 steps 1-2
+- `bridge/` → Task 5
+- `profile/` → Task 4
+- `canvas/` → Task 3
+- "`./build-dev.sh`" → Task 2
+- "Test + CI integration" → Tasks 6, 8, 9
+- "redin-cli template parity" — *not* covered here; lives in a separate redin-cli PR. The smoke-native templates that mirror redin-cli's constants ARE covered in Task 9. The redin-cli PR is out of scope for this plan but should ship in the same release bump (per the spec).
+- "Documentation updates" → Tasks 10, 11, 12
+- "Migration / breaking changes" → Task 7's commit message captures the BREAKING CHANGE
+- "Verification" → Task 13
+
+**2. Placeholder scan:** No "TBD", "TODO", "implement later" patterns. The one near-placeholder is Task 4 step 2's instruction to "wrap the body of any `draw_overlay`-like proc in `when REDIN_PROFILE`" — but that's accompanied by a concrete `cat overlay.odin` step that lets the engineer see the file and a precise pattern (`when !REDIN_PROFILE do return` at the top of each public proc). Acceptable.
+
+**3. Type consistency:** `Config :: struct { app: string }` referenced consistently across Tasks 7, 9, and 12. `bridge.init(b)` (no parameter) consistent across Tasks 5 and 7. `profile.init()` (no parameter) consistent across Tasks 4 and 7. `canvas.set_dev_mode` removed entirely (Task 3) — no later task references it.
+
+**4. Ambiguity check:** The one judgment call is in Task 4: how to gate `is_enabled() -> bool` (returns `true` when `REDIN_PROFILE`, else `false`). I picked the explicit form. If a caller currently special-cases `!is_enabled()` for fast-path, gating works fine because the result is a compile-time constant. No later task contradicts.
+
+The plan is ready.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-03-compile-time-flags.md`.** Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints for review.
+
+Which approach?

--- a/docs/superpowers/plans/2026-05-03-compile-time-flags.md
+++ b/docs/superpowers/plans/2026-05-03-compile-time-flags.md
@@ -1195,21 +1195,12 @@ Replace with:
         run: |
           rm -rf dist-agent
           mkdir -p dist-agent
-          ./build-dev.sh -define:REDIN_AGENT=true -o:speed -out:dist-agent/redin
+          odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \
+            -define:REDIN_DEV=true -define:REDIN_PROFILE=true -define:REDIN_TRACK_MEM=true \
+            -define:REDIN_AGENT=true -out:dist-agent/redin -o:speed
 ```
 
-`./build-dev.sh` accepts a trailing `-out:` because `"$@"` is passed AFTER the script's hard-coded `-out:build/redin`, so the second `-out:` overrides. Verify this assumption by reading the script: `-out:build/redin "$@"` means the second `-out:` from `"$@"` overrides. Test locally:
-
-```bash
-./build-dev.sh -out:build/redin-test
-ls build/redin-test
-```
-
-Expected: `build/redin-test` exists. Delete it:
-
-```bash
-rm build/redin-test
-```
+This step bypasses `./build-dev.sh` because Odin rejects duplicate `-out:` flags — the script already hard-codes `-out:build/redin`, so we can't append a different `-out:` via `"$@"`. The agent release build needs a different output path (`dist-agent/redin`), so we expand the flags inline. The flag set matches what `./build-dev.sh` bakes in plus `-define:REDIN_AGENT=true` and the alternate `-out:`.
 
 - [ ] **Step 6: Update the release-notes "What's included" block**
 

--- a/docs/superpowers/specs/2026-05-03-compile-time-flags-design.md
+++ b/docs/superpowers/specs/2026-05-03-compile-time-flags-design.md
@@ -1,0 +1,230 @@
+# Compile-time flags for dev / profile / track-mem
+
+**Status:** design  
+**Date:** 2026-05-03  
+**Track:** developer ergonomics + release hygiene
+
+## Goal
+
+Convert the runtime CLI flags `--dev`, `--profile`, and `--track-mem`
+into compile-time `-define` constants, matching the existing
+`REDIN_AGENT` pattern. Bare `odin build` produces a release-stripped
+binary; `./build-dev.sh` produces a debug binary with all three
+features compiled in.
+
+## Why
+
+- **Strip dev surface from release builds.** Today the dev server,
+  hot reload, frame-timing ring buffer, and tracking allocator are
+  always compiled in; only their *activation* is gated by a runtime
+  flag. The HTTP listener thread, file watcher, port/token files, and
+  every `profile.begin / .end` call site live in the release binary.
+  Compile-time gating removes them entirely from binaries that don't
+  need them.
+- **Zero runtime cost for stripped features.** `when` blocks at the
+  call sites collapse to nothing, so the layout/render hot path
+  doesn't pay even an unused-branch cost.
+- **Consistency.** `REDIN_AGENT` already uses `#config(...) + when` to
+  ship zero agent code in default builds. The new flags follow the
+  same shape, so there's one mental model for "feature gated by build
+  flag" across the framework.
+- **Security posture.** A release binary that physically lacks the
+  dev-server listener can't be tricked into starting it.
+
+## Surface
+
+### New compile-time constants
+
+Declared in `src/redin/bridge/bridge.odin` next to `REDIN_AGENT`:
+
+```odin
+REDIN_DEV       :: #config(REDIN_DEV, false)
+REDIN_PROFILE   :: #config(REDIN_PROFILE, false)
+REDIN_TRACK_MEM :: #config(REDIN_TRACK_MEM, false)
+```
+
+All default `false`. Enable per-feature with `-define:REDIN_DEV=true`
+etc., or in bulk via `./build-dev.sh`.
+
+### CLI flags removed
+
+`--dev`, `--profile`, `--track-mem` are removed from `src/cmd/redin/main.odin`.
+The first non-flag argv stays as the app file (e.g., `./redin main.fnl`).
+
+### `redin.Config` shrinks
+
+```odin
+// before
+Config :: struct { app: string, dev: bool, profile: bool }
+
+// after
+Config :: struct { app: string }
+```
+
+Public API change for `--native` projects.
+
+## Per-package code changes
+
+### `src/cmd/redin/main.odin`
+
+- Drop arg parsing for `--dev`, `--profile`, `--track-mem`.
+- Wrap the tracker setup in `when bridge.REDIN_TRACK_MEM { ... }` so
+  the `mem.Tracking_Allocator`, the `context.allocator =` hoist
+  (added in #108), and the deferred leak dump are absent in non-track
+  builds.
+- The arg loop becomes: `for arg in os.args[1:] do cfg.app = arg`.
+
+### `src/redin/runtime.odin`
+
+- `Config` struct: drop `dev` and `profile`.
+- `run()`: drop `cfg.dev` / `cfg.profile` references.
+- `profile.init(cfg.profile)` → `profile.init()`.
+- `canvas.set_dev_mode(cfg.dev)` → `canvas.set_dev_mode()`,
+  internally reading `bridge.REDIN_DEV`. If the proc collapses to a
+  no-op outside dev, remove it entirely and inline a `when` block at
+  any call site that survives.
+- `bridge.init(&b, cfg.dev)` → `bridge.init(&b)`.
+
+### `src/redin/bridge/`
+
+- `Bridge.dev_mode` field removed.
+- `bridge.init` signature: drop the `dev_mode bool` parameter.
+- `bridge.destroy`'s `needs_listener := b.dev_mode || REDIN_AGENT`
+  becomes `needs_listener := REDIN_DEV || REDIN_AGENT`.
+- All `if b.dev_mode { ... }` becomes `when REDIN_DEV { ... }` so the
+  listener thread, hot-reload watcher, port/token file lifecycle, and
+  dev-only HTTP handler set are stripped from release binaries.
+- Existing `when REDIN_AGENT { ... }` branches remain unchanged. The
+  combined gate `REDIN_DEV || REDIN_AGENT` keeps the listener
+  available when either flag is set.
+
+### `src/redin/profile/`
+
+- `profile.init(profile bool)` → `profile.init()`.
+- Every public proc (`begin_frame`, `end_frame`, `begin`, `end`,
+  `draw_overlay`) wraps its body in `when REDIN_PROFILE { ... }`.
+  Callers in `runtime.run` stay unchanged — this preserves the call
+  sites and avoids sprinkling `when` blocks across the per-frame loop.
+- The `/profile` HTTP endpoint and the F3 overlay toggle are gated by
+  `when REDIN_PROFILE` so they're absent in non-profile builds.
+
+### `src/redin/canvas/`
+
+- `set_dev_mode(b: bool)` → `set_dev_mode()` reading `bridge.REDIN_DEV`,
+  *or* removed entirely if its only effect is a `when REDIN_DEV` at
+  the use sites. Pick the option that leaves fewer dead args at the
+  end of the implementation.
+
+## `./build-dev.sh`
+
+New script at the repo root:
+
+```bash
+#!/usr/bin/env bash
+set -e
+exec odin build src/cmd/redin \
+    -collection:lib=lib -collection:luajit=vendor/luajit \
+    -define:REDIN_DEV=true \
+    -define:REDIN_PROFILE=true \
+    -define:REDIN_TRACK_MEM=true \
+    -out:build/redin "$@"
+```
+
+`"$@"` forwards extra flags so the agent test job can run
+`./build-dev.sh -define:REDIN_AGENT=true` without duplicating the
+debug-flag list.
+
+## Test + CI integration
+
+- `test/ui/run-all.sh`: replace its inline `odin build` with
+  `./build-dev.sh`. The dev server is mandatory for the integration
+  suite, so this build is correct for testing.
+- `.github/workflows/test.yml`: same swap.
+- `.github/workflows/release.yml` / `release.sh`: switch to
+  `./build-dev.sh`. The redin binary in the release tarball is a dev
+  tool — its target audience (LLM/AI workflow drivers) needs the dev
+  server. The "stripped release binary" remains a `bare odin build`
+  away for `--native` users who want it for shipping their own apps.
+- `scripts/smoke-native.sh` inlines its own copies of the
+  `app.odin` and `build.sh` templates that mirror redin-cli's
+  `app-odin-fnl` / `build-sh-native` constants (per the
+  redin-maintenance skill's parity rule). Update both inline copies
+  alongside the redin-cli constants so the smoke check exercises the
+  same defaults a fresh `--native` project would.
+
+## redin-cli template parity
+
+Per `redin-maintenance/SKILL.md`'s parity rule (`app-odin-fnl` and
+`build-sh-native` constants in redin-cli must mirror the in-tree
+templates), this PR's coordinated update covers:
+
+- `redin-cli`'s `build-sh-native` constant: add the three
+  `-define:REDIN_*=true` flags as the default for new `--native`
+  projects.
+- `redin-cli`'s `app-odin-fnl` constant: drop any references to
+  `cfg.dev` / `cfg.profile`. Native projects parse `os.args` for
+  their app file only; debug features are compile-time.
+
+The `redin-cli` change ships in the same release bump as this PR.
+
+## Documentation updates
+
+Same commit (or adjacent commits in the same PR):
+
+- `CLAUDE.md` — Building, Running, Dev server sections.
+- `docs/core-api.md` — `--dev`, `--profile`, `--track-mem`
+  references → "compile with `-define:REDIN_DEV=true`".
+- `docs/reference/dev-server.md` — gating model.
+- `docs/reference/native-bridge.md` — note that `--native` `build.sh`
+  needs the flags for development.
+- `.claude/skills/redin-dev/SKILL.md` — Running, Dev server sections.
+- `.claude/skills/redin-maintenance/SKILL.md` — Build, UI tests,
+  `--track-mem`, agent build sections (multiple call sites).
+
+## Migration / breaking changes
+
+Atomic in this PR; called out in the PR description and any release
+notes:
+
+- `./redin --dev main.fnl` no longer recognises `--dev`. The first
+  argv becomes the app path, so `--dev` is treated as a missing file.
+- `redin.Config.dev` and `.profile` fields removed. `--native`
+  projects that set these fail to compile until updated.
+- `bridge.init`, `profile.init`, possibly `canvas.set_dev_mode` lose
+  their bool parameters.
+
+No deprecation period — the runtime flags map cleanly onto compile
+flags, and we'd rather take the breakage in a single PR than carry
+two parallel control surfaces. PR description includes a one-line
+migration recipe for each affected user.
+
+## Out of scope
+
+- Changing `REDIN_AGENT`'s shape or default.
+- Adding new debug features (memory snapshot endpoint, etc.).
+- Refactoring the profile package's API beyond removing the bool
+  parameter.
+- Refactoring the canvas package's dev-mode mechanism beyond
+  collapsing the bool parameter.
+- A `make`-based or task-runner build system. `./build-dev.sh` is the
+  ergonomic floor; anything richer is a separate decision.
+- Cross-compilation flag matrices.
+
+## Verification
+
+- `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin`
+  produces a release binary; running it with no `.redin-port` /
+  `.redin-token` files appearing confirms the dev server is absent.
+- `./build-dev.sh && ./build/redin --dev …` — wait, `--dev` is gone:
+  `./build-dev.sh && ./build/redin examples/kitchen-sink.fnl` should
+  start the dev server because `REDIN_DEV` was baked in.
+- Strip check: `nm build/redin | grep -ci 'devserver_\|hotreload_'`
+  should be 0 for a release build, non-zero for a `./build-dev.sh`
+  build.
+- All Fennel runtime tests pass.
+- `bash test/ui/run-all.sh --headless` passes after switching to
+  `./build-dev.sh`.
+- `--track-mem`-style verification: a `./build-dev.sh` binary still
+  reports tracker stats on graceful shutdown (the tracker is now
+  baked into dev builds, no flag needed). A bare-`odin build` binary
+  has no tracker overhead.

--- a/release.sh
+++ b/release.sh
@@ -7,7 +7,7 @@ NAME="redin-${VERSION}-${PLATFORM}"
 DIST="dist/${NAME}"
 
 echo "Building redin ${VERSION}..."
-odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+./build-dev.sh
 echo "  Binary built: build/redin"
 
 echo "Packaging ${NAME}.tar.gz..."

--- a/scripts/smoke-native.sh
+++ b/scripts/smoke-native.sh
@@ -3,7 +3,7 @@
 #
 # Takes the release tarball and simulates redin-cli's upgrade-to-native
 # flow against the current checkout: extract tarball → native/ tree →
-# ./build.sh → launch binary under --dev → curl /state.
+# ./build.sh → launch binary → curl /state.
 #
 # Catches contract breaks between the host source and the release tarball
 # (missing files, bad collection paths, runtime asset lookup) before the
@@ -52,7 +52,6 @@ import redin "./.redin/src/redin"
 
 main :: proc() {
 	cfg: redin.Config
-	cfg.dev = true
 	cfg.app = "main.fnl"
 	redin.run(cfg)
 }
@@ -66,6 +65,9 @@ mkdir -p "$SCRIPT_DIR/build"
 odin build "$SCRIPT_DIR" \
   -collection:lib="$SCRIPT_DIR/.redin/lib" \
   -collection:luajit="$SCRIPT_DIR/.redin/vendor/luajit" \
+  -define:REDIN_DEV=true \
+  -define:REDIN_PROFILE=true \
+  -define:REDIN_TRACK_MEM=true \
   -out:"$SCRIPT_DIR/build/redin"
 BUILD_SH
 chmod +x "$PROJECT/build.sh"
@@ -89,8 +91,8 @@ fi
 cd "$PROJECT"
 rm -f .redin-port .redin-token
 
-echo "=== 4/5 launching build/redin --dev ==="
-"${LAUNCHER[@]}" "$PROJECT/build/redin" --dev main.fnl &
+echo "=== 4/5 launching build/redin ==="
+"${LAUNCHER[@]}" "$PROJECT/build/redin" main.fnl &
 PID=$!
 
 cleanup() {

--- a/src/cmd/redin/main.odin
+++ b/src/cmd/redin/main.odin
@@ -12,42 +12,35 @@ import redin "../../redin"
 
 main :: proc() {
 	cfg: redin.Config
-	track_mem := false
 	for arg in os.args[1:] {
-		switch arg {
-		case "--dev":       cfg.dev = true
-		case "--track-mem": track_mem = true
-		case "--profile":   cfg.profile = true
-		case:               cfg.app = arg
-		}
+		cfg.app = arg
 	}
 
-	track: mem.Tracking_Allocator
-	allocator := context.allocator
-	if track_mem {
+	when REDIN_TRACK_MEM {
+		track: mem.Tracking_Allocator
 		mem.tracking_allocator_init(&track, context.allocator)
-		fmt.eprintln("Memory tracking enabled (--track-mem)")
-		allocator = mem.tracking_allocator(&track)
-	}
-	// Assign at proc scope. Odin's `context` is block-scoped: setting
-	// context.allocator inside an `if` block reverts when the block
-	// ends, so the tracker never reaches `redin.run` and reports zero
-	// activity. Hoisting the assignment out of the conditional fixes it.
-	context.allocator = allocator
-	defer if track_mem {
-		if len(track.allocation_map) > 0 {
-			fmt.eprintf("=== %v allocations not freed: ===\n", len(track.allocation_map))
-			for _, entry in track.allocation_map {
-				fmt.eprintf("- %v bytes @ %v\n", entry.size, entry.location)
+		fmt.eprintln("Memory tracking enabled (REDIN_TRACK_MEM)")
+		// Assign at proc scope. Odin's `context` is block-scoped: setting
+		// context.allocator inside an `if` block reverts when the block
+		// ends, so the tracker never reaches `redin.run` and reports zero
+		// activity. Compile-time `when` inlines its body at proc scope, so
+		// this assignment IS at effective proc scope when the flag is true.
+		context.allocator = mem.tracking_allocator(&track)
+		defer {
+			if len(track.allocation_map) > 0 {
+				fmt.eprintf("=== %v allocations not freed: ===\n", len(track.allocation_map))
+				for _, entry in track.allocation_map {
+					fmt.eprintf("- %v bytes @ %v\n", entry.size, entry.location)
+				}
 			}
-		}
-		if len(track.bad_free_array) > 0 {
-			fmt.eprintf("=== %v incorrect frees: ===\n", len(track.bad_free_array))
-			for entry in track.bad_free_array {
-				fmt.eprintf("- %p @ %v\n", entry.memory, entry.location)
+			if len(track.bad_free_array) > 0 {
+				fmt.eprintf("=== %v incorrect frees: ===\n", len(track.bad_free_array))
+				for entry in track.bad_free_array {
+					fmt.eprintf("- %p @ %v\n", entry.memory, entry.location)
+				}
 			}
+			mem.tracking_allocator_destroy(&track)
 		}
-		mem.tracking_allocator_destroy(&track)
 	}
 
 	redin.run(cfg)

--- a/src/cmd/redin/main.odin
+++ b/src/cmd/redin/main.odin
@@ -1,5 +1,10 @@
 package main
 
+// Compile-time flag enabling the tracking allocator. Default is false;
+// set with `odin build ... -define:REDIN_TRACK_MEM=true`. When false,
+// the tracker setup and leak dump compile out to zero bytes.
+REDIN_TRACK_MEM :: #config(REDIN_TRACK_MEM, false)
+
 import "core:fmt"
 import "core:mem"
 import "core:os"

--- a/src/redin/bridge/api.odin
+++ b/src/redin/bridge/api.odin
@@ -97,8 +97,10 @@ apply_register_cfunc :: proc(name: cstring, fn: proc(L: ^Lua_State) -> i32) {
 	L := g_bridge.L
 	if !get_redin_table(L, "register_cfunc", name) do return
 
-	if g_bridge.dev_mode && field_is_set(L, name) {
-		fmt.eprintfln("redin: warn: bridge.register_cfunc(%q) replaces an existing binding", name)
+	when REDIN_DEV {
+		if field_is_set(L, name) {
+			fmt.eprintfln("redin: warn: bridge.register_cfunc(%q) replaces an existing binding", name)
+		}
 	}
 
 	// Push the user proc pointer as a lightuserdata upvalue, then build a
@@ -116,8 +118,10 @@ apply_register_cfunc_raw :: proc(name: cstring, fn: Lua_CFunction) {
 	L := g_bridge.L
 	if !get_redin_table(L, "register_cfunc_raw", name) do return
 
-	if g_bridge.dev_mode && field_is_set(L, name) {
-		fmt.eprintfln("redin: warn: bridge.register_cfunc_raw(%q) replaces an existing binding", name)
+	when REDIN_DEV {
+		if field_is_set(L, name) {
+			fmt.eprintfln("redin: warn: bridge.register_cfunc_raw(%q) replaces an existing binding", name)
+		}
 	}
 
 	lua_pushcfunction(L, fn)

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -48,16 +48,14 @@ Bridge :: struct {
 	hot_reload:      Hot_Reload,
 	dev_server:      Dev_Server,
 	frame_changed:   bool,
-	dev_mode:        bool,
 }
 
 g_bridge: ^Bridge
 g_context: runtime.Context
 
-init :: proc(b: ^Bridge, dev_mode: bool) {
+init :: proc(b: ^Bridge) {
 	g_bridge = b
 	g_context = context
-	b.dev_mode = dev_mode
 	http_client_init(&b.http_client)
 	shell_client_init(&b.shell_client)
 	b.L = luaL_newstate()
@@ -100,27 +98,19 @@ init :: proc(b: ^Bridge, dev_mode: bool) {
 	load_fennel(b.L)
 	load_runtime(b.L)
 
-	needs_listener := dev_mode
-	when REDIN_AGENT {
-		needs_listener = true
-	}
-	if needs_listener {
+	when REDIN_DEV || REDIN_AGENT {
 		devserver_init(&b.dev_server, b)
 	}
-	if dev_mode {
+	when REDIN_DEV {
 		hotreload_init(&b.hot_reload)
 	}
 }
 
 destroy :: proc(b: ^Bridge) {
-	needs_listener := b.dev_mode
-	when REDIN_AGENT {
-		needs_listener = true
-	}
-	if needs_listener {
+	when REDIN_DEV || REDIN_AGENT {
 		devserver_destroy(&b.dev_server)
 	}
-	if b.dev_mode {
+	when REDIN_DEV {
 		hotreload_destroy(&b.hot_reload)
 	}
 	http_client_destroy(&b.http_client)
@@ -135,11 +125,7 @@ destroy :: proc(b: ^Bridge) {
 }
 
 poll_devserver :: proc(b: ^Bridge, events: ^[dynamic]types.InputEvent, node_rects: []rl.Rectangle) {
-	needs_poll := b.dev_mode
-	when REDIN_AGENT {
-		needs_poll = true
-	}
-	if !needs_poll do return
+	when !(REDIN_DEV || REDIN_AGENT) do return
 	b.dev_server.current_rects = node_rects
 	devserver_poll(&b.dev_server)
 	devserver_drain_events(&b.dev_server, events)
@@ -147,15 +133,14 @@ poll_devserver :: proc(b: ^Bridge, events: ^[dynamic]types.InputEvent, node_rect
 }
 
 is_shutdown_requested :: proc(b: ^Bridge) -> bool {
-	needs_listener := b.dev_mode
-	when REDIN_AGENT {
-		needs_listener = true
+	when REDIN_DEV || REDIN_AGENT {
+		return b.dev_server.shutdown_requested
 	}
-	return needs_listener && b.dev_server.shutdown_requested
+	return false
 }
 
 check_hotreload :: proc(b: ^Bridge) {
-	if !b.dev_mode do return
+	when !REDIN_DEV do return
 	if hotreload_check(&b.hot_reload) {
 		hotreload_execute(b)
 		b.frame_changed = true

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -6,6 +6,12 @@ package bridge
 // to zero bytes.
 REDIN_AGENT :: #config(REDIN_AGENT, false)
 
+// Compile-time flag enabling the dev server, hot reload, and dev-only
+// canvas warnings. Default is false; set with `odin build ... -define:REDIN_DEV=true`
+// (or use `./build-dev.sh`). When false, the listener thread, file watcher,
+// port/token files, and dev-only HTTP handlers compile out to zero bytes.
+REDIN_DEV :: #config(REDIN_DEV, false)
+
 import "core:fmt"
 import "core:math"
 import "core:os"

--- a/src/redin/canvas/canvas.odin
+++ b/src/redin/canvas/canvas.odin
@@ -1,6 +1,11 @@
 // src/redin/canvas/canvas.odin
 package canvas
 
+// Same compile-time flag declared in bridge — Odin's `#config` reads
+// the same -define value regardless of which package declares it, so
+// this stays in lockstep without a cross-package import.
+REDIN_DEV :: #config(REDIN_DEV, false)
+
 import "core:fmt"
 import rl "vendor:raylib"
 

--- a/src/redin/canvas/canvas.odin
+++ b/src/redin/canvas/canvas.odin
@@ -31,18 +31,9 @@ Canvas_Entry :: struct {
 entries: map[string]Canvas_Entry
 current_name: string
 
-@(private = "file")
-g_dev_mode: bool
-
-// Toggle dev-mode warnings. Called by redin.run; user code shouldn't need
-// this directly.
-set_dev_mode :: proc(dev: bool) {
-	g_dev_mode = dev
-}
-
 register :: proc(name: string, provider: Canvas_Provider) {
 	if existing, ok := entries[name]; ok {
-		if g_dev_mode {
+		when REDIN_DEV {
 			fmt.eprintfln("redin: warn: canvas.register(%q) replaces an existing provider", name)
 		}
 		if existing.provider.stop != nil {

--- a/src/redin/profile/overlay.odin
+++ b/src/redin/profile/overlay.odin
@@ -12,7 +12,7 @@ GRAPH_H   :: 30
 
 // Called from main.odin between draw_tree and canvas.end_frame. Toggles on F3.
 draw_overlay :: proc() {
-    if !enabled_flag do return
+    when !REDIN_PROFILE do return
 
     if rl.IsKeyPressed(.F3) {
         visible_flag = !visible_flag

--- a/src/redin/profile/profile.odin
+++ b/src/redin/profile/profile.odin
@@ -32,7 +32,6 @@ Scope :: struct {
     live:  bool, // zero-valued Scopes from the no-op path are skipped
 }
 
-@(private) enabled_flag: bool
 @(private) visible_flag: bool
 @(private) ring:         Ring
 @(private) snapshot_mu:  sync.Mutex
@@ -43,27 +42,31 @@ Scope :: struct {
 @(private) frame_start:    time.Tick
 @(private) phase_scratch:  [Phase]i64
 
-is_enabled :: proc() -> bool { return enabled_flag }
+is_enabled :: proc() -> bool {
+    when REDIN_PROFILE { return true }
+    return false
+}
 
 overlay_visible :: proc() -> bool { return visible_flag }
 set_overlay_visible :: proc(v: bool) { visible_flag = v }
 
-init :: proc(enabled: bool) {
-    enabled_flag = enabled
-    visible_flag = enabled
-    ring = {}
-    frame_start = {}
-    phase_scratch = {}
+init :: proc() {
+    when REDIN_PROFILE {
+        visible_flag = true
+        ring = {}
+        frame_start = {}
+        phase_scratch = {}
+    }
 }
 
 begin_frame :: proc() {
-    if !enabled_flag do return
+    when !REDIN_PROFILE do return
     frame_start = time.tick_now()
     phase_scratch = {}
 }
 
 end_frame :: proc() {
-    if !enabled_flag do return
+    when !REDIN_PROFILE do return
     total := time.tick_diff(frame_start, time.tick_now())
 
     sync.lock(&snapshot_mu)
@@ -81,17 +84,19 @@ end_frame :: proc() {
 }
 
 begin :: proc(p: Phase) -> Scope {
-    if !enabled_flag do return Scope{}
+    when !REDIN_PROFILE do return Scope{}
     return Scope{phase = p, start = time.tick_now(), live = true}
 }
 
 end :: proc(s: Scope) {
+    when !REDIN_PROFILE do return
     if !s.live do return
     phase_scratch[s.phase] += i64(time.tick_diff(s.start, time.tick_now()))
 }
 
 // Append current ring contents (oldest→newest) to `out`.
 snapshot_into :: proc(out: ^[dynamic]FrameSample) {
+    when !REDIN_PROFILE do return
     sync.lock(&snapshot_mu)
     defer sync.unlock(&snapshot_mu)
 

--- a/src/redin/profile/profile.odin
+++ b/src/redin/profile/profile.odin
@@ -1,5 +1,11 @@
 package profile
 
+// Compile-time flag enabling frame-timing instrumentation, the F3
+// overlay, and the /profile HTTP endpoint. Default is false; set with
+// `odin build ... -define:REDIN_PROFILE=true`. When false, every public
+// proc body in this package compiles out to zero bytes.
+REDIN_PROFILE :: #config(REDIN_PROFILE, false)
+
 import "core:sync"
 import "core:time"
 

--- a/src/redin/profile/profile_test.odin
+++ b/src/redin/profile/profile_test.odin
@@ -10,11 +10,12 @@ import "core:time"
 
 @(test)
 test_ring_fill_short :: proc(t: ^testing.T) {
+    when !REDIN_PROFILE { return }
     sync.lock(&test_mu)
     defer sync.unlock(&test_mu)
 
-    init(true)
-    defer init(false) // reset
+    init()
+    defer init() // reset
 
     for i in 0 ..< 30 {
         begin_frame()
@@ -32,11 +33,12 @@ test_ring_fill_short :: proc(t: ^testing.T) {
 
 @(test)
 test_ring_wrap :: proc(t: ^testing.T) {
+    when !REDIN_PROFILE { return }
     sync.lock(&test_mu)
     defer sync.unlock(&test_mu)
 
-    init(true)
-    defer init(false)
+    init()
+    defer init()
 
     for i in 0 ..< 200 {
         begin_frame()
@@ -55,31 +57,37 @@ test_ring_wrap :: proc(t: ^testing.T) {
 
 @(test)
 test_disabled_is_noop :: proc(t: ^testing.T) {
+    // When REDIN_PROFILE is false at compile time, all procs are no-ops
+    // and is_enabled() always returns false. Verify that invariant.
     sync.lock(&test_mu)
     defer sync.unlock(&test_mu)
 
-    init(false)
+    when !REDIN_PROFILE {
+        begin_frame()
+        s := begin(.Input)
+        end(s)
+        end_frame()
 
-    begin_frame()
-    s := begin(.Input)
-    end(s)
-    end_frame()
+        samples := make([dynamic]FrameSample)
+        defer delete(samples)
+        snapshot_into(&samples)
 
-    samples := make([dynamic]FrameSample)
-    defer delete(samples)
-    snapshot_into(&samples)
-
-    testing.expect_value(t, len(samples), 0)
-    testing.expect_value(t, is_enabled(), false)
+        testing.expect_value(t, len(samples), 0)
+        testing.expect_value(t, is_enabled(), false)
+    } else {
+        // REDIN_PROFILE=true: is_enabled always returns true.
+        testing.expect_value(t, is_enabled(), true)
+    }
 }
 
 @(test)
 test_phase_accumulation :: proc(t: ^testing.T) {
+    when !REDIN_PROFILE { return }
     sync.lock(&test_mu)
     defer sync.unlock(&test_mu)
 
-    init(true)
-    defer init(false)
+    init()
+    defer init()
 
     begin_frame()
     s := begin(.Input)

--- a/src/redin/runtime.odin
+++ b/src/redin/runtime.odin
@@ -154,7 +154,7 @@ run :: proc(cfg: Config) {
 	profile.init()
 
 	b: bridge.Bridge
-	bridge.init(&b, cfg.dev)
+	bridge.init(&b)
 	defer bridge.destroy(&b)
 	defer canvas.destroy()
 

--- a/src/redin/runtime.odin
+++ b/src/redin/runtime.odin
@@ -14,9 +14,7 @@ import rl "vendor:raylib"
 // ---------------------------------------------------------------------------
 
 Config :: struct {
-	app:     string,
-	dev:     bool,
-	profile: bool,
+	app: string,
 }
 
 // Hook callback types. Hooks are typed as default-convention `proc()` so
@@ -130,7 +128,8 @@ request_shutdown :: proc() {
 // ---------------------------------------------------------------------------
 
 // Block until the window closes or `request_shutdown` is called. Sets up
-// the window, bridge, and dev server (if cfg.dev), then runs the loop.
+// the window, bridge, and dev server (when built with -define:REDIN_DEV=true),
+// then runs the loop.
 //
 // Per-frame call order:
 //   poll_input -> on_input(filter) -> bridge tick -> on_frame -> render

--- a/src/redin/runtime.odin
+++ b/src/redin/runtime.odin
@@ -151,7 +151,7 @@ run :: proc(cfg: Config) {
 	font.init()
 	defer font.destroy()
 
-	profile.init(cfg.profile)
+	profile.init()
 
 	b: bridge.Bridge
 	bridge.init(&b, cfg.dev)

--- a/src/redin/runtime.odin
+++ b/src/redin/runtime.odin
@@ -153,8 +153,6 @@ run :: proc(cfg: Config) {
 
 	profile.init(cfg.profile)
 
-	canvas.set_dev_mode(cfg.dev)
-
 	b: bridge.Bridge
 	bridge.init(&b, cfg.dev)
 	defer bridge.destroy(&b)

--- a/test/ui/run-all.sh
+++ b/test/ui/run-all.sh
@@ -45,7 +45,7 @@ TOTAL_FAILED=0
 
 # Build
 echo "=== Building redin ==="
-odin build "$ROOT_DIR/src/cmd/redin" -collection:lib="$ROOT_DIR/lib" -collection:luajit="$ROOT_DIR/vendor/luajit" -out:"$BINARY"
+( cd "$ROOT_DIR" && ./build-dev.sh )
 echo ""
 
 wait_for_server() {
@@ -91,7 +91,7 @@ for test_file in "$SCRIPT_DIR"/test_*.bb; do
 
   # Start dev server in background
   rm -f "$PORT_FILE"
-  "${LAUNCHER[@]}" "$BINARY" --dev "${extra_flags[@]}" "$app_file" &
+  "${LAUNCHER[@]}" "$BINARY" "${extra_flags[@]}" "$app_file" &
   SERVER_PID=$!
 
   if ! wait_for_server; then


### PR DESCRIPTION
## Summary

Converts the runtime CLI flags `--dev`, `--profile`, and `--track-mem` into compile-time `-define` constants (`REDIN_DEV`, `REDIN_PROFILE`, `REDIN_TRACK_MEM`) matching the existing `REDIN_AGENT` pattern. Bare `odin build` produces a release-stripped binary with **zero** dev-server / profile / tracker code; `./build-dev.sh` (new) bakes in all three flags for the everyday dev workflow. `redin.Config` shrinks to `{ app: string }`.

## Why

- **Strip dev surface from release builds.** The HTTP listener thread, file watcher, port/token files, profile ring buffer, every `profile.begin / .end` call, and the tracking allocator are all stripped to zero bytes when their flag is off.
- **Zero runtime cost for stripped features.** `when` blocks at call sites collapse to nothing — no unused-branch cost in the layout/render hot path.
- **Consistency.** Same `#config(NAME, false)` + `when NAME { ... }` shape as `REDIN_AGENT`. One mental model for "feature gated by build flag" across the framework.
- **Security.** A release binary that physically lacks the dev-server listener can't be tricked into starting it.

## What changed

- New: `build-dev.sh` — wraps `odin build` with the three `-define`s + forwards `"$@"`.
- `src/redin/{bridge,canvas,profile}/` — runtime gates replaced with `when REDIN_*` blocks; bool params dropped from `bridge.init` / `profile.init` / `canvas.set_dev_mode`.
- `src/redin/runtime.odin` — `Config` shrunk to `{ app: string }`.
- `src/cmd/redin/main.odin` — drops `--dev` / `--profile` / `--track-mem` argv parsing; tracker setup wrapped in `when REDIN_TRACK_MEM`.
- CI (`test.yml`, `release.yml`) + `release.sh` + `scripts/smoke-native.sh` — switch to `./build-dev.sh` (the agent release build expands flags inline because Odin rejects duplicate `-out:`).
- Docs (`CLAUDE.md`, `docs/core-api.md`, `docs/reference/{dev-server,native-bridge}.md`, `docs/guide/{quickstart,lua-guide}.md`) and skills (`redin-dev`, `redin-maintenance`) — wording swapped to compile-time model.

## BREAKING CHANGES

- `./redin --dev main.fnl` no longer recognises `--dev`; argv is treated as a missing file path. Use `./build-dev.sh` to produce a binary with the dev server compiled in.
- `redin.Config.dev` and `.profile` fields removed. `--native` projects that set them fail to compile.
- `bridge.init`, `profile.init`, `canvas.set_dev_mode` lose their bool parameters.

## Spec / plan

- Spec: `docs/superpowers/specs/2026-05-03-compile-time-flags-design.md`
- Plan: `docs/superpowers/plans/2026-05-03-compile-time-flags.md` (13 tasks, executed via subagent-driven workflow with two-stage review per task)

## Test plan

- [x] `odin build` (release) — clean, no dev-server symbols' heavy variants (`devserver_init`, `devserver_destroy`, `hotreload_init`, `hotreload_destroy` all absent).
- [x] `./build-dev.sh` (dev) — clean, dev server starts on launch without `--dev` argv.
- [x] Behavioral: release binary creates no `.redin-port` / `.redin-token`; dev binary creates them and `/shutdown` round-trips.
- [x] `--track-mem` behavior: dev binary prints "Memory tracking enabled (REDIN_TRACK_MEM)" + 23 long-lived global allocations on shutdown (existing baseline).
- [x] Fennel runtime tests: 133/133.
- [x] Odin unit tests: markdown 27, bridge 24, parser 26, input 22, profile 4 — all pass.
- [x] Full UI integration suite (`bash test/ui/run-all.sh --headless`): "All test suites passed".
- [x] Smoke-native check: tarball → simulated `--native` project → "smoke check PASSED".

## Followups

A handful of doc/script polish items surfaced in the cumulative review (README.md, setup.sh, redin-dev skill `./build.sh` mislabel, migration recipe, three minor cleanups). Tracked separately — branch is functionally correct and tested green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)