### PR TITLE
fix: compile-time flags doc/script polish followups (#115)

### DIFF
--- a/.claude/skills/redin-dev/SKILL.md
+++ b/.claude/skills/redin-dev/SKILL.md
@@ -422,10 +422,12 @@ main :: proc() {
 ### Running
 
 ```bash
-./build-dev.sh                    # rebuild with REDIN_DEV=true (dev server enabled)
+./build-dev.sh                    # rebuild with REDIN_DEV / REDIN_PROFILE / REDIN_TRACK_MEM all baked in
 ./build/redin main.fnl            # built with REDIN_DEV → dev server starts
-./build.sh                        # (--native only) rebuild after editing app.odin (release build)
+./build.sh                        # (--native only) rebuild after editing app.odin (dev build with REDIN_DEV / REDIN_PROFILE / REDIN_TRACK_MEM)
 ```
+
+**Migrating from pre-compile-time-flags `--native` projects:** if your `app.odin` sets `cfg.dev = true` or `cfg.profile = true`, drop those lines (`Config` only has `app: string` now). Add `-define:REDIN_DEV=true -define:REDIN_PROFILE=true -define:REDIN_TRACK_MEM=true` to your `build.sh` before the `-out:` flag — the scaffolded template already does this for new projects.
 
 ## Key conventions
 

--- a/.claude/skills/redin-maintenance/SKILL.md
+++ b/.claude/skills/redin-maintenance/SKILL.md
@@ -23,7 +23,7 @@ Requires: `libssl-dev`, `libraylib-dev`, and the `lib/odin-http` git submodule (
 luajit test/lua/runner.lua test/lua/test_*.fnl
 ```
 
-Covers dataflow, effects, frames, views, themes, canvas, and shell. Currently 122 tests. Run after any change to `src/runtime/`.
+Covers dataflow, effects, frames, views, themes, canvas, and shell. Currently 133 tests. Run after any change to `src/runtime/`.
 
 ## UI integration tests
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,3 +159,35 @@ jobs:
             redin-cli new-fnl my-app
             cd my-app && ./redinw main.fnl
             ```
+
+            ## Breaking changes from prior releases
+
+            The `--dev`, `--profile`, and `--track-mem` runtime CLI flags
+            are removed. They become compile-time `-define`s
+            (`REDIN_DEV`, `REDIN_PROFILE`, `REDIN_TRACK_MEM`). The
+            shipped `redin` binary has all three baked in (its audience
+            is AI workflow drivers that need the dev server); a bare
+            `odin build` still produces a release-stripped variant.
+
+            **Migrating an existing `--native` project:**
+
+            ```diff
+            # app.odin
+              cfg: redin.Config
+            - cfg.dev = true
+            - cfg.profile = true
+              cfg.app = "main.fnl"
+              redin.run(cfg)
+
+            # build.sh — add the three -define flags before -out:
+              odin build "$SCRIPT_DIR" \
+                -collection:lib="$SCRIPT_DIR/.redin/lib" \
+                -collection:luajit="$SCRIPT_DIR/.redin/vendor/luajit" \
+            +   -define:REDIN_DEV=true \
+            +   -define:REDIN_PROFILE=true \
+            +   -define:REDIN_TRACK_MEM=true \
+                -out:"$SCRIPT_DIR/build/redin"
+            ```
+
+            The F3 frame-timing overlay is now visible by default in any
+            binary built with `REDIN_PROFILE=true`. Press F3 to hide it.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ curl -sL https://raw.githubusercontent.com/sstoehrm/redin-cli/main/install.sh | 
 # Create a Fennel project
 redin-cli new-fnl my-app
 cd my-app
-./redinw --dev main.fnl
+./redinw main.fnl
 
 # Or a Lua project
 redin-cli new-lua my-app
@@ -45,11 +45,17 @@ The CLI downloads a pinned redin binary into `.redin/` — no build tools needed
 # Prerequisites (Ubuntu/Debian)
 sudo apt-get install -y luajit libluajit-5.1-dev libssl-dev
 
-# Build
-odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+# Dev build (bakes in REDIN_DEV / REDIN_PROFILE / REDIN_TRACK_MEM)
+./build-dev.sh
 
-# Run
-./build/redin --dev examples/kitchen-sink.fnl
+# Run — dev server starts because REDIN_DEV is compiled in
+./build/redin examples/kitchen-sink.fnl
+```
+
+For a release-stripped binary (no dev server, no profile, no tracker), use bare `odin build` instead:
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
 ```
 
 | Dependency | Purpose | Required |

--- a/setup.sh
+++ b/setup.sh
@@ -58,10 +58,14 @@ git submodule update --init --recursive
 
 # --- Build ---
 echo ""
-echo "Building redin..."
+echo "Building redin (dev binary: REDIN_DEV / REDIN_PROFILE / REDIN_TRACK_MEM baked in)..."
 mkdir -p build
-odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+./build-dev.sh
 
 echo ""
 echo "=== Setup complete ==="
-echo "  ./build/redin --dev examples/kitchen-sink.fnl"
+echo "  ./build/redin examples/kitchen-sink.fnl"
+echo ""
+echo "Dev server (port + auth token in .redin-port / .redin-token) starts"
+echo "automatically because REDIN_DEV is compiled in. For a stripped"
+echo "release binary, use bare 'odin build' instead of ./build-dev.sh."

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -92,7 +92,7 @@ sync_queue_drain :: proc(sq: ^Sync_Queue, out: ^[dynamic]^Pending_Request) {
 //
 // On EEXIST we lstat the path and only retry after unlinking when the
 // existing entry is a regular file — handles the legitimate case where
-// a previous --dev run crashed without cleaning up. Symlinks raise
+// a previous dev run crashed without cleaning up. Symlinks raise
 // ELOOP under O_NOFOLLOW, FIFOs/sockets/devices fall through without
 // retry, so neither path can be hijacked.
 write_private_no_follow :: proc(path: string, data: []u8) -> bool {

--- a/src/redin/bridge/devserver_write_test.odin
+++ b/src/redin/bridge/devserver_write_test.odin
@@ -76,7 +76,7 @@ test_write_private_no_follow_refuses_symlink :: proc(t: ^testing.T) {
 
 @(test)
 test_write_private_no_follow_replaces_stale_regular_file :: proc(t: ^testing.T) {
-	// A previous --dev run that crashed leaves .redin-token behind as a
+	// A previous dev run that crashed leaves .redin-token behind as a
 	// regular file with mode 0600. The next run must be able to replace
 	// it (otherwise dev mode breaks after any crash). The replacement
 	// must NOT preserve any prior content.


### PR DESCRIPTION
## Summary

Closes the seven user-facing doc/script gaps surfaced in #114's cumulative review (issue #115). All polish — no behavior change.

### Important
- `README.md` — dev recipe now `./build-dev.sh && ./build/redin …`; release build documented as the alternative path.
- `setup.sh` — builds via `./build-dev.sh`, welcome line drops `--dev`, adds a note that the dev server requires the dev build.
- `.claude/skills/redin-dev/SKILL.md` — `./build.sh` for `--native` projects is correctly labelled as a dev build (matches `scripts/smoke-native.sh`'s template + redin-cli's `build-sh-native` constant). Adds an inline migration note for users upgrading from the pre-PR `cfg.dev = true` style.
- `.github/workflows/release.yml` — release notes body now carries a "Breaking changes" section with a one-glance `app.odin` + `build.sh` diff plus a one-line note that the F3 frame-timing overlay is visible by default in `REDIN_PROFILE` builds.

### Minor
- `src/redin/bridge/devserver.odin` and `src/redin/bridge/devserver_write_test.odin` — stale `--dev run` comments → `dev run`.
- `.claude/skills/redin-maintenance/SKILL.md` — stale Fennel runtime test count `122` → `133` (pre-existing drift, easy fix while the file's open).

## Test plan

- [x] `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin` — clean.
- [x] `./build-dev.sh` — clean.
- [x] `odin test src/redin/bridge -define:ODIN_TEST_THREADS=1` — 24/24.
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 133/133.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — parses.
- [x] `grep -rn "\-\-dev\b" README.md setup.sh .claude/skills/ src/redin/` — zero matches.

Closes #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)