### PR TITLE
fix: security audit hardening (#99)

### DIFF
--- a/.claude/skills/redin-dev/SKILL.md
+++ b/.claude/skills/redin-dev/SKILL.md
@@ -226,6 +226,21 @@ canvas.register("my-provider", my_provider)
      :dispatch-later {:ms 1000 :dispatch [:event/timeout]}}))
 ```
 
+### Effect-map fields (security-relevant)
+
+`:http` map:
+- `:timeout` (ms, default 30000). On expiry, error handler receives `{status: 0, error: "http timeout exceeded"}`.
+- URL scheme must be `http`/`https`; header keys/values must not contain `\r`, `\n`, `\x00`. 3xx responses are not auto-followed. In-flight cap is 64. See `docs/reference/effects.md` for the full failure-message table.
+
+`:shell` map:
+- `:cmd` array of strings (argv, no shell interpolation), `:stdin` optional string.
+- `:timeout` (ms, default 30000). On expiry, child is killed; error handler receives `{exit_code: -1, error_msg: "shell timeout exceeded N ms"}`.
+- `:max-output` (MiB, default 16). Combined stdout+stderr cap; on exceedance, child is killed; error handler receives `{exit_code: -1, error_msg: "shell output exceeded N MiB cap"}`.
+
+Optional global policy (in `app.odin` for `--native` projects):
+- `bridge.set_http_whitelist([]string{...})` — restrict `redin.http` to listed hostnames / CIDR blocks.
+- `bridge.set_shell_env_allowlist([]string{...})` — strip env vars not in the list when spawning children.
+
 ## Dev server (built with `-define:REDIN_DEV=true` or `./build-dev.sh`, default port 8800)
 
 Authenticated: every non-OPTIONS request needs `Authorization: Bearer <token>`, where the token is written to `./.redin-token` on startup (0600, deleted on shutdown). The `Host` header must also be `localhost:<port>` or `127.0.0.1:<port>`. Bound port is in `./.redin-port`.
@@ -346,6 +361,8 @@ For `proc "c"` cfuncs (escape hatch — usually not needed), use `bridge.registe
 | `bridge.push(L, value: any)` | Marshaller: Odin → Lua. Supports primitives, slices, arrays, dynamic arrays, maps, structs, unions, pointers, enums, any. Bails at depth 32 on cycles. |
 | `bridge.dispatch(event, payload: any) -> (ok, err)` | Marshal payload + push to Fennel as `[:dispatch [:event-name payload]]`. Calls the matching `reg-handler`. |
 | `bridge.dispatch_tos(L, event) -> (ok, err)` | Zero-copy: caller already pushed payload onto the stack (hot path, e.g. per-frame state). |
+| `bridge.set_http_whitelist(allow: []string)` | Restrict `redin.http` to listed hostnames / CIDR blocks. `nil` = unset (accept any). Rejection: `{status: 0, error: "host <name> not in http whitelist"}`. |
+| `bridge.set_shell_env_allowlist(allow: []string)` | Strip env vars not in the list when spawning `redin.shell` children. `nil` = full passthrough. |
 
 ## redin-cli
 

--- a/.claude/skills/redin-dev/SKILL.md
+++ b/.claude/skills/redin-dev/SKILL.md
@@ -234,8 +234,8 @@ canvas.register("my-provider", my_provider)
 
 `:shell` map:
 - `:cmd` array of strings (argv, no shell interpolation), `:stdin` optional string.
-- `:timeout` (ms, default 30000). On expiry, child is killed; error handler receives `{exit_code: -1, error_msg: "shell timeout exceeded N ms"}`.
-- `:max-output` (MiB, default 16). Combined stdout+stderr cap; on exceedance, child is killed; error handler receives `{exit_code: -1, error_msg: "shell output exceeded N MiB cap"}`.
+- `:timeout` (ms, default 30000). On expiry, child is killed; error handler receives `{exit-code: -1, error: "shell timeout exceeded N ms"}`.
+- `:max-output` (MiB, default 16). Combined stdout+stderr cap; on exceedance, child is killed; error handler receives `{exit-code: -1, error: "shell output exceeded N MiB cap"}`.
 
 Optional global policy (in `app.odin` for `--native` projects):
 - `bridge.set_http_whitelist([]string{...})` — restrict `redin.http` to listed hostnames / CIDR blocks.

--- a/docs/core-api.md
+++ b/docs/core-api.md
@@ -78,13 +78,22 @@ This is by design and appropriate for a development framework. **It does mean re
 
 The runtime's internal tables (`dataflow`, `effect`, `view`, etc.) are reachable from app code via `require`. Don't rely on them being private — they're "internal" by convention only.
 
-### `redin.http` — unrestricted URLs
+### `redin.http` — unrestricted URLs by default
 
-The `redin.http` host function (and the `:http` effect that wraps it) sends whatever URL the app constructs. There is no allowlist for loopback (`127/8`), link-local (`169.254/16`), RFC1918 (`10/8`, `172.16/12`, `192.168/16`), or `file://`. Any string that reaches the helper hits the network as-is.
+The `redin.http` host function (and the `:http` effect that wraps it) sends whatever URL the app constructs. There is no built-in SSRF allowlist for loopback (`127/8`), link-local (`169.254/16`), or RFC1918 (`10/8`, `172.16/12`, `192.168/16`); any reachable host is fair game.
 
-For most apps this is fine — the app author chose the URL. If your app embeds third-party templates, plugin URLs, or anything that could turn a remote string into a request target, **sanitize before dispatching**. Server-side request forgery (SSRF) is otherwise on the table.
+For most apps this is fine — the app author chose the URL. If your app embeds third-party templates, plugin URLs, or anything that could turn a remote string into a request target, **sanitize before dispatching**, or use `bridge.set_http_whitelist` (see [native bridge](reference/native-bridge.md)) to enforce a hostname/CIDR allowlist at the host boundary.
 
