### PR TITLE
fix(input): reset slice/string headers after delete; serialize state-mutating tests (closes #118, #61)

### DIFF
--- a/src/redin/input/override_test.odin
+++ b/src/redin/input/override_test.odin
@@ -1,19 +1,18 @@
 package input
 
+import "core:sync"
 import "core:testing"
 import rl "vendor:raylib"
 
-// These tests mutate the package-level `override` variable, so they must
-// be run sequentially. Use:
-//
-//   odin test src/redin/input -collection:lib=lib -collection:luajit=vendor/luajit \
-//       -define:ODIN_TEST_THREADS=1
-//
-// Without the flag, parallel test execution races on the shared global
-// and yields intermittent failures.
+// These tests mutate the package-level `override` variable. Each one
+// acquires g_input_test_state_mutex (declared in state_test.odin) so the
+// runner can stay parallel package-wide while these tests serialize
+// against each other and against state-mutating tests.
 
 @(test)
 test_mouse_pos_falls_back_to_raylib_when_inactive :: proc(t: ^testing.T) {
+	sync.lock(&g_input_test_state_mutex)
+	defer sync.unlock(&g_input_test_state_mutex)
 	override = Mouse_Override{}
 	// Cannot easily mock rl.GetMousePosition; just assert active=false path
 	// returns the raylib value (whatever it is) by reading both.
@@ -24,6 +23,8 @@ test_mouse_pos_falls_back_to_raylib_when_inactive :: proc(t: ^testing.T) {
 
 @(test)
 test_mouse_pos_uses_override_when_active :: proc(t: ^testing.T) {
+	sync.lock(&g_input_test_state_mutex)
+	defer sync.unlock(&g_input_test_state_mutex)
 	override = Mouse_Override{active = true, pos = {123, 456}}
 	got := mouse_pos()
 	testing.expect_value(t, got.x, f32(123))
@@ -33,6 +34,8 @@ test_mouse_pos_uses_override_when_active :: proc(t: ^testing.T) {
 
 @(test)
 test_is_mouse_button_down_uses_override :: proc(t: ^testing.T) {
+	sync.lock(&g_input_test_state_mutex)
+	defer sync.unlock(&g_input_test_state_mutex)
 	override = Mouse_Override{active = true, button_left = true}
 	testing.expect(t, is_mouse_button_down(.LEFT))
 	testing.expect(t, !is_mouse_button_down(.RIGHT))
@@ -41,6 +44,8 @@ test_is_mouse_button_down_uses_override :: proc(t: ^testing.T) {
 
 @(test)
 test_pressed_clears_pending_flag :: proc(t: ^testing.T) {
+	sync.lock(&g_input_test_state_mutex)
+	defer sync.unlock(&g_input_test_state_mutex)
 	override = Mouse_Override{active = true, pending_press_left = true}
 	testing.expect(t, is_mouse_button_pressed(.LEFT))
 	testing.expect(t, !override.pending_press_left,
@@ -52,6 +57,8 @@ test_pressed_clears_pending_flag :: proc(t: ^testing.T) {
 
 @(test)
 test_released_clears_pending_flag :: proc(t: ^testing.T) {
+	sync.lock(&g_input_test_state_mutex)
+	defer sync.unlock(&g_input_test_state_mutex)
 	override = Mouse_Override{active = true, pending_release_left = true}
 	testing.expect(t, is_mouse_button_released(.LEFT))
 	testing.expect(t, !override.pending_release_left)
@@ -60,6 +67,8 @@ test_released_clears_pending_flag :: proc(t: ^testing.T) {
 
 @(test)
 test_pending_flags_do_not_bleed_across_buttons :: proc(t: ^testing.T) {
+	sync.lock(&g_input_test_state_mutex)
+	defer sync.unlock(&g_input_test_state_mutex)
 	override = Mouse_Override{
 		active             = true,
 		pending_press_left = true,

--- a/src/redin/input/state.odin
+++ b/src/redin/input/state.odin
@@ -21,8 +21,13 @@ Input_State :: struct {
 
 state: Input_State
 
+// Both init and destroy must be idempotent: every owned field is freed
+// AND its slice/string header is reset to {}/"". Otherwise a stale header
+// survives across init/destroy pairs and the next delete is a double-free
+// (visible as "bad free" warnings under the tracking allocator).
 state_init :: proc() {
 	delete(state.selection_path)
+	state.selection_path = {}
 	state.selection_start = -1
 	state.selection_end = -1
 	state.selection_kind = .None
@@ -30,10 +35,13 @@ state_init :: proc() {
 
 state_destroy :: proc() {
 	delete(state.text)
+	state.text = {}
 	if len(state.last_dispatched) > 0 {
 		delete(state.last_dispatched)
 	}
+	state.last_dispatched = ""
 	delete(state.selection_path)
+	state.selection_path = {}
 }
 
 // Called when an input gains focus. Copies the node's value into the editing buffer.
@@ -50,6 +58,7 @@ focus_enter :: proc(value: string) {
 	state.active = true
 	if len(state.last_dispatched) > 0 {
 		delete(state.last_dispatched)
+		state.last_dispatched = ""
 	}
 	state.last_dispatched = strings_clone(value)
 }
@@ -102,6 +111,7 @@ controlled_sync :: proc(node_value: string) -> bool {
 	}
 	if len(state.last_dispatched) > 0 {
 		delete(state.last_dispatched)
+		state.last_dispatched = ""
 	}
 	state.last_dispatched = strings_clone(node_value)
 	return true

--- a/src/redin/input/state_test.odin
+++ b/src/redin/input/state_test.odin
@@ -1,9 +1,20 @@
 package input
 
+import "core:sync"
 import "core:testing"
+
+// `state` and `override` are package-level mutable globals (see
+// state.odin / override.odin). Odin's test runner is parallel by default,
+// so any test that mutates either global must serialize through this
+// mutex. Same pattern as bridge's g_test_http_state_mutex. Package-scope
+// (no @private) so text_select_test and override_test can lock the same
+// mutex.
+g_input_test_state_mutex: sync.Mutex
 
 @(test)
 test_set_text_selection_stores_path_copy :: proc(t: ^testing.T) {
+	sync.lock(&g_input_test_state_mutex)
+	defer sync.unlock(&g_input_test_state_mutex)
 	state_init()
 	defer state_destroy()
 
@@ -21,6 +32,8 @@ test_set_text_selection_stores_path_copy :: proc(t: ^testing.T) {
 
 @(test)
 test_clear_text_selection_frees_path :: proc(t: ^testing.T) {
+	sync.lock(&g_input_test_state_mutex)
+	defer sync.unlock(&g_input_test_state_mutex)
 	state_init()
 	defer state_destroy()
 
@@ -34,6 +47,8 @@ test_clear_text_selection_frees_path :: proc(t: ^testing.T) {
 
 @(test)
 test_clear_text_selection_resets_has_selection :: proc(t: ^testing.T) {
+	sync.lock(&g_input_test_state_mutex)
+	defer sync.unlock(&g_input_test_state_mutex)
 	state_init()
 	defer state_destroy()
 	set_text_selection([]u8{0x01}, 3, 7)
@@ -44,6 +59,8 @@ test_clear_text_selection_resets_has_selection :: proc(t: ^testing.T) {
 
 @(test)
 test_focus_enter_clears_text_selection :: proc(t: ^testing.T) {
+	sync.lock(&g_input_test_state_mutex)
+	defer sync.unlock(&g_input_test_state_mutex)
 	state_init()
 	defer state_destroy()
 	set_text_selection([]u8{0xAA}, 0, 1)
@@ -54,6 +71,8 @@ test_focus_enter_clears_text_selection :: proc(t: ^testing.T) {
 
 @(test)
 test_copy_selection_source_text_for_text_kind :: proc(t: ^testing.T) {
+	sync.lock(&g_input_test_state_mutex)
+	defer sync.unlock(&g_input_test_state_mutex)
 	state_init()
 	defer state_destroy()
 	set_text_selection([]u8{0x01}, 4, 9)
@@ -63,6 +82,8 @@ test_copy_selection_source_text_for_text_kind :: proc(t: ^testing.T) {
 
 @(test)
 test_copy_selection_source_text_for_input_kind :: proc(t: ^testing.T) {
+	sync.lock(&g_input_test_state_mutex)
+	defer sync.unlock(&g_input_test_state_mutex)
 	state_init()
 	defer state_destroy()
 	focus_enter("hello world")
@@ -75,6 +96,8 @@ test_copy_selection_source_text_for_input_kind :: proc(t: ^testing.T) {
 
 @(test)
 test_copy_selection_source_text_none_kind :: proc(t: ^testing.T) {
+	sync.lock(&g_input_test_state_mutex)
+	defer sync.unlock(&g_input_test_state_mutex)
 	state_init()
 	defer state_destroy()
 	got := copy_selection_source_text("ignored")
@@ -83,6 +106,8 @@ test_copy_selection_source_text_none_kind :: proc(t: ^testing.T) {
 
 @(test)
 test_copy_selection_source_text_clamps_text_kind :: proc(t: ^testing.T) {
+	sync.lock(&g_input_test_state_mutex)
+	defer sync.unlock(&g_input_test_state_mutex)
 	state_init()
 	defer state_destroy()
 	set_text_selection([]u8{0x01}, 2, 100)   // hi beyond content

--- a/src/redin/input/text_select_test.odin
+++ b/src/redin/input/text_select_test.odin
@@ -1,5 +1,6 @@
 package input
 
+import "core:sync"
 import "core:testing"
 import "../types"
 
@@ -18,6 +19,8 @@ test_find_node_by_path_returns_match :: proc(t: ^testing.T) {
 
 @(test)
 test_resolve_clears_when_path_missing :: proc(t: ^testing.T) {
+	sync.lock(&g_input_test_state_mutex)
+	defer sync.unlock(&g_input_test_state_mutex)
 	state_init()
 	defer state_destroy()
 	set_text_selection([]u8{0xAA}, 0, 3)
@@ -30,6 +33,8 @@ test_resolve_clears_when_path_missing :: proc(t: ^testing.T) {
 
 @(test)
 test_resolve_clears_when_content_shrinks :: proc(t: ^testing.T) {
+	sync.lock(&g_input_test_state_mutex)
+	defer sync.unlock(&g_input_test_state_mutex)
 	state_init()
 	defer state_destroy()
 


### PR DESCRIPTION
## Summary

Two related issues surfaced by \`odin test src/redin/input\`:

1. **Bad-frees** (#118): \`state_init\` / \`state_destroy\` / \`focus_enter\` / \`controlled_sync\` called \`delete\` on owned dynamic arrays and strings without resetting the field. The slice/string header retained a stale pointer + length, so the next \`delete\` on the same field was a double-free — visible as \`+++ bad free\` warnings even under \`-define:ODIN_TEST_THREADS=1\`.
2. **Races** (#118, #61): \`state\` and \`override\` are package-global mutables; the default Odin test runner uses one thread per logical CPU, so two state-mutating tests ran concurrently. Surfaced as random failures like \"expected selection_kind to be Input, got None\".

## Fix

- After every \`delete(state.<field>)\` reset the header (\`= {}\` for dynamic arrays / slices, \`= \"\"\` for strings). Both \`state_init\` and \`state_destroy\` are now idempotent.
- Add a package-scope \`g_input_test_state_mutex\` (declared in \`state_test.odin\`, package-visible so the other test files use it — same pattern as bridge's \`g_test_http_state_mutex\`). Every test that touches \`state\` or \`override\` locks it; tests serialize against each other; the runner stays parallel package-wide.
- Drop the obsolete \"use \`ODIN_TEST_THREADS=1\`\" comment in \`override_test.odin\`.

Also closes #61 — same race against \`src/host/input/state.odin\` (path was renamed to \`src/redin/input/\`).

## Test plan

- [x] \`odin test src/redin/input -collection:lib=lib -collection:luajit=vendor/luajit -define:ODIN_TEST_THREADS=1\` — 22 pass, 0 bad-frees
- [x] \`odin test src/redin/input -collection:lib=lib -collection:luajit=vendor/luajit\` (default 22 threads) — 22 pass, 0 bad-frees; ran 5 consecutive clean rounds (was previously flaky 1–2 failures per run)
- [x] \`odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin\` — exit 0
- [x] \`luajit test/lua/runner.lua test/lua/test_*.fnl\` — 133 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)