### PR TITLE
fix(parser): free cloned strings on tree teardown (closes #119)

### DIFF
--- a/src/redin/parser/view_tree_parser.odin
+++ b/src/redin/parser/view_tree_parser.odin
@@ -12,9 +12,61 @@ _Tree_Node :: struct {
 	children: [dynamic]_Tree_Node,
 }
 
+// Free strings cloned by _parse_element on a parsed node. The parser
+// only clones a subset of types.Node string fields, so this is a narrow
+// mirror of bridge.clear_node_strings — DO NOT add fields the parser
+// does not clone (those would be slices into source text and freeing
+// them would be a bad free).
+_clear_node_strings :: proc(n: types.Node) {
+	switch v in n {
+	case types.NodeStack:
+	case types.NodeCanvas:
+		if len(v.provider) > 0 do delete(v.provider)
+		if len(v.aspect) > 0 do delete(v.aspect)
+	case types.NodeVbox:
+		if len(v.overflow) > 0 do delete(v.overflow)
+		if len(v.aspect) > 0 do delete(v.aspect)
+	case types.NodeHbox:
+		if len(v.overflow) > 0 do delete(v.overflow)
+		if len(v.aspect) > 0 do delete(v.aspect)
+	case types.NodeInput:
+		if len(v.aspect) > 0 do delete(v.aspect)
+		if len(v.change) > 0 do delete(v.change)
+		if len(v.key) > 0 do delete(v.key)
+	case types.NodeButton:
+		if len(v.label) > 0 do delete(v.label)
+		if len(v.aspect) > 0 do delete(v.aspect)
+		if len(v.click) > 0 do delete(v.click)
+	case types.NodeText:
+		if len(v.content) > 0 do delete(v.content)
+		if len(v.aspect) > 0 do delete(v.aspect)
+	case types.NodeImage:
+		if len(v.aspect) > 0 do delete(v.aspect)
+	case types.NodePopout:
+		if len(v.aspect) > 0 do delete(v.aspect)
+	case types.NodeModal:
+		if len(v.aspect) > 0 do delete(v.aspect)
+	}
+}
+
+// Tear down a parsed _Tree_Node that still owns its strings (i.e. the
+// node has not been flattened). Frees children recursively, the children
+// array itself, and the cloned strings on this node.
 _tree_node_destroy :: proc(n: ^_Tree_Node) {
 	for &child in n.children {
 		_tree_node_destroy(&child)
+	}
+	delete(n.children)
+	_clear_node_strings(n.data)
+}
+
+// Tear down a _Tree_Node after _flatten has copied n.data into the flat
+// nodes array. _flatten transfers string ownership by shallow-copying the
+// node value, so callers must NOT also free strings on the tree side —
+// the flat nodes array is now responsible (free with _clear_node_strings).
+_tree_node_destroy_after_flatten :: proc(n: ^_Tree_Node) {
+	for &child in n.children {
+		_tree_node_destroy_after_flatten(&child)
 	}
 	delete(n.children)
 }
@@ -354,7 +406,12 @@ _parse_element :: proc(p: ^_Parser) -> (_Tree_Node, bool) {
 	return result, true
 }
 
-// Flatten tree into parallel path/node arrays (depth-first)
+// Flatten tree into parallel path/node arrays (depth-first).
+// Shallow-copies n.data into the flat nodes array, transferring ownership
+// of any cloned strings to the flat nodes. Callers must release strings on
+// each flat node via _clear_node_strings, and must use
+// _tree_node_destroy_after_flatten (not _tree_node_destroy) to tear down
+// the source tree to avoid double-free.
 
 _flatten :: proc(
 	n: ^_Tree_Node,
@@ -416,7 +473,7 @@ load_view_tree :: proc(
 		fmt.eprintfln("Failed to parse %s", filepath)
 		return {}, {}, {}, {}, false
 	}
-	defer _tree_node_destroy(&tree)
+	defer _tree_node_destroy_after_flatten(&tree)
 
 	cur: [dynamic]u8
 	defer delete(cur)

--- a/src/redin/parser/view_tree_parser_test.odin
+++ b/src/redin/parser/view_tree_parser_test.odin
@@ -149,7 +149,7 @@ test_flatten_produces_correct_count :: proc(t: ^testing.T) {
 	p := _Parser{text = input, pos = 0}
 	tree, ok := _parse_element(&p)
 	testing.expect(t, ok, "parse should succeed")
-	defer _tree_node_destroy(&tree)
+	defer _tree_node_destroy_after_flatten(&tree)
 
 	paths: [dynamic]types.Path
 	nodes: [dynamic]types.Node
@@ -160,6 +160,7 @@ test_flatten_produces_correct_count :: proc(t: ^testing.T) {
 
 	_flatten(&tree, &cur, &paths, &nodes, &parent_indices, &children_list, -1)
 	defer {
+		for &n in nodes do _clear_node_strings(n)
 		for &pa in paths do delete(pa.value)
 		delete(paths)
 		delete(nodes)


### PR DESCRIPTION
## Summary

- Parser tests leaked every string `_parse_element` cloned into a tree node — `_tree_node_destroy` freed the children array but not the strings. Fixes #119.
- Make ownership explicit: keep `_tree_node_destroy` for the common (non-flatten) test path and have it free strings + children; add `_tree_node_destroy_after_flatten` for the post-flatten path where ownership has moved to the flat `nodes[]`.
- Add `_clear_node_strings`, a parser-local mirror of `bridge.clear_node_strings` scoped to exactly the fields `_parse_element` clones (any other field would be a bad-free against a source-text slice).
- Flatten test now releases strings on each flat node via `_clear_node_strings`. `load_view_tree` (only test-path, no production callers) switches to `_tree_node_destroy_after_flatten`.

## Test plan

- [x] `odin test src/redin/parser -define:ODIN_TEST_THREADS=1` — 26 pass, 0 leak warnings
- [x] `odin test src/redin/parser` (default threading) — 26 pass, 0 leak warnings
- [x] `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)