-A 16 MiB cap on response bodies is enforced by the host (oversized announcements fail fast with a "Response body too large" error). Per-request wall-clock timeout is not yet wired through to the worker thread; the `:timeout` field on the effect is currently advisory.
+Always-on guards (no opt-out):
+
+- **Scheme:** only `http` and `https` URLs are accepted. Other schemes (e.g. `file://`, `ftp://`) fail with `{status: 0, error: "http scheme must be http or https"}`.
+- **Headers:** any header key/value containing `\r`, `\n`, or `\x00` fails with `{status: 0, error: "http header contains invalid character"}` (defence against header-splitting).
+- **Redirects:** 3xx responses are **not** auto-followed. The status, headers (including `Location`), and body surface to the caller as-is.
+- **Body cap:** 16 MiB cap on response bodies; oversized responses fail with "Response body too large".
+- **In-flight cap:** 64 concurrent requests; over-cap submission fails with `{status: 0, error: "too many concurrent http requests (cap 64)"}`.
+- **Timeout:** default 30000 ms; override via `:timeout N` (ms) on the `:http` effect map. On expiry: `{status: 0, error: "http timeout exceeded"}`.
+
+See [Effects](reference/effects.md#built-in-http) for the full failure-response table and [native bridge](reference/native-bridge.md) for the optional whitelist setter.
 
 ### Dev server (built with `-define:REDIN_DEV=true`)
 
@@ -513,6 +522,8 @@ Called automatically by the view runner after `main_view` returns.
 
 Queues an async HTTP request. The request runs on a background thread. When complete, the response is delivered as an `[:http-response data]` event where `data` is `{id, status, body, headers, error}`.
 
+`timeout` is in milliseconds (default 30000). Scheme must be `http` or `https`. Header keys/values must not contain `\r`, `\n`, or `\x00`. 3xx responses are not auto-followed. Concurrency cap: 64 in-flight requests. See [Effects](reference/effects.md#built-in-http) for the full failure-response table.
+
 Typically called through the `:http` effect rather than directly.
 
 ### `redin.json_encode(value)`
@@ -554,7 +565,7 @@ Providers register in Odin via `canvas.register(name, provider)`. See the [canva
 
 Runs on `localhost:8800` when the binary was built with `-define:REDIN_DEV=true` (or `-define:REDIN_AGENT=true`). All responses are JSON unless noted.
 
-**Authentication.** Every non-`OPTIONS` request must include `Authorization: Bearer <token>`, where the token is read from `./.redin-token` (generated on startup, mode 0600, removed on shutdown). The server also verifies the `Host` header is `localhost:<port>` or `127.0.0.1:<port>` (DNS-rebinding defence). Missing token → `401`, bad Host → `403`, `OPTIONS` → `405` (CORS preflight not served — the endpoint is for local tools, not browsers). See [dev-server reference](../reference/dev-server.md) for usage examples.
+**Authentication.** Every non-`OPTIONS` request must include `Authorization: Bearer <token>`, where the token is read from `./.redin-token` (generated on startup, mode 0600, removed on shutdown). The server also verifies the `Host` header is `localhost:<port>` or `127.0.0.1:<port>` (DNS-rebinding defence). Missing token → `401`, bad Host → `403`, `OPTIONS` → `405` (CORS preflight not served — the endpoint is for local tools, not browsers), malformed `Content-Length` (more than 12 digits) → `400`. See [dev-server reference](../reference/dev-server.md) for usage examples.
 
 ### Frames
 

--- a/docs/reference/dev-server.md
+++ b/docs/reference/dev-server.md
@@ -20,7 +20,9 @@ On startup the server generates a random 256-bit token and writes it to `./.redi
 Authorization: Bearer <contents of .redin-token>
 ```
 
-The server also verifies the `Host` header matches `localhost:<port>` or `127.0.0.1:<port>` to blunt DNS-rebinding attacks. CORS preflight is not served — the endpoint is intended for local tools, not browsers. Missing token → `401`; bad Host → `403`; OPTIONS → `405`.
+The server also verifies the `Host` header matches `localhost:<port>` or `127.0.0.1:<port>` to blunt DNS-rebinding attacks. CORS preflight is not served — the endpoint is intended for local tools, not browsers. Missing token → `401`; bad Host → `403`; OPTIONS → `405`; malformed `Content-Length` (more than 12 digits) → `400 Bad Request`.
+
+If the server cannot write `.redin-token` or `.redin-port` at startup (read-only directory, etc.), it aborts startup and prints a clear stderr line. The dev server never runs without a token file in place.
 
 All examples below assume:
 

--- a/docs/reference/effects.md
+++ b/docs/reference/effects.md
@@ -151,10 +151,10 @@ Spawn a child process. The result is routed back as an event.
 | `stdin` | string | no | `nil` | Bytes piped to the child's stdin. |
 | `timeout` | number | no | `30000` | Per-call timeout in milliseconds. On expiry the child is killed and the call fails. |
 | `max-output` | number | no | `16` | Per-call cap on combined stdout + stderr in MiB. On exceedance the child is killed. |
-| `on-success` | keyword | yes | -- | Event dispatched on `exit_code == 0`. |
+| `on-success` | keyword | yes | -- | Event dispatched on `exit-code == 0`. |
 | `on-error` | keyword | yes | -- | Event dispatched on non-zero exit, kill, or host-side failure. |
 
-**Failure response shape.** Failures dispatch to `on-error` with `{:exit_code -1 :error_msg "<message>"}` (no partial output). Possible messages:
+**Failure response shape.** Failures dispatch to `on-error` with `{:exit-code -1 :error "<message>"}` (no partial output). Possible messages:
 
 | Message | Cause |
 |---|---|

--- a/docs/reference/effects.md
+++ b/docs/reference/effects.md
@@ -84,15 +84,27 @@ Make an async HTTP request. The response is routed back as an event.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `url` | string | yes | -- | Request URL (HTTP or HTTPS) |
+| `url` | string | yes | -- | Request URL. Scheme must be `http` or `https`. |
 | `method` | keyword | no | `:get` | `:get`, `:post`, `:put`, `:delete`, `:patch` |
-| `headers` | table | no | `{}` | Key-value header pairs |
+| `headers` | table | no | `{}` | Key-value header pairs. Keys/values containing `\r`, `\n`, or `\x00` are rejected. |
 | `body` | string | no | `nil` | Request body |
-| `timeout` | number | no | `30000` | Timeout in milliseconds |
+| `timeout` | number | no | `30000` | Per-call timeout in milliseconds. On expiry the call fails with `error = "http timeout exceeded"`. |
 | `on-success` | keyword | yes | -- | Event dispatched on 2xx response |
 | `on-error` | keyword | yes | -- | Event dispatched on error |
 
 **Response routing:** 2xx status codes dispatch to `on-success`, all others to `on-error`. The host calls `effect.handle-http-response` with `{:id :status :headers :body}`.
+
+**Redirects** are **not** auto-followed. 3xx responses surface to the caller as-is, including the `Location` header.
+
+**Failure response shape.** Network/host-side failures dispatch to `on-error` with `{:status 0 :error "<message>"}`. Possible messages:
+
+| Message | Cause |
+|---|---|
+| `"http scheme must be http or https"` | URL scheme is not `http`/`https` (e.g. `file://`, `ftp://`). |
+| `"http header contains invalid character"` | A header key or value contained `\r`, `\n`, or `\x00`. |
+| `"http timeout exceeded"` | Wall-clock timeout (per-call `:timeout`, default 30000 ms) elapsed. |
+| `"too many concurrent http requests (cap 64)"` | Submitted while 64 in-flight requests were already running. |
+| `"host <name> not in http whitelist"` | Whitelist is set (`bridge.set_http_whitelist`) and the URL host is not on it. See [native bridge](native-bridge.md). |
 
 **Success handler** receives `[event-name response]`:
 
@@ -115,6 +127,41 @@ Make an async HTTP request. The response is routed back as an event.
     (assoc db :error (or error.error (.. "HTTP " (tostring error.status)))
               :loading false)))
 ```
+
+---
+
+## Built-in: `:shell`
+
+Spawn a child process. The result is routed back as an event.
+
+```fennel
+(reg-handler :event/run-build
+  (fn [db event]
+    {:db (assoc db :building true)
+     :shell {:cmd ["bb" "build.bb" "--release"]
+             :timeout 60000
+             :max-output 32
+             :on-success :event/build-done
+             :on-error :event/build-failed}}))
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `cmd` | array of strings | yes | -- | Argv (no shell interpolation). |
+| `stdin` | string | no | `nil` | Bytes piped to the child's stdin. |
+| `timeout` | number | no | `30000` | Per-call timeout in milliseconds. On expiry the child is killed and the call fails. |
+| `max-output` | number | no | `16` | Per-call cap on combined stdout + stderr in MiB. On exceedance the child is killed. |
+| `on-success` | keyword | yes | -- | Event dispatched on `exit_code == 0`. |
+| `on-error` | keyword | yes | -- | Event dispatched on non-zero exit, kill, or host-side failure. |
+
+**Failure response shape.** Failures dispatch to `on-error` with `{:exit_code -1 :error_msg "<message>"}` (no partial output). Possible messages:
+
+| Message | Cause |
+|---|---|
+| `"shell timeout exceeded N ms"` | Wall-clock timeout (per-call `:timeout`, default 30000 ms) elapsed; child killed. |
+| `"shell output exceeded N MiB cap"` | Combined stdout + stderr exceeded the cap (per-call `:max-output`, default 16 MiB); child killed. |
+
+The shell-env allowlist (`bridge.set_shell_env_allowlist`, see [native bridge](native-bridge.md)) is applied at spawn time and does not produce a runtime failure — children just see a stripped environment when it is set.
 
 ---
 

--- a/docs/reference/effects.md
+++ b/docs/reference/effects.md
@@ -149,7 +149,7 @@ Spawn a child process. The result is routed back as an event.
 |-------|------|----------|---------|-------------|
 | `cmd` | array of strings | yes | -- | Argv (no shell interpolation). |
 | `stdin` | string | no | `nil` | Bytes piped to the child's stdin. |
-| `timeout` | number | no | `30000` | Per-call timeout in milliseconds. On expiry the child is killed and the call fails. |
+| `timeout` | number | no | `30000` | Per-call timeout in milliseconds (includes child-process startup latency). On expiry the child is killed and the call fails. |
 | `max-output` | number | no | `16` | Per-call cap on combined stdout + stderr in MiB. On exceedance the child is killed. |
 | `on-success` | keyword | yes | -- | Event dispatched on `exit-code == 0`. |
 | `on-error` | keyword | yes | -- | Event dispatched on non-zero exit, kill, or host-side failure. |

--- a/docs/reference/native-bridge.md
+++ b/docs/reference/native-bridge.md
@@ -109,6 +109,32 @@ build_combat_table_on_stack(L, &combat)
 ok, err := bridge.dispatch_tos(L, "combat/push")
 ```
 
+## Effect policy setters
+
+These setters install host-side policy for the built-in `redin.http` and `redin.shell` host functions. Both are global, take a slice of strings (cloned internally), and accept `nil` to clear back to the permissive default. Call before or after `redin.run`; changes apply to subsequent requests.
+
+### `bridge.set_http_whitelist(allow: []string)`
+
+When set, `redin.http` accepts only URLs whose host matches an entry. Entries are either hostname literals (case-insensitive — e.g. `"api.example.com"`) or CIDR blocks (IPv4 or IPv6 — e.g. `"127.0.0.0/8"`, `"::1/128"`). CIDR entries are matched only against IP-literal hosts, not DNS names. `nil` (the default) accepts any host.
+
+Rejection failure (delivered to the `:http` effect's `on-error`): `{status: 0, error: "host <name> not in http whitelist"}`.
+
+```odin
+bridge.set_http_whitelist([]string{"api.example.com", "127.0.0.0/8"})
+redin.run(cfg)
+```
+
+### `bridge.set_shell_env_allowlist(allow: []string)`
+
+When set, child processes spawned by `redin.shell` see only env vars whose keys match a list entry. Comparison is exact (case-sensitive on POSIX). `nil` (the default) is full passthrough — children inherit the parent process environment.
+
+The setter does not produce a runtime failure path. It only changes the env that reaches `execve(2)`.
+
+```odin
+bridge.set_shell_env_allowlist([]string{"PATH", "HOME", "GITHUB_TOKEN"})
+redin.run(cfg)
+```
+
 ## Calling conventions and context
 
 | Convention | Context propagates? | When you write it |

--- a/docs/superpowers/plans/2026-05-06-security-audit-99.md
+++ b/docs/superpowers/plans/2026-05-06-security-audit-99.md
@@ -1,0 +1,1853 @@
+# Security audit fixes (#99) — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land all eight findings from the bridge / devserver / http / shell security audit (issue #99) on a single branch, with TDD coverage and matching docs.
+
+**Architecture:** Permissive defaults plus opt-in hardening setters (`set_http_whitelist`, `set_shell_env_allowlist`) added to `bridge/api.odin`. New required defaults baked into the bridge effect path (HTTP/shell timeouts, shell output cap, scheme reject, header CRLF reject, redirect disable, Content-Length overflow guard, fatal token-write).
+
+**Tech Stack:** Odin (host), LuaJIT + Fennel (scripting), `lib:odin-http` (vendored submodule, do not modify in this plan), Babashka (UI tests).
+
+**Branch:** `fix/security-audit-99`, branched off `origin/main` (already created).
+
+**Spec:** [`docs/superpowers/specs/2026-05-06-security-audit-99-design.md`](../specs/2026-05-06-security-audit-99-design.md) — read this before starting.
+
+**Spec→plan unit alignment:** the spec said `:timeout` is "seconds" for `:http` and `:shell`. The existing Fennel `:http` effect handler already passes the timeout in **milliseconds** (default `30000`, see `src/runtime/effect.fnl:100`). The plan aligns with the existing convention: **`:timeout` is milliseconds (integer), default `30000`**. `:max-output` for `:shell` stays MiB (integer), default `16`.
+
+**File layout (created or modified by this plan):**
+
+- Create: `src/redin/bridge/shell_test.odin` — new unit tests for `execute_shell` (output cap, env allowlist, timeout)
+- Modify: `src/redin/bridge/http_client.odin` — timeouts, in-flight cap, scheme guard, whitelist, header CRLF validation, disable redirects
+- Modify: `src/redin/bridge/shell.odin` — output cap, timeout, env allowlist
+- Modify: `src/redin/bridge/bridge.odin` — read new args from Lua in `redin_http` / `redin_shell`
+- Modify: `src/redin/bridge/api.odin` — add `set_http_whitelist`, `set_shell_env_allowlist`, package-level state
+- Modify: `src/redin/bridge/devserver.odin` — Content-Length overflow guard, fatal token write
+- Modify: `src/redin/bridge/devserver_headers_test.odin` — overflow tests
+- Modify: `src/redin/bridge/devserver_write_test.odin` — token-write fatal test
+- Modify: `src/redin/bridge/http_client_test.odin` — scheme/whitelist/CRLF/redirect tests
+- Modify: `src/runtime/effect.fnl` — add `:max-output` and `:timeout` to `:shell` effect handler; pass through to `redin_shell`
+- Modify: `docs/core-api.md`, `docs/reference/effects.md`, `docs/reference/native-bridge.md`, `docs/reference/dev-server.md`, `.claude/skills/redin-dev/SKILL.md`
+
+**Conventions across all tasks:**
+
+- Each task is TDD: write the failing test, run it red, implement, run green, commit.
+- Test runner for bridge unit tests: `odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit`. Add `-define:ODIN_TEST_THREADS=1` if any new test exhibits a race; do not add it preemptively.
+- Commit messages use Conventional Commits with the issue scope, e.g. `fix(bridge): ...` and end with the framework's standard co-authored-by line.
+- Do not modify `lib/odin-http/` (it is a submodule). All HTTP timeout / redirect work happens in our wrapper layer in `bridge/http_client.odin`.
+
+---
+
+## Task 1: M5 — Reject CRLF / NUL in HTTP request headers
+
+**Files:**
+- Modify: `src/redin/bridge/http_client.odin` (helper + check at request boundary)
+- Modify: `src/redin/bridge/http_client_test.odin` (add cases)
+
+The `redin.http` effect lets the app set arbitrary headers. Today they are passed verbatim to odin-http with no validation. A header value containing `\r\n` could split the request. Fix: reject any header key or value containing `\r`, `\n`, or `\x00` at the boundary, fail the call with an error response.
+
+- [ ] **Step 1: Add failing test for CRLF rejection in header value**
+
+In `src/redin/bridge/http_client_test.odin`, append:
+
+```odin
+@(test)
+test_http_header_value_rejects_crlf :: proc(t: ^testing.T) {
+	headers := make(map[string]string)
+	headers["X-Smuggle"] = strings.clone("evil\r\nHost: attacker")
+	defer {
+		for k, v in headers { delete(k); delete(v) }
+		delete(headers)
+	}
+	headers["X-Smuggle"] = strings.clone("evil\r\nHost: attacker")
+
+	req := Http_Request{
+		id      = strings.clone("crlf-test"),
+		url     = strings.clone("http://127.0.0.1:1/"),
+		method  = strings.clone("GET"),
+		headers = headers,
+	}
+	defer {
+		delete(req.id); delete(req.url); delete(req.method)
+	}
+
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+
+	testing.expect(t, got.status == 0, "expected synthesized error status 0")
+	testing.expect(t, strings.contains(got.error_msg, "invalid character"),
+		fmt.tprintf("expected 'invalid character' in error_msg, got %q", got.error_msg))
+}
+```
+
+Add a near-duplicate `test_http_header_key_rejects_nul` that puts `\x00` in a key.
+
+- [ ] **Step 2: Run the test, expect failure**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+Expected: the new tests fail because the call attempts a real connection to `127.0.0.1:1` and returns a connect error rather than the validation error.
+
+- [ ] **Step 3: Add the helper and the boundary check**
+
+In `src/redin/bridge/http_client.odin`, near the top of the file (below the `HTTP_MAX_BODY` const), add:
+
+```odin
+@(private = "file")
+header_safe :: proc(s: string) -> bool {
+	for r in s {
+		if r == '\r' || r == '\n' || r == 0 do return false
+	}
+	return true
+}
+```
+
+In `execute_http_request`, **before** the `for k, v in req.headers` loop that calls `http.headers_set`, validate:
+
+```odin
+for k, v in req.headers {
+	if !header_safe(k) || !header_safe(v) {
+		response.status = 0
+		response.error_msg = strings.clone("http header contains invalid character")
+		return response
+	}
+}
+```
+
+- [ ] **Step 4: Run the tests, expect green**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/redin/bridge/http_client.odin src/redin/bridge/http_client_test.odin
+git commit -m "$(cat <<'EOF'
+fix(bridge): reject CRLF/NUL in HTTP request headers (#99 M5)
+
+Adds a per-call validation step before request submission. Header
+keys or values containing \r, \n, or \x00 fail the call with a
+synthesized error response (status 0, error "http header contains
+invalid character"). Closes the request-smuggling vector flagged in
+issue #99.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: L1 — Reject malformed Content-Length on the dev server
+
+**Files:**
+- Modify: `src/redin/bridge/devserver.odin` (`find_content_length` + caller at line ~267)
+- Modify: `src/redin/bridge/devserver_headers_test.odin`
+
+Today `find_content_length` accumulates digits into an `int` with no overflow check. Inputs longer than 19 digits (or with arithmetic overflow) silently wrap. The caller's `cl > MAX_BODY` check doesn't catch a wrapped negative value. Fix: cap the digit count to 12 and return `-1` on overflow; reject negative results in the caller with `400`.
+
+- [ ] **Step 1: Add failing tests**
+
+In `src/redin/bridge/devserver_headers_test.odin`, append:
+
+```odin
+@(test)
+test_find_content_length_overflow_returns_negative :: proc(t: ^testing.T) {
+	// 19 digits — well above 12-digit cap; current code silently wraps.
+	headers := "POST / HTTP/1.1\r\nContent-Length: 9999999999999999999\r\n"
+	testing.expect(t, find_content_length(headers) < 0,
+		"expected negative on overflow")
+}
+
+@(test)
+test_find_content_length_normal :: proc(t: ^testing.T) {
+	headers := "POST / HTTP/1.1\r\nContent-Length: 1024\r\n"
+	testing.expect_value(t, find_content_length(headers), 1024)
+}
+
+@(test)
+test_find_content_length_zero :: proc(t: ^testing.T) {
+	headers := "GET / HTTP/1.1\r\nContent-Length: 0\r\n"
+	testing.expect_value(t, find_content_length(headers), 0)
+}
+```
+
+- [ ] **Step 2: Run tests, expect failure on the overflow case**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+Expected: `test_find_content_length_overflow_returns_negative` fails (returns a wrapped positive value).
+
+- [ ] **Step 3: Patch `find_content_length`**
+
+In `src/redin/bridge/devserver.odin`, replace the digit-accumulation loop in `find_content_length` (currently around lines 530–537) with:
+
+```odin
+n := 0
+digits := 0
+for c in val {
+	if c >= '0' && c <= '9' {
+		digits += 1
+		if digits > 12 { return -1 }
+		n = n*10 + int(c - '0')
+	} else {
+		break
+	}
+}
+return n
+```
+
+(The 12-digit cap = up to `999_999_999_999`, ~1 TiB — far above `MAX_BODY` and well below `int` overflow on any supported platform.)
+
+- [ ] **Step 4: Patch the caller to honour negative**
+
+In `src/redin/bridge/devserver.odin` around line 267, after `cl := find_content_length(...)` but before the `cl > MAX_BODY` check, add:
+
+```odin
+if cl < 0 {
+	resp := "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+	net.send_tcp(client, transmute([]u8)resp)
+	net.close(client)
+	break  // (or continue, depending on local control flow — match the existing too_large path)
+}
+```
+
+Verify the local control flow against the existing `too_large` branch a few lines below; the negative-CL branch should match its structure (send 400, close, exit the inner loop the same way).
+
+- [ ] **Step 5: Run tests, expect green**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/redin/bridge/devserver.odin src/redin/bridge/devserver_headers_test.odin
+git commit -m "$(cat <<'EOF'
+fix(bridge): guard Content-Length parser against overflow (#99 L1)
+
+find_content_length now caps digit count at 12 and returns -1 on
+overflow. The caller responds 400 Bad Request when the parser
+returns a negative value. Prevents the silent integer wrap that
+could produce a small positive cl from a 99999... header and
+sneak past the MAX_BODY check.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: L2 — Make token / port file write failure fatal in dev mode
+
+**Files:**
+- Modify: `src/redin/bridge/devserver.odin` (~lines 172–180)
+- Modify: `src/redin/bridge/devserver_write_test.odin`
+
+Today, if `write_private_no_follow` fails for `.redin-token` or `.redin-port`, the dev server logs a warning and keeps running. The token still works in memory, but local clients (test runners, the user's own `curl`) silently fail to authenticate. Fix: make a write failure abort dev-server startup so the user gets a clear error instead of a stream of inscrutable 401s.
+
+- [ ] **Step 1: Add failing test**
+
+In `src/redin/bridge/devserver_write_test.odin`, append a test that proves the write-failure branch aborts startup. Reuse the existing approach from the file (likely involves placing a non-regular file at the target path). Minimum sketch:
+
+```odin
+@(test)
+test_devserver_aborts_on_token_write_fail :: proc(t: ^testing.T) {
+	// Place a directory at TOKEN_FILE so write_private_no_follow refuses.
+	// Save & restore the working dir; use a temp dir to keep CI tidy.
+	// Assert ds.running == false after devserver_init returns.
+	// (Implementation depends on the existing helpers in this file —
+	// follow the existing pattern.)
+}
+```
+
+If the existing test file already has a helper for chdir-into-temp + cleanup, reuse it. If not, write the smallest one needed (a temp dir + `os.chdir` with deferred restore).
+
+- [ ] **Step 2: Run the test, expect failure**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+Expected: the new test fails because today `ds.running` stays true.
+
+- [ ] **Step 3: Patch the write block**
+
+In `src/redin/bridge/devserver.odin` around lines 171–177, replace:
+
+```odin
+port_str := fmt.tprintf("%d", bound_port)
+if !write_private_no_follow(PORT_FILE, transmute([]u8)port_str) {
+	fmt.eprintfln("Warning: could not write %s (refused to follow non-regular path)", PORT_FILE)
+}
+if !write_private_no_follow(TOKEN_FILE, transmute([]u8)ds.auth_token) {
+	fmt.eprintfln("Warning: could not write %s (refused to follow non-regular path)", TOKEN_FILE)
+}
+```
+
+with:
+
+```odin
+port_str := fmt.tprintf("%d", bound_port)
+if !write_private_no_follow(PORT_FILE, transmute([]u8)port_str) {
+	fmt.eprintfln("redin: failed to write %s; aborting dev server", PORT_FILE)
+	ds.running = false
+	return
+}
+if !write_private_no_follow(TOKEN_FILE, transmute([]u8)ds.auth_token) {
+	fmt.eprintfln("redin: failed to write %s; aborting dev server", TOKEN_FILE)
+	// Clean up the port file we just wrote so it doesn't lie about a live server.
+	os.remove(PORT_FILE)
+	ds.running = false
+	return
+}
+```
+
+(The port-file cleanup on token failure prevents `.redin-port` from advertising a server that never finished standing up.)
+
+- [ ] **Step 4: Run tests, expect green**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/redin/bridge/devserver.odin src/redin/bridge/devserver_write_test.odin
+git commit -m "$(cat <<'EOF'
+fix(bridge): abort dev server on token-file write failure (#99 L2)
+
+Previously logged a warning and kept running, which produced silent
+401 responses on every subsequent request because local clients
+read .redin-token to authenticate. Now write failure prints a clear
+"failed to write" line and exits devserver_init, after cleaning up
+.redin-port if it was just written.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: L3 — Stop following HTTP redirects automatically
+
+**Files:**
+- Modify: `src/redin/bridge/http_client.odin` (`execute_http_request`)
+- Modify: `src/redin/bridge/http_client_test.odin`
+
+The existing `http_client.request` (vendored, do not modify) does not document a redirect-follow option, but its current implementation reads as if it returns the first response without auto-redirecting. **Verify** during implementation by reading `lib/odin-http/client/client.odin` more thoroughly; if it does follow redirects internally, the fix is to switch our wrapper to a more direct call (e.g. dial + send + parse without the auto-follow path) or to pass a 0-hop option if one exists.
+
+If the library already does not follow redirects, this task reduces to writing the regression test that pins the behaviour.
+
+- [ ] **Step 1: Inspect odin-http for a redirect-follow option**
+
+```bash
+grep -n -i "redirect\|follow\|location" lib/odin-http/client/client.odin
+```
+
+Document the finding in the commit message of this task. Three outcomes:
+1. odin-http never follows redirects → only test is needed.
+2. odin-http follows redirects via a flag we can pass → set the flag to false in `request_init` (or an equivalent struct-field assignment) before `request`.
+3. odin-http follows redirects unconditionally → in `execute_http_request`, replace the call to `http_client.request(...)` with a more granular sequence that returns the first response without recursing on `Location`. This is the most invasive case; if you reach it, write a one-line note in the spec ("L3 deferred — needs upstream work") and stop here.
+
+- [ ] **Step 2: Add the test**
+
+In `src/redin/bridge/http_client_test.odin`, append:
+
+```odin
+@(test)
+test_http_redirect_not_followed :: proc(t: ^testing.T) {
+	resp := "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:1/elsewhere\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+	m := mock_start(resp)
+	if m == nil {
+		testing.fail_now(t, "could not bind a mock server port")
+	}
+	defer mock_stop(m)
+
+	url := fmt.tprintf("http://127.0.0.1:%d/", m.port)
+	req := Http_Request{
+		id = strings.clone("redirect-test"),
+		url = strings.clone(url),
+		method = strings.clone("GET"),
+	}
+	defer { delete(req.id); delete(req.url); delete(req.method) }
+
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+
+	testing.expect_value(t, got.status, 302)
+}
+```
+
+- [ ] **Step 3: Run the test**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+Expected behaviour depends on the outcome of Step 1. If the library already returns 302 without following, the test passes immediately and you are done after committing it as a regression. If the library does follow, the test will fail (the `mock_start` only answers once, so the second hop will hang or error) and Step 4 needs the fix described above.
+
+- [ ] **Step 4: If needed, disable redirect-follow**
+
+Apply the change identified in Step 1. The exact line depends on what the library exposes — do not invent a field name. If the only path is invasive (case 3 above), document and skip per the Step 1 instructions.
+
+- [ ] **Step 5: Run tests green**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/redin/bridge/http_client.odin src/redin/bridge/http_client_test.odin
+git commit -m "$(cat <<'EOF'
+fix(bridge): pin HTTP redirect non-following (#99 L3)
+
+Adds a regression test that asserts a 302 response is returned to
+the caller as-is (status 302, Location header in response.headers)
+rather than transparently followed. Library inspection in Step 1
+of this task established whether any wrapper change was needed;
+the commit either pins existing behaviour with a test, or adds a
+small wrapper-level redirect-disable, depending on the outcome.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: M4 part A — Reject non-http(s) URL schemes
+
+**Files:**
+- Modify: `src/redin/bridge/http_client.odin` (early in `execute_http_request`)
+- Modify: `src/redin/bridge/http_client_test.odin`
+
+- [ ] **Step 1: Add failing tests**
+
+In `src/redin/bridge/http_client_test.odin`, append:
+
+```odin
+@(test)
+test_http_rejects_ftp_scheme :: proc(t: ^testing.T) {
+	req := Http_Request{
+		id = strings.clone("scheme-1"),
+		url = strings.clone("ftp://example.com/"),
+		method = strings.clone("GET"),
+	}
+	defer { delete(req.id); delete(req.url); delete(req.method) }
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+	testing.expect_value(t, got.status, 0)
+	testing.expect(t, strings.contains(got.error_msg, "scheme"),
+		fmt.tprintf("expected 'scheme' in error_msg, got %q", got.error_msg))
+}
+
+@(test)
+test_http_rejects_file_scheme :: proc(t: ^testing.T) {
+	req := Http_Request{
+		id = strings.clone("scheme-2"),
+		url = strings.clone("file:///etc/passwd"),
+		method = strings.clone("GET"),
+	}
+	defer { delete(req.id); delete(req.url); delete(req.method) }
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+	testing.expect_value(t, got.status, 0)
+	testing.expect(t, strings.contains(got.error_msg, "scheme"),
+		"expected scheme rejection error_msg")
+}
+
+@(test)
+test_http_accepts_uppercase_https :: proc(t: ^testing.T) {
+	// Just confirms scheme matching is case-insensitive — no real connect.
+	// We expect a connect error (status 0, error_msg contains "Request failed"
+	// or similar), NOT the scheme-rejection error_msg.
+	req := Http_Request{
+		id = strings.clone("scheme-3"),
+		url = strings.clone("HTTPS://127.0.0.1:1/"),
+		method = strings.clone("GET"),
+	}
+	defer { delete(req.id); delete(req.url); delete(req.method) }
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+	testing.expect(t, !strings.contains(got.error_msg, "scheme"),
+		"HTTPS (uppercase) must not be rejected as scheme")
+}
+```
+
+- [ ] **Step 2: Run tests, expect failure**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+- [ ] **Step 3: Add scheme guard**
+
+At the top of `execute_http_request` in `src/redin/bridge/http_client.odin` (after the response init, before any odin-http calls), add:
+
+```odin
+// Scheme guard. Always-on; not opt-out. M4 from issue #99.
+{
+	colon := strings.index_byte(req.url, ':')
+	scheme := colon < 0 ? "" : strings.to_lower(req.url[:colon], context.temp_allocator)
+	if scheme != "http" && scheme != "https" {
+		response.status = 0
+		response.error_msg = strings.clone("http scheme must be http or https")
+		return response
+	}
+}
+```
+
+- [ ] **Step 4: Run tests green**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/redin/bridge/http_client.odin src/redin/bridge/http_client_test.odin
+git commit -m "$(cat <<'EOF'
+fix(bridge): reject non-http(s) URL schemes in redin.http (#99 M4 A)
+
+Always-on scheme check at the start of execute_http_request. URLs
+whose scheme is not http or https (case-insensitive) fail with a
+synthesized error response. Closes the file://, ftp://, gopher://
+exfiltration vectors flagged in the audit; complements the opt-in
+destination whitelist that follows in part B.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: M4 part B — HTTP destination whitelist + public bridge API
+
+**Files:**
+- Modify: `src/redin/bridge/api.odin` (new public proc + package state + mutex)
+- Modify: `src/redin/bridge/http_client.odin` (whitelist check inside `execute_http_request`)
+- Modify: `src/redin/bridge/http_client_test.odin` (whitelist tests)
+
+Add a public proc `bridge.set_http_whitelist(allow: []string)` that stores a clone of the input behind a package-level mutex. When the whitelist is unset (default), any host is allowed. When set, the request's host must match a hostname literal (case-insensitive) or a CIDR (IPv4 or IPv6, only matched against IP-literal hosts). On rejection, return a synthesized error response that names the rejected host.
+
+- [ ] **Step 1: Add failing tests**
+
+In `src/redin/bridge/http_client_test.odin`, append (use the mock server from Task 4 / existing tests):
+
+```odin
+@(test)
+test_http_whitelist_allows_listed_host :: proc(t: ^testing.T) {
+	resp := "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+	m := mock_start(resp)
+	if m == nil { testing.fail_now(t, "could not bind mock") }
+	defer mock_stop(m)
+
+	set_http_whitelist([]string{"127.0.0.1"})
+	defer set_http_whitelist(nil)
+
+	url := fmt.tprintf("http://127.0.0.1:%d/", m.port)
+	req := Http_Request{
+		id = strings.clone("wl-1"), url = strings.clone(url),
+		method = strings.clone("GET"),
+	}
+	defer { delete(req.id); delete(req.url); delete(req.method) }
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+	testing.expect_value(t, got.status, 200)
+}
+
+@(test)
+test_http_whitelist_blocks_unlisted_host :: proc(t: ^testing.T) {
+	set_http_whitelist([]string{"example.com"})
+	defer set_http_whitelist(nil)
+
+	req := Http_Request{
+		id = strings.clone("wl-2"),
+		url = strings.clone("http://127.0.0.1:1/"),
+		method = strings.clone("GET"),
+	}
+	defer { delete(req.id); delete(req.url); delete(req.method) }
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+	testing.expect_value(t, got.status, 0)
+	testing.expect(t, strings.contains(got.error_msg, "127.0.0.1"),
+		fmt.tprintf("expected rejected host name in error, got %q", got.error_msg))
+	testing.expect(t, strings.contains(got.error_msg, "whitelist"),
+		"expected 'whitelist' in error message")
+}
+
+@(test)
+test_http_whitelist_hostname_case_insensitive :: proc(t: ^testing.T) {
+	set_http_whitelist([]string{"Example.COM"})
+	defer set_http_whitelist(nil)
+
+	req := Http_Request{
+		id = strings.clone("wl-3"),
+		url = strings.clone("http://example.com/"),
+		method = strings.clone("GET"),
+	}
+	defer { delete(req.id); delete(req.url); delete(req.method) }
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+	// Connect will likely fail (no DNS in CI for example.com), but the
+	// failure must NOT be a whitelist rejection. We assert the absence
+	// of the whitelist error string.
+	testing.expect(t, !strings.contains(got.error_msg, "whitelist"),
+		"hostname compare should be case-insensitive")
+}
+
+@(test)
+test_http_whitelist_cidr_match :: proc(t: ^testing.T) {
+	resp := "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+	m := mock_start(resp)
+	if m == nil { testing.fail_now(t, "could not bind mock") }
+	defer mock_stop(m)
+
+	set_http_whitelist([]string{"127.0.0.0/8"})
+	defer set_http_whitelist(nil)
+
+	url := fmt.tprintf("http://127.0.0.1:%d/", m.port)
+	req := Http_Request{
+		id = strings.clone("wl-4"), url = strings.clone(url),
+		method = strings.clone("GET"),
+	}
+	defer { delete(req.id); delete(req.url); delete(req.method) }
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+	testing.expect_value(t, got.status, 200)
+}
+```
+
+- [ ] **Step 2: Run tests, expect failure**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+(Compile failures are expected since `set_http_whitelist` doesn't exist yet.)
+
+- [ ] **Step 3: Add the public API + state to `api.odin`**
+
+At the bottom of `src/redin/bridge/api.odin`, append:
+
+```odin
+// ---------------------------------------------------------------------------
+// Outbound HTTP destination whitelist (issue #99 M4)
+// ---------------------------------------------------------------------------
+//
+// When unset (default), redin.http accepts any http(s) destination.
+// When set, the URL host must match either a hostname literal
+// (case-insensitive) or a CIDR (IPv4 or IPv6, applied only to
+// IP-literal hosts). Apps opt in by calling this setter at startup
+// from app.odin (--native projects) or via a registered cfunc.
+
+@(private)
+g_http_whitelist:       []string
+@(private)
+g_http_whitelist_mutex: sync.Mutex
+
+set_http_whitelist :: proc(allow: []string) {
+	sync.lock(&g_http_whitelist_mutex)
+	defer sync.unlock(&g_http_whitelist_mutex)
+
+	for s in g_http_whitelist do delete(s)
+	delete(g_http_whitelist)
+	g_http_whitelist = nil
+
+	if allow == nil do return
+
+	cloned := make([]string, len(allow))
+	for s, i in allow do cloned[i] = strings.clone(s)
+	g_http_whitelist = cloned
+}
+
+// http_whitelist_check returns ("", true) if allowed, ("<rejected host>", false)
+// otherwise. host must already be the URL host (no port, no scheme).
+@(private)
+http_whitelist_check :: proc(host: string) -> (rejected: string, ok: bool) {
+	sync.lock(&g_http_whitelist_mutex)
+	defer sync.unlock(&g_http_whitelist_mutex)
+
+	if g_http_whitelist == nil do return "", true
+
+	host_lower := strings.to_lower(host, context.temp_allocator)
+	for entry in g_http_whitelist {
+		// CIDR entry?
+		if strings.contains(entry, "/") {
+			if cidr_match(host, entry) do return "", true
+			continue
+		}
+		// Hostname literal — case-insensitive exact match.
+		entry_lower := strings.to_lower(entry, context.temp_allocator)
+		if host_lower == entry_lower do return "", true
+	}
+	return host, false
+}
+
+// cidr_match: parse `cidr` ("a.b.c.d/N" or IPv6) and test against `host`.
+// host is matched only if it is an IP literal; hostnames return false.
+@(private)
+cidr_match :: proc(host: string, cidr: string) -> bool {
+	addr := net.parse_ip4_address(host)
+	if addr == 0 {
+		// Not an IPv4 literal — try IPv6 path.
+		addr6, ok6 := net.parse_ip6_address(host)
+		if !ok6 do return false
+		// IPv6 CIDR matching — minimal impl: parse, mask, compare.
+		return cidr6_match(addr6, cidr)
+	}
+	return cidr4_match(addr, cidr)
+}
+```
+
+Add helpers `cidr4_match` and `cidr6_match` in the same file. The IPv4 version splits `cidr` on `/`, parses the prefix as `net.IP4_Address`, parses the bits, builds a mask, and does the bitwise compare. IPv6 mirrors with `net.IP6_Address`. (Confirm the exact `net` package API names during implementation; `core:net` exposes parsing primitives.)
+
+If `core:net` does not have a CIDR helper out of the box, add one as a private file-scope helper in `api.odin` rather than pulling in a third-party dependency. Keep it ~20 lines.
+
+You will also need to add `import "core:net"` and `import "core:sync"` at the top of `api.odin` if not already present.
+
+- [ ] **Step 4: Wire the whitelist check into `execute_http_request`**
+
+In `src/redin/bridge/http_client.odin`, immediately **after** the scheme guard added in Task 5 and **before** anything that mutates request state, parse the URL host and check the whitelist:
+
+```odin
+// Whitelist guard. Opt-in via bridge.set_http_whitelist. M4 from issue #99.
+{
+	host := url_host(req.url) // see helper below
+	if rejected, ok := http_whitelist_check(host); !ok {
+		response.status = 0
+		response.error_msg = fmt.aprintf("host %s not in http whitelist", rejected)
+		return response
+	}
+}
+```
+
+Add `url_host` as a `@(private = "file")` helper in `http_client.odin`:
+
+```odin
+@(private = "file")
+url_host :: proc(url: string) -> string {
+	// "http://host:port/path" → "host"
+	idx := strings.index(url, "://")
+	if idx < 0 do return ""
+	rest := url[idx + 3:]
+	end := len(rest)
+	for i in 0 ..< len(rest) {
+		c := rest[i]
+		if c == '/' || c == '?' || c == '#' { end = i; break }
+	}
+	host := rest[:end]
+	// strip port
+	if colon := strings.last_index_byte(host, ':'); colon >= 0 {
+		// Skip the last-colon strip if this is a bracketed IPv6 host.
+		if !strings.has_prefix(host, "[") {
+			host = host[:colon]
+		}
+	}
+	// Strip IPv6 brackets if present.
+	if strings.has_prefix(host, "[") && strings.has_suffix(host, "]") {
+		host = host[1 : len(host) - 1]
+	}
+	return host
+}
+```
+
+- [ ] **Step 5: Run tests green**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/redin/bridge/api.odin src/redin/bridge/http_client.odin src/redin/bridge/http_client_test.odin
+git commit -m "$(cat <<'EOF'
+feat(bridge): opt-in HTTP destination whitelist (#99 M4 B)
+
+Adds bridge.set_http_whitelist([]string) to api.odin. When unset
+(default), redin.http accepts any http(s) host. When set, the URL
+host must match a hostname literal (case-insensitive) or a CIDR
+(IPv4 or IPv6, only matched against IP-literal hosts).
+
+Rejected calls return a synthesized error response naming the
+rejected host. Hostnames are not resolved at validation time; the
+app is trusted, so this is a self-protection tool, not anti-hostile-
+app defense.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: M3 — Shell env allowlist + public bridge API
+
+**Files:**
+- Modify: `src/redin/bridge/api.odin` (add `set_shell_env_allowlist` + state + mutex)
+- Modify: `src/redin/bridge/shell.odin` (filter env in `execute_shell` when allowlist set)
+- Create: `src/redin/bridge/shell_test.odin`
+
+When the allowlist is set, child processes spawned by `redin.shell` see only the env vars whose keys are in the list. When unset (default), they inherit the full parent env (current behaviour).
+
+- [ ] **Step 1: Create `shell_test.odin` with a failing allowlist test**
+
+```odin
+package bridge
+
+import "core:strings"
+import "core:testing"
+
+@(test)
+test_shell_env_allowlist_filters :: proc(t: ^testing.T) {
+	// Use uname-like env-printer command. /usr/bin/env exists on Linux/macOS.
+	set_shell_env_allowlist([]string{"PATH"})
+	defer set_shell_env_allowlist(nil)
+
+	cmd := []string{strings.clone("/usr/bin/env")}
+	defer { for s in cmd do delete(s); delete(cmd) }
+
+	req := Shell_Request{
+		id = strings.clone("env-1"),
+		cmd = cmd,
+		stdin = strings.clone(""),
+	}
+	defer { delete(req.id); delete(req.stdin) }
+
+	got := execute_shell(req)
+	defer {
+		delete(got.id); delete(got.stdout); delete(got.stderr); delete(got.error_msg)
+	}
+
+	// stdout should contain PATH=... but no other typical user env vars.
+	testing.expect(t, strings.contains(got.stdout, "PATH="),
+		"expected PATH in env output")
+	testing.expect(t, !strings.contains(got.stdout, "AWS_"),
+		"expected AWS_ vars filtered out by allowlist")
+}
+
+@(test)
+test_shell_env_allowlist_unset_full_passthrough :: proc(t: ^testing.T) {
+	set_shell_env_allowlist(nil)
+
+	cmd := []string{strings.clone("/usr/bin/env")}
+	defer { for s in cmd do delete(s); delete(cmd) }
+	req := Shell_Request{
+		id = strings.clone("env-2"),
+		cmd = cmd,
+		stdin = strings.clone(""),
+	}
+	defer { delete(req.id); delete(req.stdin) }
+
+	got := execute_shell(req)
+	defer {
+		delete(got.id); delete(got.stdout); delete(got.stderr); delete(got.error_msg)
+	}
+	// PATH is reliably present in the test runner's env.
+	testing.expect(t, strings.contains(got.stdout, "PATH="),
+		"expected PATH= in default-passthrough env output")
+}
+```
+
+If `/usr/bin/env` is not portable in the test environment, fall back to a small Odin-side env-printing test command — but Linux is the supported platform so `/usr/bin/env` is fine.
+
+- [ ] **Step 2: Run, expect compile failure (`set_shell_env_allowlist` undefined)**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+- [ ] **Step 3: Add public API + state to `api.odin`**
+
+```odin
+// ---------------------------------------------------------------------------
+// Shell env allowlist (issue #99 M3)
+// ---------------------------------------------------------------------------
+//
+// When unset (default), child processes inherit the full parent env.
+// When set, only keys present in the allowlist are passed through.
+// Exact match, case-sensitive.
+
+@(private)
+g_shell_env_allowlist:       []string
+@(private)
+g_shell_env_allowlist_mutex: sync.Mutex
+
+set_shell_env_allowlist :: proc(allow: []string) {
+	sync.lock(&g_shell_env_allowlist_mutex)
+	defer sync.unlock(&g_shell_env_allowlist_mutex)
+
+	for s in g_shell_env_allowlist do delete(s)
+	delete(g_shell_env_allowlist)
+	g_shell_env_allowlist = nil
+
+	if allow == nil do return
+	cloned := make([]string, len(allow))
+	for s, i in allow do cloned[i] = strings.clone(s)
+	g_shell_env_allowlist = cloned
+}
+
+// shell_env_filtered returns the filtered env, or nil if the allowlist is
+// unset (caller should leave Process_Desc.env = nil for full passthrough).
+// Returned slice is owned by the caller (free each entry + the slice itself).
+@(private)
+shell_env_filtered :: proc() -> []string {
+	sync.lock(&g_shell_env_allowlist_mutex)
+	defer sync.unlock(&g_shell_env_allowlist_mutex)
+
+	if g_shell_env_allowlist == nil do return nil
+
+	out := make([dynamic]string, 0, len(g_shell_env_allowlist))
+	for entry in os.environ() {
+		// `entry` is "KEY=VALUE"; extract KEY.
+		eq := strings.index_byte(entry, '=')
+		if eq < 0 do continue
+		key := entry[:eq]
+		for allow in g_shell_env_allowlist {
+			if key == allow {
+				append(&out, strings.clone(entry))
+				break
+			}
+		}
+	}
+	return out[:]
+}
+```
+
+Add `import "core:os"` to `api.odin` if not already there.
+
+- [ ] **Step 4: Wire the filter into `execute_shell`**
+
+In `src/redin/bridge/shell.odin`, modify the `Process_Desc` construction (line 137):
+
+```odin
+filtered_env := shell_env_filtered()
+defer if filtered_env != nil {
+	for s in filtered_env do delete(s)
+	delete(filtered_env)
+}
+
+desc := os.Process_Desc {
+	command = req.cmd,
+	stdout  = stdout_w,
+	stderr  = stderr_w,
+	stdin   = stdin_r,
+	env     = filtered_env,  // nil = inherit parent env (current behaviour)
+}
+```
+
+Verify: `os.Process_Desc.env` accepts `nil` to mean "inherit". This is the Odin core convention; if `env` is a non-nillable type, set it only inside an `if filtered_env != nil` branch and use a separate `desc` constant.
+
+- [ ] **Step 5: Run tests green**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/redin/bridge/api.odin src/redin/bridge/shell.odin src/redin/bridge/shell_test.odin
+git commit -m "$(cat <<'EOF'
+feat(bridge): opt-in shell env allowlist (#99 M3)
+
+Adds bridge.set_shell_env_allowlist([]string) to api.odin. When
+unset (default), spawned children inherit the full parent env
+(current behaviour). When set, children see only the keys present
+in the allowlist; everything else is stripped.
+
+Apps that shell out to credential-aware tools (gh, aws, git) still
+work by default. Apps that want hardening opt in by listing the
+keys they actually need.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: M1 part A — HTTP request timeout (with pending registry)
+
+**Files:**
+- Modify: `src/redin/bridge/http_client.odin` (`Http_Request`, `Http_Client`, `http_client_request`, `http_thread_proc`, `http_client_poll`)
+- Modify: `src/redin/bridge/bridge.odin` (`redin_http` reads new arg)
+- Modify: `src/redin/bridge/http_client_test.odin`
+
+The Fennel `:http` effect handler already passes a `timeout` (ms) as the 6th argument to `redin_http`, but Odin currently ignores arg 6. Read it; if absent or ≤0 use `HTTP_DEFAULT_TIMEOUT_MS = 30000`. Implement the deadline using a per-request entry in a "pending" registry on `Http_Client`. Each frame, `http_client_poll` checks for entries whose deadline has passed and synthesizes a timeout error response, removing the entry. The actual worker thread is allowed to continue (we cannot cancel `http_client.request` from outside without modifying the vendored library); when it eventually finishes, it looks up its registry entry and discards the result if the entry is gone.
+
+- [ ] **Step 1: Add a failing test using a slow mock**
+
+In `src/redin/bridge/http_client_test.odin`, add:
+
+```odin
+@(private = "file")
+slow_mock_serve :: proc(m: ^Mock_Server) {
+	defer sync.sema_post(&m.done)
+	client, _, err := net.accept_tcp(m.sock)
+	if err != nil do return
+	defer net.close(client)
+	// Read the request, then sleep instead of responding.
+	buf: [4096]u8
+	total := 0
+	for total < len(buf) {
+		n, rerr := net.recv_tcp(client, buf[total:])
+		if rerr != nil || n <= 0 do break
+		total += n
+		if strings.contains(string(buf[:total]), "\r\n\r\n") do break
+	}
+	time.sleep(2 * time.Second)
+}
+
+@(test)
+test_http_timeout_fires :: proc(t: ^testing.T) {
+	m := new(Mock_Server)
+	for p in 18900 ..< 19000 {
+		s, e := net.listen_tcp(net.Endpoint{address = net.IP4_Loopback, port = p})
+		if e == nil { m.sock = s; m.port = p; break }
+	}
+	if m.port == 0 { testing.fail_now(t, "no port") }
+	m.thread = thread.create_and_start_with_poly_data(m, slow_mock_serve, context)
+	defer mock_stop(m)
+
+	hc: Http_Client
+	http_client_init(&hc)
+	defer http_client_destroy(&hc)
+
+	req := Http_Request{
+		id = strings.clone("timeout-1"),
+		url = strings.clone(fmt.tprintf("http://127.0.0.1:%d/", m.port)),
+		method = strings.clone("GET"),
+		timeout_ms = 200,  // 200 ms; mock sleeps 2 s
+	}
+	http_client_request(&hc, req)
+
+	// Poll for up to 1 s to pick up the timeout result.
+	deadline := time.time_add(time.now(), 1 * time.Second)
+	results: [dynamic]Http_Response
+	defer { for &r in results do http_response_destroy(&r); delete(results) }
+	for time.diff(time.now(), deadline) > 0 {
+		http_client_poll(&hc, &results)
+		if len(results) > 0 do break
+		time.sleep(50 * time.Millisecond)
+	}
+
+	testing.expect(t, len(results) == 1, "expected one timeout result")
+	if len(results) == 1 {
+		testing.expect_value(t, results[0].status, 0)
+		testing.expect(t, strings.contains(results[0].error_msg, "timeout"),
+			fmt.tprintf("expected 'timeout' in error_msg, got %q", results[0].error_msg))
+	}
+}
+```
+
+Add `import "core:time"` if not already imported.
+
+- [ ] **Step 2: Run, expect failure**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+- [ ] **Step 3: Add `timeout_ms` + pending registry**
+
+In `src/redin/bridge/http_client.odin`:
+
+```odin
+HTTP_DEFAULT_TIMEOUT_MS :: 30_000
+
+Http_Request :: struct {
+	id:         string,
+	url:        string,
+	method:     string,
+	headers:    map[string]string,
+	body:       string,
+	timeout_ms: int,
+}
+
+@(private = "file")
+Pending_Http :: struct {
+	id:       string,         // owned copy; freed when the entry is removed
+	deadline: time.Time,
+}
+
+Http_Client :: struct {
+	results:       [dynamic]Http_Response,
+	results_mutex: sync.Mutex,
+	pending:       map[string]Pending_Http,
+	pending_mutex: sync.Mutex,
+}
+```
+
+Update `http_client_request`:
+
+```odin
+http_client_request :: proc(hc: ^Http_Client, req: Http_Request) {
+	timeout := req.timeout_ms <= 0 ? HTTP_DEFAULT_TIMEOUT_MS : req.timeout_ms
+
+	sync.lock(&hc.pending_mutex)
+	hc.pending[strings.clone(req.id)] = Pending_Http{
+		id       = strings.clone(req.id),
+		deadline = time.time_add(time.now(), time.Duration(timeout) * time.Millisecond),
+	}
+	sync.unlock(&hc.pending_mutex)
+
+	data := new(Http_Thread_Data)
+	data.client = hc
+	data.request = req
+	thread.create_and_start_with_data(data, http_thread_proc, self_cleanup = true)
+}
+```
+
+Update `http_thread_proc` to drop the result if the entry was removed by the timeout sweep:
+
+```odin
+http_thread_proc :: proc(raw_data_ptr: rawptr) {
+	data := cast(^Http_Thread_Data)raw_data_ptr
+	response := execute_http_request(data.request)
+
+	keep := false
+	sync.lock(&data.client.pending_mutex)
+	if entry, ok := data.client.pending[data.request.id]; ok {
+		// Owned id key — free it before removing from the map.
+		delete_key(&data.client.pending, data.request.id)
+		delete(entry.id)
+		keep = true
+	}
+	sync.unlock(&data.client.pending_mutex)
+
+	if keep {
+		sync.lock(&data.client.results_mutex)
+		append(&data.client.results, response)
+		sync.unlock(&data.client.results_mutex)
+	} else {
+		// Entry was already replaced by a timeout. Discard the result.
+		http_response_destroy(&response)
+	}
+
+	http_request_destroy(&data.request)
+	free(data)
+}
+```
+
+Update `http_client_poll` to sweep pending entries and synthesize timeout responses:
+
+```odin
+http_client_poll :: proc(hc: ^Http_Client, results: ^[dynamic]Http_Response) {
+	now := time.now()
+	timed_out: [dynamic]string  // owned ids
+	defer delete(timed_out)
+
+	sync.lock(&hc.pending_mutex)
+	for id, entry in hc.pending {
+		if time.diff(now, entry.deadline) <= 0 {
+			append(&timed_out, strings.clone(id))
+		}
+	}
+	for id in timed_out {
+		if entry, ok := hc.pending[id]; ok {
+			delete_key(&hc.pending, id)
+			delete(entry.id)
+		}
+	}
+	sync.unlock(&hc.pending_mutex)
+
+	if len(timed_out) > 0 {
+		sync.lock(&hc.results_mutex)
+		for id in timed_out {
+			r := Http_Response{
+				id        = id,  // ownership transfers; freed by destroy
+				status    = 0,
+				error_msg = strings.clone("http timeout exceeded"),
+				headers   = make(map[string]string),
+			}
+			append(&hc.results, r)
+		}
+		sync.unlock(&hc.results_mutex)
+	} else {
+		// IDs aren't transferred above; nothing to clean.
+	}
+
+	sync.lock(&hc.results_mutex)
+	defer sync.unlock(&hc.results_mutex)
+	for &r in hc.results do append(results, r)
+	clear(&hc.results)
+}
+```
+
+Update `http_client_destroy` to free the pending map.
+
+In `src/redin/bridge/bridge.odin` `redin_http` (line ~438), after reading args 1–5, read arg 6:
+
+```odin
+if lua_isnumber(L, 6) {
+	req.timeout_ms = int(lua_tonumber(L, 6))
+}
+```
+
+(Default of 0 here triggers the default in `http_client_request`.)
+
+- [ ] **Step 4: Run tests green**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/redin/bridge/http_client.odin src/redin/bridge/bridge.odin src/redin/bridge/http_client_test.odin
+git commit -m "$(cat <<'EOF'
+feat(bridge): HTTP request timeout with pending registry (#99 M1 A)
+
+Adds Http_Request.timeout_ms (default 30000 ms via the Fennel
+effect handler, also defaulted on the Odin side). Each in-flight
+request is tracked in a pending registry on Http_Client; the
+poll loop synthesizes a timeout error response and removes the
+entry once the deadline has passed. The worker thread checks the
+registry on completion and discards the result if it has been
+replaced by a timeout — the underlying http_client.request call
+cannot be cancelled (vendored library), so the worker continues
+in the background but its result is no longer surfaced.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: M1 part B — HTTP in-flight concurrency cap
+
+**Files:**
+- Modify: `src/redin/bridge/http_client.odin`
+- Modify: `src/redin/bridge/http_client_test.odin`
+
+Cap concurrent in-flight requests at 64. New requests beyond the cap fail synchronously with a synthesized error response.
+
+- [ ] **Step 1: Add failing test**
+
+```odin
+@(test)
+test_http_inflight_cap_rejects :: proc(t: ^testing.T) {
+	hc: Http_Client
+	http_client_init(&hc)
+	defer http_client_destroy(&hc)
+
+	// Spin up MAX_INFLIGHT_HTTP slow requests.
+	m := new(Mock_Server)
+	for p in 18900 ..< 19000 {
+		s, e := net.listen_tcp(net.Endpoint{address = net.IP4_Loopback, port = p})
+		if e == nil { m.sock = s; m.port = p; break }
+	}
+	if m.port == 0 { testing.fail_now(t, "no port") }
+	m.thread = thread.create_and_start_with_poly_data(m, slow_mock_serve, context)
+	defer mock_stop(m)
+
+	// Submit MAX_INFLIGHT_HTTP requests + 1; the +1 must be rejected.
+	for i in 0 ..< MAX_INFLIGHT_HTTP {
+		req := Http_Request{
+			id = strings.clone(fmt.tprintf("cap-%d", i)),
+			url = strings.clone(fmt.tprintf("http://127.0.0.1:%d/", m.port)),
+			method = strings.clone("GET"),
+			timeout_ms = 5000,
+		}
+		http_client_request(&hc, req)
+	}
+	overflow := Http_Request{
+		id = strings.clone("cap-over"),
+		url = strings.clone(fmt.tprintf("http://127.0.0.1:%d/", m.port)),
+		method = strings.clone("GET"),
+		timeout_ms = 5000,
+	}
+	http_client_request(&hc, overflow)
+
+	// Poll briefly for the rejected response.
+	deadline := time.time_add(time.now(), 500 * time.Millisecond)
+	results: [dynamic]Http_Response
+	defer { for &r in results do http_response_destroy(&r); delete(results) }
+	for time.diff(time.now(), deadline) > 0 {
+		http_client_poll(&hc, &results)
+		if len(results) >= 1 do break
+		time.sleep(20 * time.Millisecond)
+	}
+
+	found := false
+	for r in results {
+		if r.id == "cap-over" && strings.contains(r.error_msg, "concurrent") {
+			found = true; break
+		}
+	}
+	testing.expect(t, found, "expected overflow request to be rejected with 'concurrent' error")
+}
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+- [ ] **Step 3: Implement the cap**
+
+In `src/redin/bridge/http_client.odin`:
+
+```odin
+MAX_INFLIGHT_HTTP :: 64
+```
+
+In `http_client_request`, before doing anything else:
+
+```odin
+sync.lock(&hc.pending_mutex)
+inflight := len(hc.pending)
+sync.unlock(&hc.pending_mutex)
+
+if inflight >= MAX_INFLIGHT_HTTP {
+	r := Http_Response{
+		id        = strings.clone(req.id),
+		status    = 0,
+		error_msg = strings.clone("too many concurrent http requests (cap 64)"),
+		headers   = make(map[string]string),
+	}
+	sync.lock(&hc.results_mutex)
+	append(&hc.results, r)
+	sync.unlock(&hc.results_mutex)
+	http_request_destroy(&req)
+	return
+}
+```
+
+Note: `req` is by value; `http_request_destroy` consumes its allocations. Adjust the signature to take `req` by value and `defer` the cleanup if cleaner — match the surrounding style.
+
+- [ ] **Step 4: Run tests green**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/redin/bridge/http_client.odin src/redin/bridge/http_client_test.odin
+git commit -m "$(cat <<'EOF'
+feat(bridge): cap concurrent HTTP requests at 64 (#99 M1 B)
+
+Bounds in-flight HTTP threads at MAX_INFLIGHT_HTTP. A submission
+beyond the cap fails synchronously with a synthesized error
+response ('too many concurrent http requests (cap 64)'). Prevents
+a runaway loop in app code from spawning unbounded threads and
+exhausting host memory.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: M2 part A — Shell output cap
+
+**Files:**
+- Modify: `src/redin/bridge/shell.odin` (`Shell_Request`, `execute_shell`)
+- Modify: `src/redin/bridge/bridge.odin` (`redin_shell` reads new arg)
+- Modify: `src/runtime/effect.fnl` (`:shell` effect: pass `:max-output`)
+- Modify: `src/redin/bridge/shell_test.odin`
+
+Cap stdout+stderr at 16 MiB by default; per-call override via `:max-output N` (MiB) on the `:shell` map. On exceedance, kill the child, set `error_msg = "shell output exceeded N MiB cap"`, set `exit_code = -1`, and clear stdout/stderr.
+
+- [ ] **Step 1: Add failing test**
+
+In `src/redin/bridge/shell_test.odin`:
+
+```odin
+@(test)
+test_shell_output_cap_kills_child :: proc(t: ^testing.T) {
+	// `yes` runs forever; with a 1 MiB cap it should be killed quickly.
+	cmd := []string{strings.clone("yes")}
+	defer { for s in cmd do delete(s); delete(cmd) }
+
+	req := Shell_Request{
+		id = strings.clone("cap-1"),
+		cmd = cmd,
+		stdin = strings.clone(""),
+		max_output_bytes = 1 * 1024 * 1024,
+	}
+	defer { delete(req.id); delete(req.stdin) }
+
+	got := execute_shell(req)
+	defer {
+		delete(got.id); delete(got.stdout); delete(got.stderr); delete(got.error_msg)
+	}
+
+	testing.expect_value(t, got.exit_code, -1)
+	testing.expect(t, strings.contains(got.error_msg, "exceeded"),
+		fmt.tprintf("expected 'exceeded' in error_msg, got %q", got.error_msg))
+	testing.expect_value(t, len(got.stdout), 0)
+	testing.expect_value(t, len(got.stderr), 0)
+}
+```
+
+Add `import "core:fmt"` to the file if needed.
+
+- [ ] **Step 2: Run, expect failure**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+- [ ] **Step 3: Add the field + the cap check**
+
+In `src/redin/bridge/shell.odin`:
+
+```odin
+SHELL_DEFAULT_MAX_OUTPUT :: 16 * 1024 * 1024  // 16 MiB
+
+Shell_Request :: struct {
+	id:               string,
+	cmd:              []string,
+	stdin:            string,
+	max_output_bytes: int,
+}
+```
+
+In `execute_shell`, derive `cap`:
+
+```odin
+cap := req.max_output_bytes
+if cap <= 0 do cap = SHELL_DEFAULT_MAX_OUTPUT
+```
+
+Modify the read loop. On each successful append, check the combined buffer size; on overflow, kill, clear, set error, break the loop:
+
+```odin
+killed := false
+for !stdout_done || !stderr_done {
+	if !stdout_done {
+		n, err := os.read(stdout_r, read_buf[:])
+		if err != nil || n <= 0 {
+			stdout_done = true
+		} else {
+			append(&stdout_buf, ..read_buf[:n])
+		}
+	}
+	if !stderr_done {
+		n, err := os.read(stderr_r, read_buf[:])
+		if err != nil || n <= 0 {
+			stderr_done = true
+		} else {
+			append(&stderr_buf, ..read_buf[:n])
+		}
+	}
+	if len(stdout_buf) + len(stderr_buf) > cap {
+		os.process_kill(process)
+		clear(&stdout_buf)
+		clear(&stderr_buf)
+		response.exit_code = -1
+		response.error_msg = fmt.aprintf("shell output exceeded %d MiB cap", cap / (1024*1024))
+		killed = true
+		break
+	}
+}
+
+if killed {
+	// Reap the child to avoid a zombie.
+	_, _ = os.process_wait(process)
+	return response
+}
+```
+
+Verify `os.process_kill` exists in the Odin core (it does as of recent versions); if not, replace with the platform-specific equivalent already used elsewhere in the codebase.
+
+- [ ] **Step 4: Plumb through Lua → Fennel → bridge**
+
+In `src/redin/bridge/bridge.odin` `redin_shell` (line ~931), after reading args 1–3:
+
+```odin
+if lua_isnumber(L, 4) {
+	mb := int(lua_tonumber(L, 4))
+	if mb > 0 do req.max_output_bytes = mb * 1024 * 1024
+}
+```
+
+In `src/runtime/effect.fnl` `:shell` handler (line ~105), pass `:max-output` through:
+
+```fennel
+(M.reg-fx :shell
+  (fn [params]
+    (set next-shell-id (+ next-shell-id 1))
+    (let [id (tostring next-shell-id)
+          cmd (or params.cmd [])
+          stdin (or params.stdin "")
+          max-output (or params.max-output 16)]
+      (tset pending-shell id {:on-success params.on-success
+                              :on-error params.on-error})
+      (when _G.redin_shell
+        (_G.redin_shell id cmd stdin max-output)))))
+```
+
+- [ ] **Step 5: Run tests green**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+luajit test/lua/runner.lua test/lua/test_*.fnl
+```
+
+The Fennel tests should still pass — the new `:max-output` param has a default of 16, so existing test apps don't need updates.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/redin/bridge/shell.odin src/redin/bridge/bridge.odin src/runtime/effect.fnl src/redin/bridge/shell_test.odin
+git commit -m "$(cat <<'EOF'
+feat(bridge): cap shell stdout+stderr at 16 MiB (#99 M2 A)
+
+Adds max_output_bytes to Shell_Request, default 16 MiB, per-call
+override via :max-output N (MiB) on the :shell effect map. When
+the combined buffer crosses the cap during the read loop, the
+child is killed (and reaped), buffers are cleared, and the
+response is returned with exit_code -1 and a descriptive error
+message. No partial data is surfaced — the call simply fails.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: M2 part B — Shell timeout
+
+**Files:**
+- Modify: `src/redin/bridge/shell.odin`
+- Modify: `src/redin/bridge/bridge.odin`
+- Modify: `src/runtime/effect.fnl`
+- Modify: `src/redin/bridge/shell_test.odin`
+
+Per-call `:timeout` (ms) on `:shell`, default 30000 ms. On expiry, kill child, clear buffers, return error.
+
+- [ ] **Step 1: Add failing test**
+
+```odin
+@(test)
+test_shell_timeout_kills_child :: proc(t: ^testing.T) {
+	// `sleep 60` should be killed by a 200 ms timeout.
+	cmd := []string{strings.clone("sleep"), strings.clone("60")}
+	defer { for s in cmd do delete(s); delete(cmd) }
+
+	req := Shell_Request{
+		id = strings.clone("to-1"),
+		cmd = cmd,
+		stdin = strings.clone(""),
+		timeout_ms = 200,
+	}
+	defer { delete(req.id); delete(req.stdin) }
+
+	got := execute_shell(req)
+	defer {
+		delete(got.id); delete(got.stdout); delete(got.stderr); delete(got.error_msg)
+	}
+
+	testing.expect_value(t, got.exit_code, -1)
+	testing.expect(t, strings.contains(got.error_msg, "timeout"),
+		fmt.tprintf("expected 'timeout' in error_msg, got %q", got.error_msg))
+}
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+- [ ] **Step 3: Add timeout field + deadline check**
+
+```odin
+SHELL_DEFAULT_TIMEOUT_MS :: 30_000
+
+Shell_Request :: struct {
+	id:               string,
+	cmd:              []string,
+	stdin:            string,
+	max_output_bytes: int,
+	timeout_ms:       int,
+}
+```
+
+In `execute_shell`, after the cap derivation, derive the deadline:
+
+```odin
+timeout_ms := req.timeout_ms
+if timeout_ms <= 0 do timeout_ms = SHELL_DEFAULT_TIMEOUT_MS
+deadline := time.time_add(time.now(), time.Duration(timeout_ms) * time.Millisecond)
+```
+
+Set non-blocking reads on both pipes (using the platform's pipe fcntl call) so the read loop can poll without blocking. If non-blocking pipes are not straightforward in Odin core, fall back to a watchdog goroutine that sends SIGTERM at the deadline; the read loop notices the closed pipes and exits.
+
+The simplest implementation: skip the watchdog goroutine and check the elapsed time inline at the top of each read-loop iteration. The downside is that an idle child (one that produces no output) won't be killed until the next read returns; with blocking reads that means the timeout fires only when output finally arrives or both pipes close. To make idle-child timeouts responsive, set `SO_RCVTIMEO` on each pipe fd via `setsockopt` (Linux) or use `fcntl(F_SETFL, O_NONBLOCK)` plus `poll`. Pick whichever is supported in `core:os` / `core:sys/linux` without inventing wrappers; if neither is straightforward, accept the "kills on next read" tradeoff and document it in a code comment above the loop.
+
+In the read loop, on each iteration also check the elapsed time:
+
+```odin
+if time.diff(time.now(), deadline) <= 0 {
+	os.process_kill(process)
+	clear(&stdout_buf); clear(&stderr_buf)
+	response.exit_code = -1
+	response.error_msg = fmt.aprintf("shell timeout exceeded %d ms", timeout_ms)
+	killed = true
+	break
+}
+```
+
+(Two paths to "killed = true" — output cap or timeout — both end with `os.process_wait` to reap, then return.)
+
+Note: with blocking reads, the timeout check only fires between read returns. If the child writes nothing for 60 s and the timeout is 200 ms, the read won't return until something arrives. To make timeouts responsive on idle children: either set `SO_RCVTIMEO` on the pipe fds (Linux/macOS via `fcntl` or `setsockopt`), OR run the read loop on a separate goroutine and have the main thread sleep on a sema with timeout. **Pick the simpler approach during impl** and document the tradeoff in a code comment.
+
+- [ ] **Step 4: Plumb through Lua → Fennel → bridge**
+
+In `redin_shell`:
+
+```odin
+if lua_isnumber(L, 5) {
+	ms := int(lua_tonumber(L, 5))
+	if ms > 0 do req.timeout_ms = ms
+}
+```
+
+In `effect.fnl` `:shell` handler:
+
+```fennel
+(let [...
+      max-output (or params.max-output 16)
+      timeout    (or params.timeout 30000)]
+  ...
+  (_G.redin_shell id cmd stdin max-output timeout))
+```
+
+- [ ] **Step 5: Run tests green**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+luajit test/lua/runner.lua test/lua/test_*.fnl
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/redin/bridge/shell.odin src/redin/bridge/bridge.odin src/runtime/effect.fnl src/redin/bridge/shell_test.odin
+git commit -m "$(cat <<'EOF'
+feat(bridge): shell timeout (#99 M2 B)
+
+Adds timeout_ms to Shell_Request, default 30 000 ms, per-call
+override via :timeout N (ms) on the :shell effect map. On expiry
+the child is killed and reaped, buffers are cleared, and the
+response is returned with exit_code -1 and a descriptive error
+message. Together with the M2 A output cap this closes the
+shell-side DoS vectors flagged in the audit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Documentation + skill updates
+
+**Files:**
+- Modify: `docs/core-api.md` (effect map fields, error shapes, dev-server 400 path)
+- Modify: `docs/reference/effects.md` (`:http` and `:shell` keys)
+- Modify: `docs/reference/native-bridge.md` (new public procs)
+- Modify: `docs/reference/dev-server.md` (note 400 + fatal token write)
+- Modify: `.claude/skills/redin-dev/SKILL.md` (effect-map fields + setters)
+
+CLAUDE.md mandates docs land in the same commits as code, but the seven prior tasks each touch one finding and the doc text covers multiple findings. Bundle the doc updates here as one self-contained docs commit; the prior commits stand as code-with-tests, this one closes the contract.
+
+- [ ] **Step 1: Update `docs/core-api.md`**
+
+Find the section that documents the `:http` effect (search for `redin.http` or `:http`). Add the `:timeout` field with its default and the new error shapes (status 0 with `error` containing the failure message; specifically: `"http timeout exceeded"`, `"too many concurrent http requests"`, `"http scheme must be http or https"`, `"host <name> not in http whitelist"`, `"http header contains invalid character"`).
+
+Find the section that documents the `:shell` effect. Add `:timeout` (ms, default 30000) and `:max-output` (MiB, default 16). Document the failure shapes: `exit_code -1` with `error_msg` containing one of `"shell output exceeded N MiB cap"`, `"shell timeout exceeded N ms"`.
+
+In the dev-server section, add a row noting that malformed `Content-Length` returns 400.
+
+- [ ] **Step 2: Update `docs/reference/effects.md`**
+
+Add the same fields with brief descriptions and the failure modes. Cross-reference `docs/reference/native-bridge.md` for the opt-in setters.
+
+- [ ] **Step 3: Update `docs/reference/native-bridge.md`**
+
+Append entries for `bridge.set_http_whitelist(allow: []string)` and `bridge.set_shell_env_allowlist(allow: []string)`. Include short examples:
+
+```odin
+// In app.odin
+bridge.set_http_whitelist([]string{"api.example.com", "127.0.0.0/8"})
+bridge.set_shell_env_allowlist([]string{"PATH", "HOME", "GITHUB_TOKEN"})
+redin.run(cfg)
+```
+
+- [ ] **Step 4: Update `docs/reference/dev-server.md`**
+
+Note the 400 response for malformed Content-Length, and that the dev server now aborts startup if `.redin-token` or `.redin-port` write fails (with a clear stderr line).
+
+- [ ] **Step 5: Update `.claude/skills/redin-dev/SKILL.md`**
+
+In the section that describes the effect maps, add the new optional fields. In the bridge-API section, add the two new setters.
+
+- [ ] **Step 6: Skim `CLAUDE.md`**
+
+Search for `redin.http` and `redin.shell` in `CLAUDE.md`. The current text in this file is broad (high-level conventions), so likely no update is needed. If you find a misleading example, fix it.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/core-api.md docs/reference/effects.md docs/reference/native-bridge.md docs/reference/dev-server.md .claude/skills/redin-dev/SKILL.md
+git commit -m "$(cat <<'EOF'
+docs: security audit fix surface (#99)
+
+Documents the new effect-map fields (:timeout, :max-output) on
+:http and :shell, the new public bridge setters
+(set_http_whitelist, set_shell_env_allowlist), the failure
+response shapes for the new reject paths (scheme, whitelist,
+header CRLF, timeout, output cap, in-flight cap), the dev-server
+400 on malformed Content-Length, and the now-fatal token-file
+write failure. Same-commit docs landing per CLAUDE.md.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Final verification
+
+No new code in this task. Run every gate from the `redin-maintenance` skill in order; fix anything that fails by going back to the relevant earlier task. Do not skip steps.
+
+- [ ] **Step 1: Release build**
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+```
+
+Expected: succeeds with no warnings. The dev-server code is excluded from this build (no `REDIN_DEV`), so L1/L2 changes contribute no symbols here.
+
+- [ ] **Step 2: Dev build**
+
+```bash
+./build-dev.sh
+```
+
+Expected: succeeds.
+
+- [ ] **Step 3: Agent build**
+
+```bash
+./build-dev.sh -define:REDIN_AGENT=true
+```
+
+Expected: succeeds. Confirms the agent path still compiles with the new bridge setters.
+
+- [ ] **Step 4: Fennel runtime tests**
+
+```bash
+luajit test/lua/runner.lua test/lua/test_*.fnl
+```
+
+Expected: 122 tests pass. The `:shell` and `:http` runtime paths now route extra params; if any existing test stubs `_G.redin_http` or `_G.redin_shell` with a fixed-arity proc, the test will fail with an arity error — fix the stub to accept (and ignore) the new params.
+
+- [ ] **Step 5: Bridge unit tests**
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
+```
+
+If a race appears (it shouldn't, the bridge tests don't currently need it), retry with:
+
+```bash
+odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit -define:ODIN_TEST_THREADS=1
+```
+
+- [ ] **Step 6: UI integration tests**
+
+```bash
+bash test/ui/run-all.sh --headless
+```
+
+Expected: full suite passes. The hardening fixes are not UI-visible; this is the regression check.
+
+- [ ] **Step 7: Tracking-allocator smoke**
+
+```bash
+./build/redin test/ui/smoke_app.fnl &
+PID=$!
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+# Issue a few :http and :shell calls via the dev events endpoint, exercising
+# success + cap + timeout paths. (Adapt to whatever events smoke_app.fnl
+# defines; if none, write a one-off events sequence inline.)
+sleep 2
+curl -sf -X POST -H "Authorization: Bearer $TOKEN" \
+  http://localhost:$PORT/shutdown
+wait $PID
+```
+
+Inspect stderr for tracking-allocator leak lines. Expected: none. Pay special attention to the cloned allowlist slices (Tasks 6 and 7) and timed-out request cleanup (Task 8) — these are the new allocations introduced by this work.
+
+- [ ] **Step 8: Final commit (if any in-task fixes were needed)**
+
+If any previous task needed a touch-up (e.g. a leak or an unused import), commit those fixes with a clear message naming the task they patch up.
+
+- [ ] **Step 9: Open the PR (optional, on user request)**
+
+Not part of this plan — awaits the user's call.

--- a/docs/superpowers/specs/2026-05-06-security-audit-99-design.md
+++ b/docs/superpowers/specs/2026-05-06-security-audit-99-design.md
@@ -1,0 +1,184 @@
+# Security audit fixes (#99) — design
+
+## Goal
+
+Implement all eight findings from the bridge / devserver / http / shell security audit (issue #99). Land them on a single branch (`fix/security-audit-99`) with the medium-severity fixes (M1–M5) and low-severity fixes (L1–L3) treated as one coherent piece of work.
+
+The redin trust model is unchanged: the `.fnl` / `.lua` app file is trusted code with full Lua + bridge access. The dev-server (gated on `REDIN_DEV` / `REDIN_AGENT`) is the externally reachable surface. These fixes harden both layers without changing the trust model.
+
+## Posture summary
+
+For findings with a behavior choice, the design is **permissive default + opt-in hardening tool**:
+
+- Existing apps continue to run unchanged.
+- Apps that want stricter behavior call a public bridge setter at startup (`set_http_whitelist`, `set_shell_env_allowlist`).
+- Findings that are pure DoS / robustness fixes (M1, M2, L1, L2) get reasonable defaults baked in. The defaults can be overridden per-call where it makes sense (M1 timeout, M2 cap + timeout).
+
+## Fixes
+
+### M1 — HTTP request timeout + concurrency cap
+
+`src/redin/bridge/http_client.odin`, `src/redin/bridge/bridge.odin`
+
+- Add `timeout: time.Duration` to `Http_Request`. Default **30 s**.
+- Per-call override on the `:http` effect map: `:timeout 60` (seconds, integer or float).
+- Plumb the timeout into odin-http via its existing request-deadline knob. If odin-http exposes none, wrap the call in a watchdog that closes the underlying socket on expiry.
+- `MAX_INFLIGHT_HTTP = 64` (compile-time const). `redin_http` rejects new requests when in-flight count is at the cap; counter decremented in `http_thread_proc` on completion.
+- Failure response (timeout or cap): `{status: 0, error: "http timeout exceeded 30s"}` or `{status: 0, error: "too many concurrent http requests (cap 64)"}`. No body, no headers, no partial data.
+
+### M2 — Shell output cap + timeout
+
+`src/redin/bridge/shell.odin`, `src/redin/bridge/bridge.odin`
+
+- `SHELL_MAX_OUTPUT = 16 * 1024 * 1024` (compile-time const, mirrors `HTTP_MAX_BODY`). Per-call override `:max-output 32` (MiB) on the `:shell` map.
+- `SHELL_DEFAULT_TIMEOUT = 30 * time.Second`. Per-call override `:timeout 60` (seconds).
+- During the read loop in `execute_shell`: after each append, check `len(stdout_buf) + len(stderr_buf) > cap`. On exceedance, `os.process_kill(process)`, set `error_msg = "shell output exceeded 16 MiB cap"`, `exit_code = -1`, and clear `stdout` / `stderr` (no partial data returned).
+- Timeout enforced via a deadline check in the read loop (poll-based using `SO_RCVTIMEO` on the pipe + elapsed-time check). On expiry: kill child, return `error_msg = "shell timeout exceeded 30s"`, `exit_code = -1`, empty buffers.
+
+### M3 — Shell env allowlist
+
+`src/redin/bridge/shell.odin`, `src/redin/bridge/api.odin`
+
+- New public bridge API: `bridge.set_shell_env_allowlist(allow: []string)`. Stores a clone in a package-global `shell_env_allowlist: []string` (nil = unset).
+- In `execute_shell`:
+  - If allowlist is **set**: build `desc.env` from `os.environ()` filtered to keys present in the allowlist (exact match, case-sensitive).
+  - If allowlist is **unset** (default): leave `desc.env = nil` so the child inherits the full parent env (current behavior).
+- No glob support in v1; can be added later if needed.
+- Setter callable any time, including from a Lua cfunc registered by the user's `app.odin`. Concurrent access protected by a new package-level `sync.Mutex` for the allowlist slice (the bridge currently has only per-client mutexes such as the shell client's `results_mutex`; the new mutex is dedicated to the allowlist). Same pattern applies to the M4 whitelist.
+
+### M4 — HTTP scheme guard + destination whitelist
+
+`src/redin/bridge/http_client.odin`, `src/redin/bridge/api.odin`
+
+- **Always** (non-bypassable): reject URLs whose scheme is not `http` or `https`. Failure: `{status: 0, error: "http scheme must be http or https"}`.
+- New public bridge API: `bridge.set_http_whitelist(allow: []string)`. Stores a clone of the input. nil = unset (default = any host allowed).
+- Each entry is either a hostname literal (case-insensitive exact match against the URL host) **or** a CIDR (IPv4 or IPv6, matched against URL hosts that are already IP literals). Hostnames are not resolved to IPs at validation; the app is trusted, so this is self-protection, not anti-hostile-app defense.
+- When set: parse URL host, reject if it doesn't match any whitelist entry. Failure: `{status: 0, error: "host <name> not in http whitelist"}`.
+- The whitelist is checked alongside the scheme check in `redin_http` before the request is queued.
+
+### M5 — Header CRLF / NUL validation
+
+`src/redin/bridge/http_client.odin`
+
+- New helper `header_value_safe(s: string) -> bool`: returns `false` if `s` contains `\r`, `\n`, or `\x00`. Same check on key.
+- In `redin_http`, before queuing the request: iterate `req.headers`, fail the call if any header key or value fails the check. Failure: `{status: 0, error: "http header contains invalid character"}`. No silent stripping — fail loud.
+
+### L1 — Content-Length overflow guard
+
+`src/redin/bridge/devserver.odin` (`find_content_length`, caller at line ~266)
+
+- Cap digit count to 12 inside `find_content_length`; return `-1` if exceeded.
+- Caller adds a sibling check `cl < 0` → `400 Bad Request` with body `"invalid Content-Length"`. Existing `cl > MAX_BODY` → `413` path is preserved.
+- Negative result also covers any future overflow surprise without further parser changes.
+
+### L2 — Token / port file write becomes fatal
+
+`src/redin/bridge/devserver.odin` (~lines 172–180)
+
+- If `write_private_no_follow(TOKEN_FILE, ...)` or the corresponding `.redin-port` write fails, log `"redin: failed to write .redin-token; aborting dev server"` (or analogous for the port file) on stderr, set `ds.running = false`, and return.
+- Affects only `REDIN_DEV` / `REDIN_AGENT` builds (the only ones where this code runs). Replaces the current "log warning, keep running" UX which produces silent 401s on every request.
+
+### L3 — Disable HTTP auto-redirects
+
+`src/redin/bridge/http_client.odin`
+
+- Set odin-http's redirect-follow option to `false` at `request_init`. Verify the exact field name during impl (likely something like `req.follow_redirects = false` or a max-hop count of 0).
+- 3xx responses surface to the Lua app as-is (status, headers including `Location`, body). Apps that want to follow a redirect can re-issue the request themselves.
+- Closes the SSRF-via-redirect concern even when M4's whitelist is opt-in.
+
+## Public API additions
+
+```odin
+// src/redin/bridge/api.odin
+bridge.set_shell_env_allowlist :: proc(allow: []string)  // nil = unset
+bridge.set_http_whitelist      :: proc(allow: []string)  // nil = unset
+```
+
+Both clone the slice contents into bridge-owned memory. Callable before or after `bridge.init`. Available to `--native` `app.odin` callers via the public bridge package.
+
+## Effect-map additions
+
+| Effect | New optional key | Type | Default | Behavior |
+|---|---|---|---|---|
+| `:http` | `:timeout` | seconds (number) | 30 | Per-call override of `M1` timeout |
+| `:shell` | `:timeout` | seconds (number) | 30 | Per-call override of `M2` timeout |
+| `:shell` | `:max-output` | MiB (integer) | 16 | Per-call override of `M2` output cap |
+
+No removals. No renames.
+
+## Error response shape (unchanged)
+
+All hardening rejections produce responses in the existing shape:
+
+- HTTP: `{status: 0, error: "<message>", body: "", headers: {}}`
+- Shell: `{exit_code: -1, error_msg: "<message>", stdout: "", stderr: ""}`
+
+The Fennel app's `:on-error` handler (or the existing `(if (= 0 status) ...)` / `(if (not= 0 exit-code) ...)` branch) handles these the same as today's start failures and HTTP errors. No new event shapes.
+
+## Documentation
+
+Updated in the same commits as the code changes (per CLAUDE.md):
+
+| File | What changes |
+|---|---|
+| `docs/core-api.md` | Dev-server table notes 400 for malformed Content-Length. `redin.http` / `redin.shell` sections document `:timeout`, `:max-output`, default values, error response shape, scheme rejection (M4), header validation (M5), redirect non-following (L3). |
+| `docs/reference/native-bridge.md` | Add `set_shell_env_allowlist` and `set_http_whitelist` to the public bridge API table. |
+| `docs/reference/effects.md` | Add the new effect-map keys (`:timeout` for `:http` / `:shell`; `:max-output` for `:shell`) and document the failure paths. |
+| `docs/reference/dev-server.md` | Note the 400 path for malformed Content-Length; mention that token-file write failure aborts startup. |
+| `docs/guide/*.md` | Sweep for `redin.http` / `redin.shell` examples that would mislead a reader (e.g. examples relying on auto-redirect behavior). |
+| `.claude/skills/redin-dev/SKILL.md` | Add the new optional fields on `:http` / `:shell` and the two new public-bridge setters. |
+| `CLAUDE.md` | Skim only — likely no change. The conventions list does not currently mention these specifics. |
+
+## Testing
+
+### Odin unit tests (`src/redin/bridge/*_test.odin`)
+
+- `http_client_test.odin` — extend with:
+  - Scheme rejection (`ftp://`, `file://`, empty, mixed-case `HTTP`).
+  - Header CRLF / NUL rejection (each forbidden char in key, then in value).
+  - Whitelist hostname match (case-insensitive).
+  - Whitelist CIDR match (IPv4 and IPv6 literal hosts).
+  - Whitelist mismatch returns error containing the rejected host.
+  - 3xx responses surface to the caller without following.
+- `shell_test.odin` (new) —
+  - Output-cap kill: synthesise an over-cap buffer, assert error_msg, empty stdout/stderr, exit_code -1, child killed.
+  - Env-allowlist filtering: set allowlist, run `env`, parse output, assert only allowlisted keys present; clear allowlist, assert full passthrough.
+  - Timeout kill: launch `sleep 60` with `:timeout 1`, assert error_msg + exit_code -1.
+- `devserver_headers_test.odin` — extend with:
+  - `find_content_length` returns `-1` on >12 digits and on multiplication overflow.
+  - End-to-end: `Content-Length: 999999999999999999` → 400.
+- `devserver_write_test.odin` — extend with:
+  - Token-write failure aborts server start (mock `write_private_no_follow`, assert `ds.running == false`).
+
+### Fennel runtime tests (`test/lua/`)
+
+- `test_effect.fnl` (or similar): one round-trip test confirming `:timeout` / `:max-output` on `:http` / `:shell` are passed through to the bridge call without runtime errors. The runtime side is otherwise unchanged.
+
+### UI integration tests (`test/ui/`)
+
+No new test app. The hardening fixes are server-side and not UI-visible. The existing `test/ui/run-all.sh --headless` run is the regression check.
+
+### Manual / smoke
+
+- Release build: `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin` — confirm no new warnings, no missing imports, devserver code is excluded as expected.
+- Dev build: `./build-dev.sh` — confirm dev binary builds.
+- Agent build: `./build-dev.sh -define:REDIN_AGENT=true` — confirm agent path still compiles (the new setters live in the bridge, loaded both ways).
+- Tracking-allocator smoke: dev binary on `test/ui/smoke_app.fnl`, dispatch a few `:http` and `:shell` calls (success + cap + timeout paths), verify no leaks on shutdown — especially around cloned allowlist slices and timed-out request cleanup.
+
+### Verification gates (per `redin-maintenance` skill)
+
+In order, before declaring done:
+
+1. `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin`
+2. `./build-dev.sh`
+3. `luajit test/lua/runner.lua test/lua/test_*.fnl`
+4. `odin test src/redin/bridge` (with `-define:ODIN_TEST_THREADS=1` if races appear)
+5. `bash test/ui/run-all.sh --headless`
+6. Tracking-allocator smoke on the dev binary
+
+## Out of scope
+
+- Glob / pattern support in `set_shell_env_allowlist` (v1 is exact match).
+- DNS-resolve-and-classify SSRF defense for `redin.http` (treated as out of scope per the trust model; the audit flagged it but the user opted for permissive default + opt-in whitelist).
+- Per-call `:env` field on `:shell` (current design is global allowlist via the bridge setter; per-call control can be added later if a real use case appears).
+- Hop-by-hop redirect re-validation (not needed once auto-redirects are disabled).

--- a/docs/superpowers/specs/2026-05-06-security-audit-99-design.md
+++ b/docs/superpowers/specs/2026-05-06-security-audit-99-design.md
@@ -68,7 +68,7 @@ For findings with a behavior choice, the design is **permissive default + opt-in
 `src/redin/bridge/devserver.odin` (`find_content_length`, caller at line ~266)
 
 - Cap digit count to 12 inside `find_content_length`; return `-1` if exceeded.
-- Caller adds a sibling check `cl < 0` → `400 Bad Request` with body `"invalid Content-Length"`. Existing `cl > MAX_BODY` → `413` path is preserved.
+- Caller adds a sibling check `cl < 0` → `400 Bad Request`. Existing `cl > MAX_BODY` → `413` path is preserved.
 - Negative result also covers any future overflow surprise without further parser changes.
 
 ### L2 — Token / port file write becomes fatal

--- a/src/redin/bridge/api.odin
+++ b/src/redin/bridge/api.odin
@@ -4,8 +4,11 @@ package bridge
 
 import "base:runtime"
 import "core:fmt"
+import "core:net"
 import "core:reflect"
+import "core:strconv"
 import "core:strings"
+import "core:sync"
 
 // ---------------------------------------------------------------------------
 // Context propagation
@@ -413,4 +416,118 @@ dispatch :: proc(event: string, payload: any) -> (ok: bool, err: string) {
 	}
 	push(g_bridge.L, payload)
 	return dispatch_tos(g_bridge.L, event)
+}
+
+// ---------------------------------------------------------------------------
+// Outbound HTTP destination whitelist (issue #99 M4)
+// ---------------------------------------------------------------------------
+//
+// When unset (default), redin.http accepts any http(s) destination.
+// When set, the URL host must match either a hostname literal
+// (case-insensitive) or a CIDR (IPv4 or IPv6, applied only to
+// IP-literal hosts). Apps opt in by calling this setter at startup
+// from app.odin (--native projects) or via a registered cfunc.
+
+@(private)
+g_http_whitelist:       []string
+@(private)
+g_http_whitelist_mutex: sync.Mutex
+
+set_http_whitelist :: proc(allow: []string) {
+	sync.lock(&g_http_whitelist_mutex)
+	defer sync.unlock(&g_http_whitelist_mutex)
+
+	// Use the process-wide heap allocator so storage is independent of the
+	// caller's per-thread allocator (e.g. Odin's per-test tracking allocator).
+	// In production this matters because the dev-server thread that runs
+	// http_whitelist_check is not the thread that called set_http_whitelist.
+	heap := runtime.heap_allocator()
+
+	for s in g_http_whitelist do delete(s, heap)
+	delete(g_http_whitelist, heap)
+	g_http_whitelist = nil
+
+	if allow == nil do return
+
+	cloned := make([]string, len(allow), heap)
+	for s, i in allow do cloned[i] = strings.clone(s, heap)
+	g_http_whitelist = cloned
+}
+
+// http_whitelist_check returns ("", true) if allowed, ("<rejected host>", false)
+// otherwise. host must already be the URL host (no port, no scheme).
+@(private)
+http_whitelist_check :: proc(host: string) -> (rejected: string, ok: bool) {
+	sync.lock(&g_http_whitelist_mutex)
+	defer sync.unlock(&g_http_whitelist_mutex)
+
+	if g_http_whitelist == nil do return "", true
+
+	host_lower := strings.to_lower(host, context.temp_allocator)
+	for entry in g_http_whitelist {
+		// CIDR entry?
+		if strings.contains(entry, "/") {
+			if cidr_match(host, entry) do return "", true
+			continue
+		}
+		// Hostname literal — case-insensitive exact match.
+		entry_lower := strings.to_lower(entry, context.temp_allocator)
+		if host_lower == entry_lower do return "", true
+	}
+	return host, false
+}
+
+@(private = "file")
+cidr_match :: proc(host: string, cidr: string) -> bool {
+	slash := strings.last_index_byte(cidr, '/')
+	if slash < 0 do return false
+	prefix := cidr[:slash]
+	bits_str := cidr[slash+1:]
+
+	// IPv4 path: prefix parses as v4.
+	if v4, ok := net.parse_ip4_address(prefix); ok {
+		host_v4, ok2 := net.parse_ip4_address(host)
+		if !ok2 do return false
+		bits, parse_ok := strconv.parse_int(bits_str, 10)
+		if !parse_ok || bits < 0 || bits > 32 do return false
+		return cidr4_match_bits(host_v4, v4, bits)
+	}
+
+	// IPv6 path.
+	v6, ok := net.parse_ip6_address(prefix)
+	if !ok do return false
+	host_v6, ok2 := net.parse_ip6_address(host)
+	if !ok2 do return false
+	bits, parse_ok := strconv.parse_int(bits_str, 10)
+	if !parse_ok || bits < 0 || bits > 128 do return false
+	return cidr6_match_bits(host_v6, v6, bits)
+}
+
+@(private = "file")
+cidr4_match_bits :: proc(host: net.IP4_Address, net_addr: net.IP4_Address, bits: int) -> bool {
+	if bits == 0 do return true
+	host_u := u32(host[0])<<24 | u32(host[1])<<16 | u32(host[2])<<8 | u32(host[3])
+	net_u  := u32(net_addr[0])<<24 | u32(net_addr[1])<<16 | u32(net_addr[2])<<8 | u32(net_addr[3])
+	mask: u32 = bits == 32 ? 0xFFFFFFFF : (0xFFFFFFFF << u32(32 - bits))
+	return (host_u & mask) == (net_u & mask)
+}
+
+@(private = "file")
+cidr6_match_bits :: proc(host: net.IP6_Address, net_addr: net.IP6_Address, bits: int) -> bool {
+	if bits == 0 do return true
+	// IP6_Address is `distinct [8]u16be`, i.e. 16 bytes laid out in network
+	// byte order. Transmute to a flat [16]u8 for a clean byte-by-byte
+	// CIDR comparison.
+	host_bytes := transmute([16]u8)host
+	net_bytes  := transmute([16]u8)net_addr
+	full_bytes := bits / 8
+	rem_bits   := bits % 8
+	for i in 0 ..< full_bytes {
+		if host_bytes[i] != net_bytes[i] do return false
+	}
+	if rem_bits > 0 {
+		mask: u8 = u8(0xFF) << u8(8 - rem_bits)
+		if (host_bytes[full_bytes] & mask) != (net_bytes[full_bytes] & mask) do return false
+	}
+	return true
 }

--- a/src/redin/bridge/api.odin
+++ b/src/redin/bridge/api.odin
@@ -5,6 +5,7 @@ package bridge
 import "base:runtime"
 import "core:fmt"
 import "core:net"
+import "core:os"
 import "core:reflect"
 import "core:strconv"
 import "core:strings"
@@ -530,4 +531,90 @@ cidr6_match_bits :: proc(host: net.IP6_Address, net_addr: net.IP6_Address, bits:
 		if (host_bytes[full_bytes] & mask) != (net_bytes[full_bytes] & mask) do return false
 	}
 	return true
+}
+
+// ---------------------------------------------------------------------------
+// Shell env allowlist (issue #99 M3)
+// ---------------------------------------------------------------------------
+//
+// When unset (default), child processes spawned by redin.shell inherit the
+// full parent env (Process_Desc.env = nil is the documented "inherit"
+// sentinel; see core/os/process.odin). When set, only keys present in the
+// allowlist are passed through to the child. Exact match, case-sensitive.
+//
+// Storage uses runtime.heap_allocator() for the same reason as the HTTP
+// whitelist: the allowlist is read on the shell worker thread and written
+// from the main thread; under Odin's parallel test runner, per-thread
+// tracking allocators would otherwise produce spurious "bad free"
+// warnings.
+
+@(private)
+g_shell_env_allowlist:       []string
+@(private)
+g_shell_env_allowlist_mutex: sync.Mutex
+
+set_shell_env_allowlist :: proc(allow: []string) {
+	sync.lock(&g_shell_env_allowlist_mutex)
+	defer sync.unlock(&g_shell_env_allowlist_mutex)
+
+	heap := runtime.heap_allocator()
+
+	for s in g_shell_env_allowlist do delete(s, heap)
+	delete(g_shell_env_allowlist, heap)
+	g_shell_env_allowlist = nil
+
+	if allow == nil do return
+
+	cloned := make([]string, len(allow), heap)
+	for s, i in allow do cloned[i] = strings.clone(s, heap)
+	g_shell_env_allowlist = cloned
+}
+
+// shell_env_filtered returns the filtered env, or nil if the allowlist is
+// unset (caller should leave Process_Desc.env = nil for full passthrough).
+// Returned slice is owned by the caller (free each entry + the slice
+// itself, both with the same allocator that the heap_allocator yields).
+@(private)
+shell_env_filtered :: proc() -> []string {
+	sync.lock(&g_shell_env_allowlist_mutex)
+	defer sync.unlock(&g_shell_env_allowlist_mutex)
+
+	if g_shell_env_allowlist == nil do return nil
+
+	heap := runtime.heap_allocator()
+
+	// os.environ allocates a fresh []string + cloned KEY=VALUE entries
+	// using the supplied allocator. Free the unused entries below.
+	all_env, env_err := os.environ(heap)
+	if env_err != nil {
+		// Fall back to an explicit "no env" rather than passthrough; if the
+		// caller set an allowlist they explicitly opted into restriction,
+		// so a fetch failure must not silently widen the surface.
+		return make([]string, 0, heap)
+	}
+	defer delete(all_env, heap)
+
+	out := make([dynamic]string, 0, len(g_shell_env_allowlist), heap)
+	for entry in all_env {
+		// `entry` is "KEY=VALUE"; extract KEY.
+		eq := strings.index_byte(entry, '=')
+		if eq < 0 {
+			delete(entry, heap)
+			continue
+		}
+		key := entry[:eq]
+		matched := false
+		for allow in g_shell_env_allowlist {
+			if key == allow {
+				matched = true
+				break
+			}
+		}
+		if matched {
+			append(&out, entry) // transfer ownership of the cloned string
+		} else {
+			delete(entry, heap)
+		}
+	}
+	return out[:]
 }

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -466,6 +466,9 @@ redin_http :: proc "c" (L: ^Lua_State) -> i32 {
 	} else {
 		req.body = strings.clone("")
 	}
+	if lua_isnumber(L, 6) {
+		req.timeout_ms = int(lua_tonumber(L, 6))
+	}
 
 	http_client_request(&g_bridge.http_client, req)
 	return 0

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -960,6 +960,13 @@ redin_shell :: proc "c" (L: ^Lua_State) -> i32 {
 		req.stdin = strings.clone("")
 	}
 
+	// Optional arg 4: per-call max output cap in MiB (issue #99 M2 A).
+	// Omitted / non-positive => execute_shell falls back to its 16 MiB default.
+	if lua_isnumber(L, 4) {
+		mb := int(lua_tonumber(L, 4))
+		if mb > 0 do req.max_output_bytes = mb * 1024 * 1024
+	}
+
 	shell_client_request(&g_bridge.shell_client, req)
 	return 0
 }

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -967,6 +967,13 @@ redin_shell :: proc "c" (L: ^Lua_State) -> i32 {
 		if mb > 0 do req.max_output_bytes = mb * 1024 * 1024
 	}
 
+	// Optional arg 5: per-call timeout in ms (issue #99 M2 B).
+	// Omitted / non-positive => execute_shell falls back to its 30000 ms default.
+	if lua_isnumber(L, 5) {
+		ms := int(lua_tonumber(L, 5))
+		if ms > 0 do req.timeout_ms = ms
+	}
+
 	shell_client_request(&g_bridge.shell_client, req)
 	return 0
 }

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -159,25 +159,53 @@ devserver_init :: proc(ds: ^Dev_Server, b: ^Bridge) {
 	ds.expected_host_v4   = fmt.aprintf("127.0.0.1:%d", bound_port)
 	ds.expected_host_name = fmt.aprintf("localhost:%d", bound_port)
 
-	// 0600 — owner read+write only. Previously .redin-port was 0644
-	// which leaked the bound port to anyone who could list the CWD.
-	// Testing helpers run as the same user, so 0600 doesn't regress
-	// them.
-	//
-	// write_private_no_follow refuses to write through a symlink — see
-	// issue #78 finding M1. If a stale symlink in CWD points at a
-	// sensitive file, the dev server logs and continues without writing
-	// rather than overwriting the link target.
-	port_str := fmt.tprintf("%d", bound_port)
-	if !write_private_no_follow(PORT_FILE, transmute([]u8)port_str) {
-		fmt.eprintfln("Warning: could not write %s (refused to follow non-regular path)", PORT_FILE)
-	}
-	if !write_private_no_follow(TOKEN_FILE, transmute([]u8)ds.auth_token) {
-		fmt.eprintfln("Warning: could not write %s (refused to follow non-regular path)", TOKEN_FILE)
+	if !write_port_and_token_files(ds, bound_port) {
+		// Helper has already cleared ds.running and printed a diagnostic.
+		// The TCP socket bound above stays open until devserver_destroy
+		// closes it; devserver_destroy is a no-op when ds.running is
+		// false, so close it explicitly here.
+		net.close(ds.tcp_sock)
+		return
 	}
 
 	ds.server_thread = thread.create_and_start_with_poly_data(ds, server_thread_proc, context)
 	fmt.printfln("Dev server listening on http://localhost:%d (auth token in %s)", bound_port, TOKEN_FILE)
+}
+
+// Writes .redin-port and .redin-token in the current working directory.
+//
+// 0600 — owner read+write only. Previously .redin-port was 0644 which
+// leaked the bound port to anyone who could list the CWD. Testing
+// helpers run as the same user, so 0600 doesn't regress them.
+//
+// write_private_no_follow refuses to write through a symlink — see
+// issue #78 finding M1. A stale symlink in CWD pointing at a sensitive
+// file would otherwise let an attacker redirect the write.
+//
+// On failure this clears ds.running so devserver_init's caller can
+// observe that startup aborted, removes any partial state (e.g. the
+// .redin-port that was written just before the token write failed),
+// and returns false. Failing fast beats logging a warning and
+// continuing: clients authenticate by reading .redin-token, so a
+// server that started without writing it would respond 401 to every
+// request — see issue #99 finding L2.
+@(private = "package")
+write_port_and_token_files :: proc(ds: ^Dev_Server, bound_port: int) -> bool {
+	port_str := fmt.tprintf("%d", bound_port)
+	if !write_private_no_follow(PORT_FILE, transmute([]u8)port_str) {
+		fmt.eprintfln("redin: failed to write %s; aborting dev server", PORT_FILE)
+		ds.running = false
+		return false
+	}
+	if !write_private_no_follow(TOKEN_FILE, transmute([]u8)ds.auth_token) {
+		fmt.eprintfln("redin: failed to write %s; aborting dev server", TOKEN_FILE)
+		// Clean up the port file we just wrote so it doesn't lie about
+		// a live server.
+		os.remove(PORT_FILE)
+		ds.running = false
+		return false
+	}
+	return true
 }
 
 devserver_destroy :: proc(ds: ^Dev_Server) {

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -248,6 +248,7 @@ server_thread_proc :: proc(ds: ^Dev_Server) {
 		// Read full request into buffer
 		total := 0
 		too_large := false
+		bad_request := false
 		timed_out := false
 		for {
 			if time.diff(time.now(), deadline) < 0 {
@@ -266,6 +267,10 @@ server_thread_proc :: proc(ds: ^Dev_Server) {
 					// Check Content-Length for body
 					cl := find_content_length(req_str[:header_end])
 					body_start := header_end + 4
+					if cl < 0 {
+						bad_request = true
+						break
+					}
 					if cl > MAX_BODY {
 						too_large = true
 						break
@@ -307,6 +312,13 @@ server_thread_proc :: proc(ds: ^Dev_Server) {
 
 		if too_large {
 			resp := "HTTP/1.1 413 Payload Too Large\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+			net.send_tcp(client, transmute([]u8)resp)
+			net.close(client)
+			continue
+		}
+
+		if bad_request {
+			resp := "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
 			net.send_tcp(client, transmute([]u8)resp)
 			net.close(client)
 			continue
@@ -528,9 +540,12 @@ find_content_length :: proc(headers: string) -> int {
 	if end < 0 do end = len(rest)
 	val := strings.trim_space(rest[:end])
 	n := 0
+	digits := 0
 	for c in val {
 		if c >= '0' && c <= '9' {
-			n = n * 10 + int(c - '0')
+			digits += 1
+			if digits > 12 { return -1 }
+			n = n*10 + int(c - '0')
 		} else {
 			break
 		}

--- a/src/redin/bridge/devserver_headers_test.odin
+++ b/src/redin/bridge/devserver_headers_test.odin
@@ -50,3 +50,23 @@ test_find_header_value_trims_whitespace :: proc(t: ^testing.T) {
 	headers := "GET / HTTP/1.1\r\nHost:    localhost:8800   \r\n"
 	testing.expect_value(t, find_header_value(headers, "host"), "localhost:8800")
 }
+
+@(test)
+test_find_content_length_overflow_returns_negative :: proc(t: ^testing.T) {
+	// 19 digits — well above 12-digit cap; current code silently wraps.
+	headers := "POST / HTTP/1.1\r\nContent-Length: 9999999999999999999\r\n"
+	testing.expect(t, find_content_length(headers) < 0,
+		"expected negative on overflow")
+}
+
+@(test)
+test_find_content_length_normal :: proc(t: ^testing.T) {
+	headers := "POST / HTTP/1.1\r\nContent-Length: 1024\r\n"
+	testing.expect_value(t, find_content_length(headers), 1024)
+}
+
+@(test)
+test_find_content_length_zero :: proc(t: ^testing.T) {
+	headers := "GET / HTTP/1.1\r\nContent-Length: 0\r\n"
+	testing.expect_value(t, find_content_length(headers), 0)
+}

--- a/src/redin/bridge/devserver_headers_test.odin
+++ b/src/redin/bridge/devserver_headers_test.odin
@@ -53,10 +53,12 @@ test_find_header_value_trims_whitespace :: proc(t: ^testing.T) {
 
 @(test)
 test_find_content_length_overflow_returns_negative :: proc(t: ^testing.T) {
-	// 19 digits — well above 12-digit cap; current code silently wraps.
-	headers := "POST / HTTP/1.1\r\nContent-Length: 9999999999999999999\r\n"
+	// 13 digits — exceeds the 12-digit cap but well within int64 range,
+	// so the unpatched parser would have returned 1_000_000_000_000 (positive)
+	// and slipped past MAX_BODY checks. Patched parser must return -1.
+	headers := "POST / HTTP/1.1\r\nContent-Length: 1000000000000\r\n"
 	testing.expect(t, find_content_length(headers) < 0,
-		"expected negative on overflow")
+		"expected negative when digit count exceeds 12-digit cap")
 }
 
 @(test)

--- a/src/redin/bridge/devserver_write_test.odin
+++ b/src/redin/bridge/devserver_write_test.odin
@@ -74,6 +74,60 @@ test_write_private_no_follow_refuses_symlink :: proc(t: ^testing.T) {
 	testing.expect_value(t, got, sentinel)
 }
 
+// Regression test for issue #99 finding L2: the dev server must abort
+// startup if .redin-port or .redin-token cannot be written. Previously
+// it logged a warning and kept running, which produced silent 401
+// responses on every request because clients authenticate by reading
+// .redin-token from disk.
+//
+// Forces a write failure by planting a directory at .redin-token in
+// the test's CWD: write_private_no_follow opens with O_NOFOLLOW|O_EXCL,
+// gets EEXIST, lstats and rejects anything that isn't a regular file.
+@(test)
+test_write_port_and_token_aborts_on_failure :: proc(t: ^testing.T) {
+	original_cwd, cwd_err := os.getwd(context.temp_allocator)
+	if cwd_err != nil {
+		testing.fail_now(t, fmt.tprintf("getwd failed: %v", cwd_err))
+	}
+	defer os.chdir(original_cwd)
+
+	tmp_dir := make_tmp_path("write_abort_dir")
+	defer delete(tmp_dir)
+	if mkerr := os.make_directory(tmp_dir); mkerr != nil {
+		testing.fail_now(t, fmt.tprintf("make_directory(%s) failed: %v", tmp_dir, mkerr))
+	}
+	defer os.remove(tmp_dir)
+
+	if cherr := os.chdir(tmp_dir); cherr != nil {
+		testing.fail_now(t, fmt.tprintf("chdir(%s) failed: %v", tmp_dir, cherr))
+	}
+
+	// Plant a directory at TOKEN_FILE so write_private_no_follow refuses it.
+	// PORT_FILE is left unplanted so the helper succeeds at writing it
+	// first, then fails on the token write — exercising the cleanup path.
+	if mkerr := os.make_directory(TOKEN_FILE); mkerr != nil {
+		testing.fail_now(t, fmt.tprintf("planting directory at %s failed: %v", TOKEN_FILE, mkerr))
+	}
+	defer os.remove(TOKEN_FILE)
+	defer os.remove(PORT_FILE) // helper writes this before failing on token
+
+	ds := Dev_Server{
+		running    = true,
+		auth_token = "test_token_value",
+	}
+
+	ok := write_port_and_token_files(&ds, 9999)
+	testing.expect(t, !ok, "write_port_and_token_files must return false when token write fails")
+	testing.expect(t, !ds.running, "ds.running must be cleared after a write failure")
+
+	// .redin-port must be cleaned up so it doesn't advertise a server
+	// that never finished standing up.
+	if _, stat_err := os.stat(PORT_FILE, context.temp_allocator); stat_err == nil {
+		testing.fail(t)
+		fmt.println("PORT_FILE was not cleaned up after token write failure")
+	}
+}
+
 @(test)
 test_write_private_no_follow_replaces_stale_regular_file :: proc(t: ^testing.T) {
 	// A previous dev run that crashed leaves .redin-token behind as a

--- a/src/redin/bridge/http_client.odin
+++ b/src/redin/bridge/http_client.odin
@@ -5,6 +5,7 @@ import "core:fmt"
 import "core:strings"
 import "core:sync"
 import "core:thread"
+import "core:time"
 import http "lib:odin-http"
 import http_client "lib:odin-http/client"
 
@@ -14,6 +15,12 @@ import http_client "lib:odin-http/client"
 // read. Issue #78 finding M2: previously unbounded — a malicious or
 // misbehaving remote could exhaust host memory.
 HTTP_MAX_BODY :: 16 * 1024 * 1024 // 16 MiB
+
+// Per-request deadline (ms). Used when the caller doesn't supply
+// Http_Request.timeout_ms (or supplies <=0). The Fennel :http effect
+// handler always passes a value (default 30000), so this only kicks in
+// for direct Odin callers (e.g. tests). Issue #99 M1 A.
+HTTP_DEFAULT_TIMEOUT_MS :: 30_000
 
 @(private = "file")
 header_safe :: proc(s: string) -> bool {
@@ -55,11 +62,12 @@ url_host :: proc(url: string) -> string {
 }
 
 Http_Request :: struct {
-	id:      string,
-	url:     string,
-	method:  string,
-	headers: map[string]string,
-	body:    string,
+	id:         string,
+	url:        string,
+	method:     string,
+	headers:    map[string]string,
+	body:       string,
+	timeout_ms: int,
 }
 
 Http_Response :: struct {
@@ -70,9 +78,22 @@ Http_Response :: struct {
 	error_msg: string,
 }
 
+// Per-in-flight-request entry tracked on Http_Client.pending. The id_owned
+// string is the same allocation as the map key — when the entry is removed
+// (either by the worker on completion, or by the poll-loop sweep on
+// timeout) the freer must `delete_key` first then `delete(id_owned)`. The
+// map's deletion does not free the key string.
+@(private = "file")
+Pending_Http :: struct {
+	id_owned: string,
+	deadline: time.Time,
+}
+
 Http_Client :: struct {
 	results:       [dynamic]Http_Response,
 	results_mutex: sync.Mutex,
+	pending:       map[string]Pending_Http,
+	pending_mutex: sync.Mutex,
 }
 
 http_client_init :: proc(hc: ^Http_Client) {
@@ -85,6 +106,18 @@ http_client_destroy :: proc(hc: ^Http_Client) {
 	}
 	delete(hc.results)
 	sync.unlock(&hc.results_mutex)
+
+	// Free remaining pending entries. In-flight workers may still hold a
+	// pointer to hc and try to lock pending_mutex on completion — that's
+	// caller's responsibility to avoid (don't destroy while requests are
+	// outstanding). For tests, the timeout sweep before destroy + the
+	// 200ms test deadline ensures the pending map is empty by here.
+	sync.lock(&hc.pending_mutex)
+	for _, entry in hc.pending {
+		delete(entry.id_owned)
+	}
+	delete(hc.pending)
+	sync.unlock(&hc.pending_mutex)
 }
 
 http_response_destroy :: proc(r: ^Http_Response) {
@@ -104,6 +137,18 @@ Http_Thread_Data :: struct {
 }
 
 http_client_request :: proc(hc: ^Http_Client, req: Http_Request) {
+	timeout := req.timeout_ms <= 0 ? HTTP_DEFAULT_TIMEOUT_MS : req.timeout_ms
+
+	// Clone req.id for the pending map. The same allocation is used as
+	// both the map key and id_owned, so a single delete frees both.
+	id_clone := strings.clone(req.id)
+	sync.lock(&hc.pending_mutex)
+	hc.pending[id_clone] = Pending_Http{
+		id_owned = id_clone,
+		deadline = time.time_add(time.now(), time.Duration(timeout) * time.Millisecond),
+	}
+	sync.unlock(&hc.pending_mutex)
+
 	data := new(Http_Thread_Data)
 	data.client = hc
 	data.request = req
@@ -111,6 +156,43 @@ http_client_request :: proc(hc: ^Http_Client, req: Http_Request) {
 }
 
 http_client_poll :: proc(hc: ^Http_Client, results: ^[dynamic]Http_Response) {
+	now := time.now()
+
+	// Phase 1: identify timed-out pending entries and remove them. Each
+	// timed-out id_owned string is transferred to the synthesized
+	// Http_Response below — do NOT clone, do NOT free here.
+	timed_out_ids: [dynamic]string
+	defer delete(timed_out_ids)
+
+	sync.lock(&hc.pending_mutex)
+	for _, entry in hc.pending {
+		if time.diff(now, entry.deadline) <= 0 {
+			append(&timed_out_ids, entry.id_owned)
+		}
+	}
+	for id in timed_out_ids {
+		delete_key(&hc.pending, id)
+	}
+	sync.unlock(&hc.pending_mutex)
+
+	// Phase 2: synthesize timeout responses. Ownership of id (the
+	// erstwhile id_owned) transfers into Http_Response.id; the caller's
+	// http_response_destroy will delete(r.id).
+	if len(timed_out_ids) > 0 {
+		sync.lock(&hc.results_mutex)
+		for id in timed_out_ids {
+			r := Http_Response{
+				id        = id,
+				status    = 0,
+				error_msg = strings.clone("http timeout exceeded"),
+				headers   = make(map[string]string),
+			}
+			append(&hc.results, r)
+		}
+		sync.unlock(&hc.results_mutex)
+	}
+
+	// Phase 3: drain the results buffer to the caller.
 	sync.lock(&hc.results_mutex)
 	defer sync.unlock(&hc.results_mutex)
 	for &r in hc.results {
@@ -124,9 +206,27 @@ http_thread_proc :: proc(raw_data_ptr: rawptr) {
 	data := cast(^Http_Thread_Data)raw_data_ptr
 	response := execute_http_request(data.request)
 
-	sync.lock(&data.client.results_mutex)
-	append(&data.client.results, response)
-	sync.unlock(&data.client.results_mutex)
+	// Re-check the registry on completion. If the entry is gone, the
+	// poll loop has already synthesized a timeout result for this id —
+	// drop ours on the floor. Otherwise remove our entry and surface
+	// the response.
+	keep := false
+	sync.lock(&data.client.pending_mutex)
+	if entry, ok := data.client.pending[data.request.id]; ok {
+		delete_key(&data.client.pending, data.request.id)
+		delete(entry.id_owned)
+		keep = true
+	}
+	sync.unlock(&data.client.pending_mutex)
+
+	if keep {
+		sync.lock(&data.client.results_mutex)
+		append(&data.client.results, response)
+		sync.unlock(&data.client.results_mutex)
+	} else {
+		// Entry was already replaced by a timeout. Discard the result.
+		http_response_destroy(&response)
+	}
 
 	http_request_destroy(&data.request)
 	free(data)

--- a/src/redin/bridge/http_client.odin
+++ b/src/redin/bridge/http_client.odin
@@ -23,6 +23,32 @@ header_safe :: proc(s: string) -> bool {
 	return true
 }
 
+@(private = "file")
+url_host :: proc(url: string) -> string {
+	// "http://host:port/path" → "host"
+	idx := strings.index(url, "://")
+	if idx < 0 do return ""
+	rest := url[idx + 3:]
+	end := len(rest)
+	for i in 0 ..< len(rest) {
+		c := rest[i]
+		if c == '/' || c == '?' || c == '#' { end = i; break }
+	}
+	host := rest[:end]
+	// Strip IPv6 brackets if present, before stripping port.
+	if strings.has_prefix(host, "[") {
+		if rb := strings.index_byte(host, ']'); rb >= 0 {
+			return host[1:rb]  // [::1]:8080 → ::1
+		}
+		return host  // malformed; return as-is
+	}
+	// Strip port.
+	if colon := strings.last_index_byte(host, ':'); colon >= 0 {
+		host = host[:colon]
+	}
+	return host
+}
+
 Http_Request :: struct {
 	id:      string,
 	url:     string,
@@ -125,6 +151,16 @@ execute_http_request :: proc(req: Http_Request) -> Http_Response {
 		if scheme != "http" && scheme != "https" {
 			response.status = 0
 			response.error_msg = strings.clone("http scheme must be http or https")
+			return response
+		}
+	}
+
+	// Whitelist guard. Opt-in via bridge.set_http_whitelist. M4 from issue #99.
+	{
+		host := url_host(req.url)
+		if rejected, ok := http_whitelist_check(host); !ok {
+			response.status = 0
+			response.error_msg = fmt.aprintf("host %s not in http whitelist", rejected)
 			return response
 		}
 	}

--- a/src/redin/bridge/http_client.odin
+++ b/src/redin/bridge/http_client.odin
@@ -192,8 +192,13 @@ http_client_request :: proc(hc: ^Http_Client, req: Http_Request) {
 	// In-flight cap. Soft check: two simultaneous submitters could both
 	// see `inflight = 63` and both proceed, briefly reaching 65. That's
 	// fine — we're enforcing a soft cap, not a hard one. Issue #99 M1 B.
+	// We also peek at `destroying` under the same lock so a request issued
+	// concurrently with http_client_destroy can't write into a freed
+	// pending map. Production callers are main-thread only; this hardens
+	// the contract for callers on other threads.
 	sync.lock(&hc.pending_mutex)
 	inflight := len(hc.pending)
+	shutting_down := hc.destroying
 	sync.unlock(&hc.pending_mutex)
 
 	if inflight >= MAX_INFLIGHT_HTTP {
@@ -210,6 +215,21 @@ http_client_request :: proc(hc: ^Http_Client, req: Http_Request) {
 		append(&hc.results, r)
 		sync.unlock(&hc.results_mutex)
 		// We own the request strings; free them since no worker will run.
+		req := req
+		http_request_destroy(&req)
+		return
+	}
+
+	if shutting_down {
+		r := Http_Response{
+			id        = req.id,
+			status    = 0,
+			error_msg = strings.clone("http client shutting down"),
+			headers   = make(map[string]string),
+		}
+		sync.lock(&hc.results_mutex)
+		append(&hc.results, r)
+		sync.unlock(&hc.results_mutex)
 		req := req
 		http_request_destroy(&req)
 		return

--- a/src/redin/bridge/http_client.odin
+++ b/src/redin/bridge/http_client.odin
@@ -15,6 +15,14 @@ import http_client "lib:odin-http/client"
 // misbehaving remote could exhaust host memory.
 HTTP_MAX_BODY :: 16 * 1024 * 1024 // 16 MiB
 
+@(private = "file")
+header_safe :: proc(s: string) -> bool {
+	for r in s {
+		if r == '\r' || r == '\n' || r == 0 do return false
+	}
+	return true
+}
+
 Http_Request :: struct {
 	id:      string,
 	url:     string,
@@ -133,6 +141,14 @@ execute_http_request :: proc(req: Http_Request) -> Http_Response {
 	http_req: http_client.Request
 	http_client.request_init(&http_req, method)
 	defer http_client.request_destroy(&http_req)
+
+	for k, v in req.headers {
+		if !header_safe(k) || !header_safe(v) {
+			response.status = 0
+			response.error_msg = strings.clone("http header contains invalid character")
+			return response
+		}
+	}
 
 	for k, v in req.headers {
 		http.headers_set(&http_req.headers, k, v)

--- a/src/redin/bridge/http_client.odin
+++ b/src/redin/bridge/http_client.odin
@@ -2,6 +2,7 @@ package bridge
 
 import "core:bytes"
 import "core:fmt"
+import "core:log"
 import "core:strings"
 import "core:sync"
 import "core:thread"
@@ -21,6 +22,12 @@ HTTP_MAX_BODY :: 16 * 1024 * 1024 // 16 MiB
 // handler always passes a value (default 30000), so this only kicks in
 // for direct Odin callers (e.g. tests). Issue #99 M1 A.
 HTTP_DEFAULT_TIMEOUT_MS :: 30_000
+
+// Cap on concurrent in-flight HTTP requests. Submissions beyond the cap
+// fail synchronously with a synthesized error response. Soft cap: a
+// brief race between the inflight check and the registry insert can
+// allow up to N+(concurrent submitters - 1). Issue #99 M1 B.
+MAX_INFLIGHT_HTTP :: 64
 
 @(private = "file")
 header_safe :: proc(s: string) -> bool {
@@ -94,30 +101,75 @@ Http_Client :: struct {
 	results_mutex: sync.Mutex,
 	pending:       map[string]Pending_Http,
 	pending_mutex: sync.Mutex,
+	// Set by http_client_destroy to signal in-flight workers to bail
+	// without touching `results` or freeing state we'll free below.
+	// Read/written under `pending_mutex`. Issue #99 M1 B.
+	destroying:    bool,
+	// Atomic counter of workers that have begun execute_http_request and
+	// not yet completed their cleanup. Drain waits for this to reach 0
+	// before tearing down so workers don't UAF the client. Distinct from
+	// `len(pending)` because the timeout sweep removes pending entries
+	// while the worker is still running. Issue #99 M1 B.
+	workers_alive: i32,
 }
 
 http_client_init :: proc(hc: ^Http_Client) {
 }
 
 http_client_destroy :: proc(hc: ^Http_Client) {
-	sync.lock(&hc.results_mutex)
-	for &r in hc.results {
-		http_response_destroy(&r)
+	// Signal workers to bail on completion. They re-check `destroying`
+	// under `pending_mutex` after `execute_http_request` returns and
+	// decrement `workers_alive` LAST, so a worker count of 0 means no
+	// worker holds a pointer into `hc`.
+	sync.lock(&hc.pending_mutex)
+	hc.destroying = true
+	sync.unlock(&hc.pending_mutex)
+
+	// Wait for all in-flight workers to complete their cleanup. We watch
+	// `workers_alive` (atomic) rather than `len(pending)` because the
+	// timeout sweep removes pending entries while the worker thread is
+	// still running its HTTP I/O. Cap the wait so a stuck remote doesn't
+	// hang shutdown forever.
+	deadline := time.time_add(time.now(), 3 * time.Second)
+	for {
+		if sync.atomic_load(&hc.workers_alive) == 0 do break
+		if time.diff(time.now(), deadline) <= 0 do break
+		time.sleep(10 * time.Millisecond)
+
+		// Sweep timed-out entries while we wait, so workers blocked
+		// reading the response notice (their HTTP call may eventually
+		// fail naturally; the sweep at least keeps the registry tidy).
+		dummy: [dynamic]Http_Response
+		http_client_poll(hc, &dummy)
+		for &r in dummy do http_response_destroy(&r)
+		delete(dummy)
 	}
+
+	// Final cleanup. Anything still alive is a worker we couldn't drain
+	// — log and leak (better than UAF when the worker eventually
+	// returns).
+	leaked := sync.atomic_load(&hc.workers_alive)
+	if leaked > 0 {
+		fmt.eprintfln("redin: warning: %d HTTP worker(s) still in flight at shutdown; leaking their state", leaked)
+	}
+
+	sync.lock(&hc.results_mutex)
+	for &r in hc.results do http_response_destroy(&r)
 	delete(hc.results)
 	sync.unlock(&hc.results_mutex)
 
-	// Free remaining pending entries. In-flight workers may still hold a
-	// pointer to hc and try to lock pending_mutex on completion — that's
-	// caller's responsibility to avoid (don't destroy while requests are
-	// outstanding). For tests, the timeout sweep before destroy + the
-	// 200ms test deadline ensures the pending map is empty by here.
-	sync.lock(&hc.pending_mutex)
-	for _, entry in hc.pending {
-		delete(entry.id_owned)
+	if leaked == 0 {
+		// All workers completed their cleanup; safe to free the pending
+		// map. Any remaining entries (from timeout sweep removals where
+		// the worker had already decremented workers_alive) own no live
+		// references at this point.
+		sync.lock(&hc.pending_mutex)
+		for _, entry in hc.pending do delete(entry.id_owned)
+		delete(hc.pending)
+		sync.unlock(&hc.pending_mutex)
 	}
-	delete(hc.pending)
-	sync.unlock(&hc.pending_mutex)
+	// Otherwise we deliberately leak `hc.pending` — workers may still
+	// look at it. Leaked entries leak with the Http_Client.
 }
 
 http_response_destroy :: proc(r: ^Http_Response) {
@@ -137,6 +189,32 @@ Http_Thread_Data :: struct {
 }
 
 http_client_request :: proc(hc: ^Http_Client, req: Http_Request) {
+	// In-flight cap. Soft check: two simultaneous submitters could both
+	// see `inflight = 63` and both proceed, briefly reaching 65. That's
+	// fine — we're enforcing a soft cap, not a hard one. Issue #99 M1 B.
+	sync.lock(&hc.pending_mutex)
+	inflight := len(hc.pending)
+	sync.unlock(&hc.pending_mutex)
+
+	if inflight >= MAX_INFLIGHT_HTTP {
+		// Move req.id into the rejection response (mirrors execute_http_request,
+		// which consumes req.id into response.id). http_request_destroy below
+		// then frees the rest of the request's allocations.
+		r := Http_Response{
+			id        = req.id,
+			status    = 0,
+			error_msg = strings.clone("too many concurrent http requests (cap 64)"),
+			headers   = make(map[string]string),
+		}
+		sync.lock(&hc.results_mutex)
+		append(&hc.results, r)
+		sync.unlock(&hc.results_mutex)
+		// We own the request strings; free them since no worker will run.
+		req := req
+		http_request_destroy(&req)
+		return
+	}
+
 	timeout := req.timeout_ms <= 0 ? HTTP_DEFAULT_TIMEOUT_MS : req.timeout_ms
 
 	// Clone req.id for the pending map. The same allocation is used as
@@ -152,7 +230,18 @@ http_client_request :: proc(hc: ^Http_Client, req: Http_Request) {
 	data := new(Http_Thread_Data)
 	data.client = hc
 	data.request = req
-	thread.create_and_start_with_data(data, http_thread_proc, self_cleanup = true)
+	// Pass the caller's context so the worker frees strings/maps with the
+	// same allocator that allocated them. Without this, the worker uses
+	// `runtime.default_context()` (heap), which corrupts metadata when the
+	// caller used a different allocator (e.g. the rollback stack the Odin
+	// test runner installs per-test). Logger is suppressed because
+	// odin-http logs Connection_Closed at log.errorf, which the test
+	// runner counts as a test failure even when it's the expected
+	// outcome of a slow/flaky remote.
+	worker_ctx := context
+	worker_ctx.logger = log.nil_logger()
+	sync.atomic_add(&hc.workers_alive, 1)
+	thread.create_and_start_with_data(data, http_thread_proc, init_context = worker_ctx, self_cleanup = true)
 }
 
 http_client_poll :: proc(hc: ^Http_Client, results: ^[dynamic]Http_Response) {
@@ -206,12 +295,34 @@ http_thread_proc :: proc(raw_data_ptr: rawptr) {
 	data := cast(^Http_Thread_Data)raw_data_ptr
 	response := execute_http_request(data.request)
 
+	sync.lock(&data.client.pending_mutex)
+	if data.client.destroying {
+		// Client is being torn down. Don't touch results; just remove
+		// our entry to allow the drain loop to make progress. Any
+		// synthesized timeout response in `results` for this id has
+		// already been drained by the destroy path's polling sweep;
+		// nothing to clean up there.
+		if entry, ok := data.client.pending[data.request.id]; ok {
+			delete_key(&data.client.pending, data.request.id)
+			delete(entry.id_owned)
+		}
+		sync.unlock(&data.client.pending_mutex)
+		http_response_destroy(&response)
+		http_request_destroy(&data.request)
+		client := data.client
+		free(data)
+		// Decrement workers_alive LAST so that the drain loop doesn't
+		// observe 0 and free the client while we still hold pointers
+		// into it.
+		sync.atomic_sub(&client.workers_alive, 1)
+		return
+	}
+
 	// Re-check the registry on completion. If the entry is gone, the
 	// poll loop has already synthesized a timeout result for this id —
 	// drop ours on the floor. Otherwise remove our entry and surface
 	// the response.
 	keep := false
-	sync.lock(&data.client.pending_mutex)
 	if entry, ok := data.client.pending[data.request.id]; ok {
 		delete_key(&data.client.pending, data.request.id)
 		delete(entry.id_owned)
@@ -229,7 +340,9 @@ http_thread_proc :: proc(raw_data_ptr: rawptr) {
 	}
 
 	http_request_destroy(&data.request)
+	client := data.client
 	free(data)
+	sync.atomic_sub(&client.workers_alive, 1)
 }
 
 @(private = "file")

--- a/src/redin/bridge/http_client.odin
+++ b/src/redin/bridge/http_client.odin
@@ -118,6 +118,17 @@ execute_http_request :: proc(req: Http_Request) -> Http_Response {
 	response.id = req.id
 	response.headers = make(map[string]string)
 
+	// Scheme guard. Always-on; not opt-out. M4 from issue #99.
+	{
+		colon := strings.index_byte(req.url, ':')
+		scheme := colon < 0 ? "" : strings.to_lower(req.url[:colon], context.temp_allocator)
+		if scheme != "http" && scheme != "https" {
+			response.status = 0
+			response.error_msg = strings.clone("http scheme must be http or https")
+			return response
+		}
+	}
+
 	method: http.Method
 	lower_method := strings.to_lower(req.method)
 	defer delete(lower_method)

--- a/src/redin/bridge/http_client.odin
+++ b/src/redin/bridge/http_client.odin
@@ -35,6 +35,11 @@ url_host :: proc(url: string) -> string {
 		if c == '/' || c == '?' || c == '#' { end = i; break }
 	}
 	host := rest[:end]
+	// Strip userinfo: "user:pass@host" → "host". Last `@` since password may
+	// itself be percent-encoded but cannot contain a literal `@`.
+	if at := strings.last_index_byte(host, '@'); at >= 0 {
+		host = host[at+1:]
+	}
 	// Strip IPv6 brackets if present, before stripping port.
 	if strings.has_prefix(host, "[") {
 		if rb := strings.index_byte(host, ']'); rb >= 0 {

--- a/src/redin/bridge/http_client.odin
+++ b/src/redin/bridge/http_client.odin
@@ -78,13 +78,13 @@ Http_Response :: struct {
 	error_msg: string,
 }
 
-// Per-in-flight-request entry tracked on Http_Client.pending. The id_owned
-// string is the same allocation as the map key — when the entry is removed
-// (either by the worker on completion, or by the poll-loop sweep on
-// timeout) the freer must `delete_key` first then `delete(id_owned)`. The
-// map's deletion does not free the key string.
 @(private = "file")
 Pending_Http :: struct {
+	// The `id_owned` string is the same allocation as the map key for
+	// this entry; freeing it once after `delete_key` releases both.
+	// This is independent of the caller-supplied `req.id`, which is
+	// owned by the worker's `Http_Response` and freed via
+	// `http_response_destroy`. Don't try to dedupe them.
 	id_owned: string,
 	deadline: time.Time,
 }

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -505,7 +505,7 @@ test_http_inflight_cap_rejects :: proc(t: ^testing.T) {
 			id = strings.clone(fmt.tprintf("cap-%d", i)),
 			url = strings.clone(fmt.tprintf("http://127.0.0.1:%d/", m.port)),
 			method = strings.clone("GET"),
-			timeout_ms = 5000,
+			timeout_ms = 1500,
 		}
 		http_client_request(&hc, req)
 	}
@@ -513,7 +513,7 @@ test_http_inflight_cap_rejects :: proc(t: ^testing.T) {
 		id = strings.clone("cap-over"),
 		url = strings.clone(fmt.tprintf("http://127.0.0.1:%d/", m.port)),
 		method = strings.clone("GET"),
-		timeout_ms = 5000,
+		timeout_ms = 1500,
 	}
 	http_client_request(&hc, overflow)
 

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -362,20 +362,11 @@ test_http_whitelist_hostname_case_insensitive :: proc(t: ^testing.T) {
 	set_http_whitelist([]string{"Example.COM"})
 	defer set_http_whitelist(nil)
 
-	req := Http_Request{
-		id = strings.clone("wl-3"),
-		url = strings.clone("http://example.com/"),
-		method = strings.clone("GET"),
-	}
-	defer { delete(req.id); delete(req.url); delete(req.method) }
-	got := execute_http_request(req)
-	defer {
-		delete(got.body); delete(got.error_msg)
-		for k, v in got.headers { delete(k); delete(v) }
-		delete(got.headers)
-	}
-	testing.expect(t, !strings.contains(got.error_msg, "whitelist"),
-		"hostname compare should be case-insensitive")
+	// Direct check against the whitelist function — proves case-insensitive
+	// matching without requiring DNS or a network round-trip.
+	rejected, ok := http_whitelist_check("example.com")
+	testing.expect(t, ok, "case-insensitive match should accept lowercased host")
+	testing.expect_value(t, rejected, "")
 }
 
 @(test)
@@ -404,4 +395,24 @@ test_http_whitelist_cidr_match :: proc(t: ^testing.T) {
 		delete(got.headers)
 	}
 	testing.expect_value(t, got.status, 200)
+}
+
+@(test)
+test_http_whitelist_ipv6_cidr_match :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+
+	set_http_whitelist([]string{"2001:db8::/32"})
+	defer set_http_whitelist(nil)
+
+	{
+		rejected, ok := http_whitelist_check("2001:db8:1234::1")
+		testing.expect(t, ok, "IPv6 inside the /32 should match")
+		testing.expect_value(t, rejected, "")
+	}
+	{
+		rejected, ok := http_whitelist_check("2001:db9::1")
+		testing.expect(t, !ok, "IPv6 outside the /32 must not match")
+		testing.expect_value(t, rejected, "2001:db9::1")
+	}
 }

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -120,3 +120,65 @@ test_http_response_cap_rejects_oversized_content_length :: proc(t: ^testing.T) {
 	testing.expect(t, strings.contains(got.error_msg, "too large"),
 		fmt.tprintf("expected error_msg to mention 'too large', got %q", got.error_msg))
 }
+
+@(test)
+test_http_header_value_rejects_crlf :: proc(t: ^testing.T) {
+	headers := make(map[string]string)
+	headers[strings.clone("X-Smuggle")] = strings.clone("evil\r\nHost: attacker")
+	defer {
+		for k, v in headers { delete(k); delete(v) }
+		delete(headers)
+	}
+
+	req := Http_Request{
+		id      = strings.clone("crlf-test"),
+		url     = strings.clone("http://127.0.0.1:1/"),
+		method  = strings.clone("GET"),
+		headers = headers,
+	}
+	defer {
+		delete(req.id); delete(req.url); delete(req.method)
+	}
+
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+
+	testing.expect(t, got.status == 0, "expected synthesized error status 0")
+	testing.expect(t, strings.contains(got.error_msg, "invalid character"),
+		fmt.tprintf("expected 'invalid character' in error_msg, got %q", got.error_msg))
+}
+
+@(test)
+test_http_header_key_rejects_nul :: proc(t: ^testing.T) {
+	headers := make(map[string]string)
+	headers[strings.clone("X-Bad\x00key")] = strings.clone("ok")
+	defer {
+		for k, v in headers { delete(k); delete(v) }
+		delete(headers)
+	}
+
+	req := Http_Request{
+		id      = strings.clone("nul-test"),
+		url     = strings.clone("http://127.0.0.1:1/"),
+		method  = strings.clone("GET"),
+		headers = headers,
+	}
+	defer {
+		delete(req.id); delete(req.url); delete(req.method)
+	}
+
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+
+	testing.expect(t, got.status == 0, "expected synthesized error status 0")
+	testing.expect(t, strings.contains(got.error_msg, "invalid character"),
+		fmt.tprintf("expected 'invalid character' in error_msg, got %q", got.error_msg))
+}

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -209,3 +209,62 @@ test_http_redirect_not_followed :: proc(t: ^testing.T) {
 
 	testing.expect_value(t, got.status, 302)
 }
+
+@(test)
+test_http_rejects_ftp_scheme :: proc(t: ^testing.T) {
+	req := Http_Request{
+		id = strings.clone("scheme-1"),
+		url = strings.clone("ftp://example.com/"),
+		method = strings.clone("GET"),
+	}
+	defer { delete(req.id); delete(req.url); delete(req.method) }
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+	testing.expect_value(t, got.status, 0)
+	testing.expect(t, strings.contains(got.error_msg, "scheme"),
+		fmt.tprintf("expected 'scheme' in error_msg, got %q", got.error_msg))
+}
+
+@(test)
+test_http_rejects_file_scheme :: proc(t: ^testing.T) {
+	req := Http_Request{
+		id = strings.clone("scheme-2"),
+		url = strings.clone("file:///etc/passwd"),
+		method = strings.clone("GET"),
+	}
+	defer { delete(req.id); delete(req.url); delete(req.method) }
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+	testing.expect_value(t, got.status, 0)
+	testing.expect(t, strings.contains(got.error_msg, "scheme"),
+		"expected scheme rejection error_msg")
+}
+
+@(test)
+test_http_accepts_uppercase_https :: proc(t: ^testing.T) {
+	// Just confirms scheme matching is case-insensitive — no real connect.
+	// We expect a connect error (status 0, error_msg contains "Request failed"
+	// or similar), NOT the scheme-rejection error_msg.
+	req := Http_Request{
+		id = strings.clone("scheme-3"),
+		url = strings.clone("HTTPS://127.0.0.1:1/"),
+		method = strings.clone("GET"),
+	}
+	defer { delete(req.id); delete(req.url); delete(req.method) }
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+	testing.expect(t, !strings.contains(got.error_msg, "scheme"),
+		"HTTPS (uppercase) must not be rejected as scheme")
+}

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -481,6 +481,13 @@ test_http_timeout_fires :: proc(t: ^testing.T) {
 }
 
 @(test)
+// Known leak: the 64 in-flight workers are blocked in odin-http's
+// http_client.request, which has no cancellation knob. http_client_destroy
+// waits 3 s for them to drain via the timeout sweep, then logs and gives up.
+// The tracking allocator reports each worker's scanner buffer (~4 KiB) as
+// leaked. Eliminating this requires either modifying odin-http (vendored,
+// out of scope) or tracking + closing pending sockets from destroy
+// (substantial change). The leak is bounded and shutdown-only.
 test_http_inflight_cap_rejects :: proc(t: ^testing.T) {
 	sync.lock(&g_test_http_state_mutex)
 	defer sync.unlock(&g_test_http_state_mutex)

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -182,3 +182,30 @@ test_http_header_key_rejects_nul :: proc(t: ^testing.T) {
 	testing.expect(t, strings.contains(got.error_msg, "invalid character"),
 		fmt.tprintf("expected 'invalid character' in error_msg, got %q", got.error_msg))
 }
+
+@(test)
+test_http_redirect_not_followed :: proc(t: ^testing.T) {
+	resp := "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:1/elsewhere\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+	m := mock_start(resp)
+	if m == nil {
+		testing.fail_now(t, "could not bind a mock server port")
+	}
+	defer mock_stop(m)
+
+	url := fmt.tprintf("http://127.0.0.1:%d/", m.port)
+	req := Http_Request{
+		id = strings.clone("redirect-test"),
+		url = strings.clone(url),
+		method = strings.clone("GET"),
+	}
+	defer { delete(req.id); delete(req.url); delete(req.method) }
+
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+
+	testing.expect_value(t, got.status, 302)
+}

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -479,3 +479,103 @@ test_http_timeout_fires :: proc(t: ^testing.T) {
 			fmt.tprintf("expected 'timeout' in error_msg, got %q", results[0].error_msg))
 	}
 }
+
+@(test)
+test_http_inflight_cap_rejects :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+
+	hc: Http_Client
+	http_client_init(&hc)
+	defer http_client_destroy(&hc)
+
+	// Spin up a slow mock so the requests stay in flight.
+	m := new(Mock_Server)
+	for p in 18900 ..< 19000 {
+		s, e := net.listen_tcp(net.Endpoint{address = net.IP4_Loopback, port = p})
+		if e == nil { m.sock = s; m.port = p; break }
+	}
+	if m.port == 0 { testing.fail_now(t, "no port") }
+	m.thread = thread.create_and_start_with_poly_data(m, slow_mock_serve, context)
+	defer mock_stop(m)
+
+	// Submit MAX_INFLIGHT_HTTP requests + 1; the +1 must be rejected.
+	for i in 0 ..< MAX_INFLIGHT_HTTP {
+		req := Http_Request{
+			id = strings.clone(fmt.tprintf("cap-%d", i)),
+			url = strings.clone(fmt.tprintf("http://127.0.0.1:%d/", m.port)),
+			method = strings.clone("GET"),
+			timeout_ms = 5000,
+		}
+		http_client_request(&hc, req)
+	}
+	overflow := Http_Request{
+		id = strings.clone("cap-over"),
+		url = strings.clone(fmt.tprintf("http://127.0.0.1:%d/", m.port)),
+		method = strings.clone("GET"),
+		timeout_ms = 5000,
+	}
+	http_client_request(&hc, overflow)
+
+	// Poll briefly for the rejected response.
+	deadline := time.time_add(time.now(), 500 * time.Millisecond)
+	results: [dynamic]Http_Response
+	defer { for &r in results do http_response_destroy(&r); delete(results) }
+	for time.diff(time.now(), deadline) > 0 {
+		http_client_poll(&hc, &results)
+		if len(results) >= 1 do break
+		time.sleep(20 * time.Millisecond)
+	}
+
+	found := false
+	for r in results {
+		if r.id == "cap-over" && strings.contains(r.error_msg, "concurrent") {
+			found = true; break
+		}
+	}
+	testing.expect(t, found, "expected overflow request to be rejected with 'concurrent' error")
+}
+
+@(test)
+test_http_destroy_drains_or_times_out :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+
+	hc := new(Http_Client)
+	http_client_init(hc)
+
+	m := new(Mock_Server)
+	for p in 18900 ..< 19000 {
+		s, e := net.listen_tcp(net.Endpoint{address = net.IP4_Loopback, port = p})
+		if e == nil { m.sock = s; m.port = p; break }
+	}
+	if m.port == 0 { testing.fail_now(t, "no port") }
+	m.thread = thread.create_and_start_with_poly_data(m, slow_mock_serve, context)
+	defer mock_stop(m)
+
+	// Submit one request with a short timeout so the registry drains naturally.
+	req := Http_Request{
+		id = strings.clone("drain-1"),
+		url = strings.clone(fmt.tprintf("http://127.0.0.1:%d/", m.port)),
+		method = strings.clone("GET"),
+		timeout_ms = 100,  // 100 ms timeout, mock sleeps 2 s
+	}
+	http_client_request(hc, req)
+
+	// Wait briefly so the request enters the pending registry.
+	time.sleep(50 * time.Millisecond)
+
+	// Destroy should drain workers (workers_alive→0) within the 3-second
+	// internal deadline. The worker is blocked on the slow mock for ~2 s,
+	// then bails via the `destroying` path. We measure: does destroy
+	// return cleanly within ~3 s, and is `hc` safe to free immediately
+	// afterward (workers_alive == 0 means no worker still holds a
+	// pointer)?
+	start := time.now()
+	http_client_destroy(hc)
+	elapsed := time.diff(start, time.now())
+	free(hc)
+
+	testing.expect(t, elapsed < 4 * time.Second,
+		"http_client_destroy should drain within ~3 s, not hang")
+}

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -18,6 +18,15 @@ import "core:sync"
 import "core:testing"
 import "core:thread"
 
+// Tests that mutate the package-level HTTP whitelist (g_http_whitelist) share
+// process state. Odin's test runner runs tests in parallel by default, so a
+// test that sets the whitelist can race against a separate test that issues
+// an HTTP request and depends on the whitelist being unset. Acquire this
+// mutex in any test that either calls set_http_whitelist or calls
+// execute_http_request with a host the whitelist might reject.
+@(private = "file")
+g_test_http_state_mutex: sync.Mutex
+
 @(private = "file")
 Mock_Server :: struct {
 	sock:     net.TCP_Socket,
@@ -76,6 +85,9 @@ mock_stop :: proc(m: ^Mock_Server) {
 
 @(test)
 test_http_response_cap_rejects_oversized_content_length :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+
 	// Announce 32 MiB. With a HTTP_MAX_BODY cap of 16 MiB the underlying
 	// scanner returns Too_Long without reading the body.
 	announced := 32 * 1024 * 1024
@@ -123,6 +135,9 @@ test_http_response_cap_rejects_oversized_content_length :: proc(t: ^testing.T) {
 
 @(test)
 test_http_header_value_rejects_crlf :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+
 	headers := make(map[string]string)
 	headers[strings.clone("X-Smuggle")] = strings.clone("evil\r\nHost: attacker")
 	defer {
@@ -154,6 +169,9 @@ test_http_header_value_rejects_crlf :: proc(t: ^testing.T) {
 
 @(test)
 test_http_header_key_rejects_nul :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+
 	headers := make(map[string]string)
 	headers[strings.clone("X-Bad\x00key")] = strings.clone("ok")
 	defer {
@@ -185,6 +203,9 @@ test_http_header_key_rejects_nul :: proc(t: ^testing.T) {
 
 @(test)
 test_http_redirect_not_followed :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+
 	resp := "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:1/elsewhere\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
 	m := mock_start(resp)
 	if m == nil {
@@ -212,6 +233,9 @@ test_http_redirect_not_followed :: proc(t: ^testing.T) {
 
 @(test)
 test_http_rejects_ftp_scheme :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+
 	req := Http_Request{
 		id = strings.clone("scheme-1"),
 		url = strings.clone("ftp://example.com/"),
@@ -231,6 +255,9 @@ test_http_rejects_ftp_scheme :: proc(t: ^testing.T) {
 
 @(test)
 test_http_rejects_file_scheme :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+
 	req := Http_Request{
 		id = strings.clone("scheme-2"),
 		url = strings.clone("file:///etc/passwd"),
@@ -250,6 +277,9 @@ test_http_rejects_file_scheme :: proc(t: ^testing.T) {
 
 @(test)
 test_http_accepts_uppercase_https :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+
 	// Just confirms scheme matching is case-insensitive — no real connect.
 	// We expect a connect error (status 0, error_msg contains "Request failed"
 	// or similar), NOT the scheme-rejection error_msg.
@@ -267,4 +297,111 @@ test_http_accepts_uppercase_https :: proc(t: ^testing.T) {
 	}
 	testing.expect(t, !strings.contains(got.error_msg, "scheme"),
 		"HTTPS (uppercase) must not be rejected as scheme")
+}
+
+@(test)
+test_http_whitelist_allows_listed_host :: proc(t: ^testing.T) {
+	resp := "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+	m := mock_start(resp)
+	if m == nil { testing.fail_now(t, "could not bind mock") }
+	defer mock_stop(m)
+
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+
+	set_http_whitelist([]string{"127.0.0.1"})
+	defer set_http_whitelist(nil)
+
+	url := fmt.tprintf("http://127.0.0.1:%d/", m.port)
+	req := Http_Request{
+		id = strings.clone("wl-1"), url = strings.clone(url),
+		method = strings.clone("GET"),
+	}
+	defer { delete(req.id); delete(req.url); delete(req.method) }
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+	testing.expect_value(t, got.status, 200)
+}
+
+@(test)
+test_http_whitelist_blocks_unlisted_host :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+
+	set_http_whitelist([]string{"example.com"})
+	defer set_http_whitelist(nil)
+
+	req := Http_Request{
+		id = strings.clone("wl-2"),
+		url = strings.clone("http://127.0.0.1:1/"),
+		method = strings.clone("GET"),
+	}
+	defer { delete(req.id); delete(req.url); delete(req.method) }
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+	testing.expect_value(t, got.status, 0)
+	testing.expect(t, strings.contains(got.error_msg, "127.0.0.1"),
+		fmt.tprintf("expected rejected host name in error, got %q", got.error_msg))
+	testing.expect(t, strings.contains(got.error_msg, "whitelist"),
+		"expected 'whitelist' in error message")
+}
+
+@(test)
+test_http_whitelist_hostname_case_insensitive :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+
+	set_http_whitelist([]string{"Example.COM"})
+	defer set_http_whitelist(nil)
+
+	req := Http_Request{
+		id = strings.clone("wl-3"),
+		url = strings.clone("http://example.com/"),
+		method = strings.clone("GET"),
+	}
+	defer { delete(req.id); delete(req.url); delete(req.method) }
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+	testing.expect(t, !strings.contains(got.error_msg, "whitelist"),
+		"hostname compare should be case-insensitive")
+}
+
+@(test)
+test_http_whitelist_cidr_match :: proc(t: ^testing.T) {
+	resp := "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+	m := mock_start(resp)
+	if m == nil { testing.fail_now(t, "could not bind mock") }
+	defer mock_stop(m)
+
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+
+	set_http_whitelist([]string{"127.0.0.0/8"})
+	defer set_http_whitelist(nil)
+
+	url := fmt.tprintf("http://127.0.0.1:%d/", m.port)
+	req := Http_Request{
+		id = strings.clone("wl-4"), url = strings.clone(url),
+		method = strings.clone("GET"),
+	}
+	defer { delete(req.id); delete(req.url); delete(req.method) }
+	got := execute_http_request(req)
+	defer {
+		delete(got.body); delete(got.error_msg)
+		for k, v in got.headers { delete(k); delete(v) }
+		delete(got.headers)
+	}
+	testing.expect_value(t, got.status, 200)
 }

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -17,6 +17,7 @@ import "core:strings"
 import "core:sync"
 import "core:testing"
 import "core:thread"
+import "core:time"
 
 // Tests that mutate the package-level HTTP whitelist (g_http_whitelist) share
 // process state. Odin's test runner runs tests in parallel by default, so a
@@ -414,5 +415,67 @@ test_http_whitelist_ipv6_cidr_match :: proc(t: ^testing.T) {
 		rejected, ok := http_whitelist_check("2001:db9::1")
 		testing.expect(t, !ok, "IPv6 outside the /32 must not match")
 		testing.expect_value(t, rejected, "2001:db9::1")
+	}
+}
+
+@(private = "file")
+slow_mock_serve :: proc(m: ^Mock_Server) {
+	defer sync.sema_post(&m.done)
+	client, _, err := net.accept_tcp(m.sock)
+	if err != nil do return
+	defer net.close(client)
+	// Read the request, then sleep instead of responding.
+	buf: [4096]u8
+	total := 0
+	for total < len(buf) {
+		n, rerr := net.recv_tcp(client, buf[total:])
+		if rerr != nil || n <= 0 do break
+		total += n
+		if strings.contains(string(buf[:total]), "\r\n\r\n") do break
+	}
+	time.sleep(2 * time.Second)
+}
+
+@(test)
+test_http_timeout_fires :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+
+	m := new(Mock_Server)
+	for p in 18900 ..< 19000 {
+		s, e := net.listen_tcp(net.Endpoint{address = net.IP4_Loopback, port = p})
+		if e == nil { m.sock = s; m.port = p; break }
+	}
+	if m.port == 0 { testing.fail_now(t, "no port") }
+	m.thread = thread.create_and_start_with_poly_data(m, slow_mock_serve, context)
+	defer mock_stop(m)
+
+	hc: Http_Client
+	http_client_init(&hc)
+	defer http_client_destroy(&hc)
+
+	req := Http_Request{
+		id = strings.clone("timeout-1"),
+		url = strings.clone(fmt.tprintf("http://127.0.0.1:%d/", m.port)),
+		method = strings.clone("GET"),
+		timeout_ms = 200,  // 200 ms; mock sleeps 2 s
+	}
+	http_client_request(&hc, req)
+
+	// Poll for up to 1 s to pick up the timeout result.
+	deadline := time.time_add(time.now(), 1 * time.Second)
+	results: [dynamic]Http_Response
+	defer { for &r in results do http_response_destroy(&r); delete(results) }
+	for time.diff(time.now(), deadline) > 0 {
+		http_client_poll(&hc, &results)
+		if len(results) > 0 do break
+		time.sleep(50 * time.Millisecond)
+	}
+
+	testing.expect(t, len(results) == 1, "expected one timeout result")
+	if len(results) == 1 {
+		testing.expect_value(t, results[0].status, 0)
+		testing.expect(t, strings.contains(results[0].error_msg, "timeout"),
+			fmt.tprintf("expected 'timeout' in error_msg, got %q", results[0].error_msg))
 	}
 }

--- a/src/redin/bridge/shell.odin
+++ b/src/redin/bridge/shell.odin
@@ -1,5 +1,6 @@
 package bridge
 
+import "base:runtime"
 import "core:fmt"
 import "core:os"
 import "core:strings"
@@ -88,7 +89,6 @@ shell_request_destroy :: proc(req: ^Shell_Request) {
 	delete(req.cmd)
 }
 
-@(private = "file")
 execute_shell :: proc(req: Shell_Request) -> Shell_Response {
 	response: Shell_Response
 	response.id = strings.clone(req.id)
@@ -133,12 +133,29 @@ execute_shell :: proc(req: Shell_Request) -> Shell_Response {
 		stdin_w = w
 	}
 
+	// Apply the env allowlist (issue #99 M3). When the allowlist is unset,
+	// shell_env_filtered returns nil — and Process_Desc.env = nil is the
+	// documented "inherit current process' environment" sentinel (see
+	// core/os/process.odin's Process_Desc docstring), preserving the
+	// historical full-passthrough behaviour.
+	//
+	// When set, shell_env_filtered allocates each entry + the slice via
+	// runtime.heap_allocator(); we free both after process_start, since
+	// process_start (Linux execve) copies the env into the child image.
+	filtered_env := shell_env_filtered()
+	defer if filtered_env != nil {
+		heap := runtime.heap_allocator()
+		for s in filtered_env do delete(s, heap)
+		delete(filtered_env, heap)
+	}
+
 	// Start process
 	desc := os.Process_Desc {
 		command = req.cmd,
 		stdout  = stdout_w,
 		stderr  = stderr_w,
 		stdin   = stdin_r,
+		env     = filtered_env, // nil = inherit parent env (default)
 	}
 
 	process, start_err := os.process_start(desc)

--- a/src/redin/bridge/shell.odin
+++ b/src/redin/bridge/shell.odin
@@ -116,6 +116,8 @@ execute_shell :: proc(req: Shell_Request) -> Shell_Response {
 	// is bounded by ~50 ms past the requested timeout.
 	timeout_ms := req.timeout_ms
 	if timeout_ms <= 0 do timeout_ms = SHELL_DEFAULT_TIMEOUT_MS
+	// Note: deadline includes process_start latency. Tight (<100 ms) timeouts
+	// may fire before exec returns. Negligible for the 30 s default.
 	deadline := time.time_add(time.now(), time.Duration(timeout_ms) * time.Millisecond)
 
 	// Create pipes for stdout and stderr

--- a/src/redin/bridge/shell.odin
+++ b/src/redin/bridge/shell.odin
@@ -7,14 +7,17 @@ import "core:strings"
 import "core:sync"
 import "core:sys/linux"
 import "core:thread"
+import "core:time"
 
 SHELL_DEFAULT_MAX_OUTPUT :: 16 * 1024 * 1024 // 16 MiB
+SHELL_DEFAULT_TIMEOUT_MS :: 30_000
 
 Shell_Request :: struct {
 	id:               string,
 	cmd:              []string,
 	stdin:            string,
 	max_output_bytes: int,
+	timeout_ms:       int,
 }
 
 Shell_Response :: struct {
@@ -106,6 +109,14 @@ execute_shell :: proc(req: Shell_Request) -> Shell_Response {
 	// Combined stdout+stderr cap. 0 / negative means "use default 16 MiB".
 	output_cap := req.max_output_bytes
 	if output_cap <= 0 do output_cap = SHELL_DEFAULT_MAX_OUTPUT
+
+	// Per-call wall-clock timeout (issue #99 M2 B). 0 / negative means
+	// "use default 30 000 ms". The deadline is checked once per poll
+	// iteration below; with a 50 ms poll tick, deadline responsiveness
+	// is bounded by ~50 ms past the requested timeout.
+	timeout_ms := req.timeout_ms
+	if timeout_ms <= 0 do timeout_ms = SHELL_DEFAULT_TIMEOUT_MS
+	deadline := time.time_add(time.now(), time.Duration(timeout_ms) * time.Millisecond)
 
 	// Create pipes for stdout and stderr
 	stdout_r, stdout_w, stdout_err := os.pipe()
@@ -211,6 +222,20 @@ execute_shell :: proc(req: Shell_Request) -> Shell_Response {
 	// we break out immediately and reap the child below.
 	killed := false
 	for !stdout_done || !stderr_done {
+		// Deadline check (issue #99 M2 B). time.diff(start, end) returns
+		// end - start, so <= 0 means now >= deadline. Checked before the
+		// poll so a deadline that has already elapsed kills the child
+		// immediately rather than waiting another 50 ms tick.
+		if time.diff(time.now(), deadline) <= 0 {
+			_ = os.process_kill(process)
+			clear(&stdout_buf)
+			clear(&stderr_buf)
+			response.exit_code = -1
+			response.error_msg = fmt.aprintf("shell timeout exceeded %d ms", timeout_ms)
+			killed = true
+			break
+		}
+
 		fds: [2]linux.Poll_Fd
 		n_fds := 0
 		stdout_idx := -1

--- a/src/redin/bridge/shell.odin
+++ b/src/redin/bridge/shell.odin
@@ -5,12 +5,16 @@ import "core:fmt"
 import "core:os"
 import "core:strings"
 import "core:sync"
+import "core:sys/linux"
 import "core:thread"
 
+SHELL_DEFAULT_MAX_OUTPUT :: 16 * 1024 * 1024 // 16 MiB
+
 Shell_Request :: struct {
-	id:    string,
-	cmd:   []string,
-	stdin: string,
+	id:               string,
+	cmd:              []string,
+	stdin:            string,
+	max_output_bytes: int,
 }
 
 Shell_Response :: struct {
@@ -98,6 +102,10 @@ execute_shell :: proc(req: Shell_Request) -> Shell_Response {
 		response.exit_code = -1
 		return response
 	}
+
+	// Combined stdout+stderr cap. 0 / negative means "use default 16 MiB".
+	output_cap := req.max_output_bytes
+	if output_cap <= 0 do output_cap = SHELL_DEFAULT_MAX_OUTPUT
 
 	// Create pipes for stdout and stderr
 	stdout_r, stdout_w, stdout_err := os.pipe()
@@ -187,31 +195,93 @@ execute_shell :: proc(req: Shell_Request) -> Shell_Response {
 	read_buf: [4096]u8
 	stdout_done, stderr_done: bool
 
-	// Blocking reads on child pipes. The previous version gated each
-	// read on os.pipe_has_data and fell through to os.read in both
-	// branches — same behaviour, extra syscall, and on macOS/BSD the
-	// has_data probe could false-negative and turn a quick command
-	// into a hang (the `else` branch still called os.read after the
-	// probe said "nothing there"). Direct blocking reads are simpler
-	// and work on all platforms: when the child exits and closes its
-	// pipe, os.read returns 0 / error and we mark that side done.
+	// Use linux.poll to multiplex stdout + stderr reads. The previous
+	// blocking-read approach (os.read on each pipe in turn) deadlocked
+	// for stderr-quiet long-running children: e.g. `yes` writes only
+	// to stdout, so the stderr read blocked indefinitely while the
+	// stdout buffer grew unbounded — the cap check at the bottom of
+	// the loop body could never fire. With poll, we only read the
+	// pipe(s) that actually have data ready (or have been closed) and
+	// re-check the cap each iteration.
+	//
+	// 50 ms timeout balances responsiveness vs. CPU. On overflow, kill
+	// the child, clear partial buffers, and surface a -1 exit code with
+	// a descriptive error_msg (issue #99 M2 A). Subsequent reads would
+	// return EOF as the kernel closes the (now-orphaned) pipe ends, but
+	// we break out immediately and reap the child below.
+	killed := false
 	for !stdout_done || !stderr_done {
+		fds: [2]linux.Poll_Fd
+		n_fds := 0
+		stdout_idx := -1
+		stderr_idx := -1
 		if !stdout_done {
-			n, err := os.read(stdout_r, read_buf[:])
-			if err != nil || n <= 0 {
-				stdout_done = true
-			} else {
-				append(&stdout_buf, ..read_buf[:n])
+			fds[n_fds] = linux.Poll_Fd {
+				fd     = linux.Fd(os.fd(stdout_r)),
+				events = {.IN},
 			}
+			stdout_idx = n_fds
+			n_fds += 1
 		}
 		if !stderr_done {
-			n, err := os.read(stderr_r, read_buf[:])
-			if err != nil || n <= 0 {
-				stderr_done = true
-			} else {
-				append(&stderr_buf, ..read_buf[:n])
+			fds[n_fds] = linux.Poll_Fd {
+				fd     = linux.Fd(os.fd(stderr_r)),
+				events = {.IN},
+			}
+			stderr_idx = n_fds
+			n_fds += 1
+		}
+
+		n_ready, perr := linux.poll(fds[:n_fds], 50)
+		if perr != .NONE {
+			// poll error (e.g. EINTR) — bail out cleanly; the cap
+			// or wait below will surface any final state.
+			stdout_done = true
+			stderr_done = true
+			break
+		}
+
+		if n_ready > 0 {
+			if stdout_idx >= 0 &&
+			   (.IN in fds[stdout_idx].revents || .HUP in fds[stdout_idx].revents) {
+				n, err := os.read(stdout_r, read_buf[:])
+				if err != nil || n <= 0 {
+					stdout_done = true
+				} else {
+					append(&stdout_buf, ..read_buf[:n])
+				}
+			}
+			if stderr_idx >= 0 &&
+			   (.IN in fds[stderr_idx].revents || .HUP in fds[stderr_idx].revents) {
+				n, err := os.read(stderr_r, read_buf[:])
+				if err != nil || n <= 0 {
+					stderr_done = true
+				} else {
+					append(&stderr_buf, ..read_buf[:n])
+				}
 			}
 		}
+
+		if len(stdout_buf) + len(stderr_buf) > output_cap {
+			_ = os.process_kill(process)
+			clear(&stdout_buf)
+			clear(&stderr_buf)
+			response.exit_code = -1
+			response.error_msg = fmt.aprintf(
+				"shell output exceeded %d MiB cap",
+				output_cap / (1024 * 1024),
+			)
+			killed = true
+			break
+		}
+	}
+
+	if killed {
+		// Reap the child to avoid a zombie. The exit_code from a SIGKILL'd
+		// process isn't useful here — we already set it to -1 above to
+		// signal "cap exceeded" distinctly from a normal non-zero exit.
+		_, _ = os.process_wait(process)
+		return response
 	}
 
 	// Wait for process

--- a/src/redin/bridge/shell.odin
+++ b/src/redin/bridge/shell.odin
@@ -233,9 +233,13 @@ execute_shell :: proc(req: Shell_Request) -> Shell_Response {
 		}
 
 		n_ready, perr := linux.poll(fds[:n_fds], 50)
+		if perr == .EINTR {
+			// signal interrupted poll (Raylib installs handlers); retry
+			continue
+		}
 		if perr != .NONE {
-			// poll error (e.g. EINTR) — bail out cleanly; the cap
-			// or wait below will surface any final state.
+			// genuinely fatal poll error (EBADF, ENOMEM, EINVAL) —
+			// bail out cleanly; wait below will surface final state.
 			stdout_done = true
 			stderr_done = true
 			break

--- a/src/redin/bridge/shell_test.odin
+++ b/src/redin/bridge/shell_test.odin
@@ -1,0 +1,81 @@
+package bridge
+
+// Regression tests for issue #99 M3: opt-in shell env allowlist.
+//
+// When set_shell_env_allowlist is set to a non-nil slice, child processes
+// spawned by execute_shell see only the env vars whose KEYs match an
+// entry in the allowlist (exact match, case-sensitive). When unset
+// (default, nil), children inherit the full parent env — preserving
+// the historical behaviour for apps that shell out to credential-aware
+// tools like `gh`, `aws`, or `git`.
+
+import "core:strings"
+import "core:sync"
+import "core:testing"
+
+// Tests in this file mutate the package-level shell env allowlist
+// (g_shell_env_allowlist). Odin's test runner runs tests in parallel by
+// default, so a test that sets the allowlist can race against another
+// test that calls execute_shell and depends on the allowlist being unset.
+// Acquire this mutex in any test that either calls set_shell_env_allowlist
+// or relies on the default-passthrough behaviour.
+@(private = "file")
+g_test_shell_state_mutex: sync.Mutex
+
+@(test)
+test_shell_env_allowlist_filters :: proc(t: ^testing.T) {
+	sync.lock(&g_test_shell_state_mutex)
+	defer sync.unlock(&g_test_shell_state_mutex)
+
+	// /usr/bin/env exists on Linux/macOS; Linux is the supported platform.
+	set_shell_env_allowlist([]string{"PATH"})
+	defer set_shell_env_allowlist(nil)
+
+	cmd := make([]string, 1)
+	cmd[0] = strings.clone("/usr/bin/env")
+	defer { for s in cmd do delete(s); delete(cmd) }
+
+	req := Shell_Request{
+		id    = strings.clone("env-1"),
+		cmd   = cmd,
+		stdin = strings.clone(""),
+	}
+	defer { delete(req.id); delete(req.stdin) }
+
+	got := execute_shell(req)
+	defer {
+		delete(got.id); delete(got.stdout); delete(got.stderr); delete(got.error_msg)
+	}
+
+	// stdout should contain PATH=... but no other typical user env vars.
+	testing.expect(t, strings.contains(got.stdout, "PATH="),
+		"expected PATH in env output")
+	testing.expect(t, !strings.contains(got.stdout, "HOME="),
+		"expected HOME stripped by allowlist")
+}
+
+@(test)
+test_shell_env_allowlist_unset_full_passthrough :: proc(t: ^testing.T) {
+	sync.lock(&g_test_shell_state_mutex)
+	defer sync.unlock(&g_test_shell_state_mutex)
+
+	set_shell_env_allowlist(nil)
+
+	cmd := make([]string, 1)
+	cmd[0] = strings.clone("/usr/bin/env")
+	defer { for s in cmd do delete(s); delete(cmd) }
+	req := Shell_Request{
+		id    = strings.clone("env-2"),
+		cmd   = cmd,
+		stdin = strings.clone(""),
+	}
+	defer { delete(req.id); delete(req.stdin) }
+
+	got := execute_shell(req)
+	defer {
+		delete(got.id); delete(got.stdout); delete(got.stderr); delete(got.error_msg)
+	}
+	// PATH is reliably present in the test runner's env.
+	testing.expect(t, strings.contains(got.stdout, "PATH="),
+		"expected PATH= in default-passthrough env output")
+}

--- a/src/redin/bridge/shell_test.odin
+++ b/src/redin/bridge/shell_test.odin
@@ -110,3 +110,32 @@ test_shell_output_cap_kills_child :: proc(t: ^testing.T) {
 	testing.expect_value(t, len(got.stdout), 0)
 	testing.expect_value(t, len(got.stderr), 0)
 }
+
+@(test)
+test_shell_timeout_kills_child :: proc(t: ^testing.T) {
+	sync.lock(&g_test_shell_state_mutex)
+	defer sync.unlock(&g_test_shell_state_mutex)
+
+	// `sleep 60` should be killed by a 200 ms timeout.
+	cmd := make([]string, 2)
+	cmd[0] = strings.clone("sleep")
+	cmd[1] = strings.clone("60")
+	defer { for s in cmd do delete(s); delete(cmd) }
+
+	req := Shell_Request{
+		id = strings.clone("to-1"),
+		cmd = cmd,
+		stdin = strings.clone(""),
+		timeout_ms = 200,
+	}
+	defer { delete(req.id); delete(req.stdin) }
+
+	got := execute_shell(req)
+	defer {
+		delete(got.id); delete(got.stdout); delete(got.stderr); delete(got.error_msg)
+	}
+
+	testing.expect_value(t, got.exit_code, -1)
+	testing.expect(t, strings.contains(got.error_msg, "timeout"),
+		fmt.tprintf("expected 'timeout' in error_msg, got %q", got.error_msg))
+}

--- a/src/redin/bridge/shell_test.odin
+++ b/src/redin/bridge/shell_test.odin
@@ -9,6 +9,7 @@ package bridge
 // the historical behaviour for apps that shell out to credential-aware
 // tools like `gh`, `aws`, or `git`.
 
+import "core:fmt"
 import "core:strings"
 import "core:sync"
 import "core:testing"
@@ -78,4 +79,34 @@ test_shell_env_allowlist_unset_full_passthrough :: proc(t: ^testing.T) {
 	// PATH is reliably present in the test runner's env.
 	testing.expect(t, strings.contains(got.stdout, "PATH="),
 		"expected PATH= in default-passthrough env output")
+}
+
+@(test)
+test_shell_output_cap_kills_child :: proc(t: ^testing.T) {
+	sync.lock(&g_test_shell_state_mutex)
+	defer sync.unlock(&g_test_shell_state_mutex)
+
+	// `yes` runs forever; with a 1 MiB cap it should be killed quickly.
+	cmd := make([]string, 1)
+	cmd[0] = strings.clone("yes")
+	defer { for s in cmd do delete(s); delete(cmd) }
+
+	req := Shell_Request{
+		id = strings.clone("cap-1"),
+		cmd = cmd,
+		stdin = strings.clone(""),
+		max_output_bytes = 1 * 1024 * 1024,
+	}
+	defer { delete(req.id); delete(req.stdin) }
+
+	got := execute_shell(req)
+	defer {
+		delete(got.id); delete(got.stdout); delete(got.stderr); delete(got.error_msg)
+	}
+
+	testing.expect_value(t, got.exit_code, -1)
+	testing.expect(t, strings.contains(got.error_msg, "exceeded"),
+		fmt.tprintf("expected 'exceeded' in error_msg, got %q", got.error_msg))
+	testing.expect_value(t, len(got.stdout), 0)
+	testing.expect_value(t, len(got.stderr), 0)
 }

--- a/src/runtime/effect.fnl
+++ b/src/runtime/effect.fnl
@@ -107,11 +107,12 @@
       (set next-shell-id (+ next-shell-id 1))
       (let [id (tostring next-shell-id)
             cmd (or params.cmd [])
-            stdin (or params.stdin "")]
+            stdin (or params.stdin "")
+            max-output (or params.max-output 16)]
         (tset pending-shell id {:on-success params.on-success
                                 :on-error params.on-error})
         (when _G.redin_shell
-          (_G.redin_shell id cmd stdin))))))
+          (_G.redin_shell id cmd stdin max-output))))))
 
 (register-builtins)
 

--- a/src/runtime/effect.fnl
+++ b/src/runtime/effect.fnl
@@ -108,11 +108,12 @@
       (let [id (tostring next-shell-id)
             cmd (or params.cmd [])
             stdin (or params.stdin "")
-            max-output (or params.max-output 16)]
+            max-output (or params.max-output 16)
+            timeout (or params.timeout 30000)]
         (tset pending-shell id {:on-success params.on-success
                                 :on-error params.on-error})
         (when _G.redin_shell
-          (_G.redin_shell id cmd stdin max-output))))))
+          (_G.redin_shell id cmd stdin max-output timeout))))))
 
 (register-builtins)
 


### PR DESCRIPTION
## Summary

Implements all eight findings from the bridge / devserver / http / shell security audit (issue #99). Posture: **permissive defaults + opt-in hardening** — existing apps continue to run unchanged, apps that want stricter behaviour reach for the new bridge setters.

**Always-on guards (no opt-out):**
- HTTP scheme check: rejects non-`http`/`https` URLs.
- HTTP header validation: rejects `\r`, `\n`, `\x00` in keys/values.
- HTTP auto-redirects disabled (3xx surfaces to caller).
- Dev-server: malformed `Content-Length` returns 400.
- Dev-server: `.redin-token` / `.redin-port` write failure aborts startup.

**New defaults + per-call overrides:**
- HTTP request timeout (30 s, `:timeout` ms override).
- HTTP concurrent in-flight cap (64).
- Shell output cap (16 MiB combined stdout+stderr, `:max-output` MiB override).
- Shell timeout (30 s, `:timeout` ms override).

**New public bridge API for `--native` apps:**
- `bridge.set_http_whitelist(allow: []string)` — hostname literals or CIDR.
- `bridge.set_shell_env_allowlist(allow: []string)` — env-var key allowlist.

**Bridge robustness:**
- `http_client_destroy` now drains in-flight workers (3 s budget) and bails late completions safely via a `destroying` flag.

Closes #99.

## Test Plan

- [x] Release build clean (`odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin`).
- [x] Dev build clean (`./build-dev.sh`).
- [x] Agent build clean (`./build-dev.sh -define:REDIN_AGENT=true`).
- [x] Fennel runtime tests: 133 pass.
- [x] Bridge unit tests: 46 pass.
- [x] UI integration tests: 143 pass across 21 suites (1 suite correctly skipped without `REDIN_AGENT`).
- [x] Manual review of \`docs/superpowers/specs/2026-05-06-security-audit-99-design.md\` and \`docs/superpowers/plans/2026-05-06-security-audit-99.md\` for context.

## Notes

- Per CLAUDE.md, all doc updates land in the same commits / branch as the code.
- Spec + plan checked into `docs/superpowers/{specs,plans}/` for the in-tree record.
- Two known follow-ups (not blocking, tracked from final review):
  - `request`-vs-`destroy` race window — pre-existing, theoretical only since both run on the main thread; mitigated by a defensive `destroying` short-circuit in `http_client_request`.
  - In-flight cap test produces ~256 KiB of "leaked" scanner buffers under the tracking allocator because odin-http exposes no cancellation knob; comment in the test acknowledges the bounded shutdown-only leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)