### PR TITLE
docs: align source-build deps and document submodule init (closes #121, #122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ The CLI downloads a pinned redin binary into `.redin/` — no build tools needed
 
 ```bash
 # Prerequisites (Ubuntu/Debian)
-sudo apt-get install -y luajit libluajit-5.1-dev libssl-dev
+sudo apt-get install -y luajit libssl-dev \
+  libgl1-mesa-dev libx11-dev libxrandr-dev libxi-dev \
+  libxcursor-dev libxinerama-dev
+
+# Initialize submodules (lib/odin-http)
+git submodule update --init --recursive
 
 # Dev build (bakes in REDIN_DEV / REDIN_PROFILE / REDIN_TRACK_MEM)
 ./build-dev.sh
@@ -62,8 +67,10 @@ odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -o
 |-----------|---------|----------|
 | **Odin** (nightly) | Compiles the host/renderer | Yes |
 | **Raylib** | Bundled with Odin | -- |
-| **LuaJIT** (`luajit` + `libluajit-5.1-dev`) | Runs tests, AOT compiles Fennel | Yes |
+| **LuaJIT** (`luajit`) | Runs tests, AOT compiles Fennel; the C library is statically linked from `vendor/luajit/` so `libluajit-5.1-dev` is not required | Yes |
 | **OpenSSL** (`libssl-dev`) | HTTPS support via odin-http | Yes |
+| **OpenGL + X11 dev headers** (Linux only — `libgl1-mesa-dev`, `libx11-dev`, `libxrandr-dev`, `libxi-dev`, `libxcursor-dev`, `libxinerama-dev`) | Required by Odin's bundled Raylib at link time | Yes (Linux) |
+| **`lib/odin-http` submodule** | Async HTTP client used by `redin.http` | Yes |
 
 ## Test
 
@@ -73,6 +80,13 @@ luajit test/lua/runner.lua test/lua/test_*.fnl
 
 # Build check
 odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin
+```
+
+UI integration tests additionally need [Babashka](https://github.com/babashka/babashka#installation) (`bb`), and `xvfb` for headless runs:
+
+```bash
+sudo apt-get install -y xvfb
+bash test/ui/run-all.sh --headless
 ```
 
 ## Project structure

--- a/build-dev.sh
+++ b/build-dev.sh
@@ -9,6 +9,16 @@
 #   ./build-dev.sh -define:REDIN_AGENT=true     # dev + agent channel
 #   ./build-dev.sh -o:speed                     # optimized dev build
 set -e
+
+# Without the odin-http submodule the Odin compiler reports an opaque
+# "Empty directory: lib:odin-http" / "Path does not exist" error.
+# Surface a single clear instruction instead.
+if [ ! -e lib/odin-http/client/client.odin ]; then
+    echo "error: lib/odin-http is not initialized." >&2
+    echo "       run: git submodule update --init --recursive" >&2
+    exit 1
+fi
+
 exec odin build src/cmd/redin \
     -collection:lib=lib -collection:luajit=vendor/luajit \
     -define:REDIN_DEV=true \

--- a/setup.sh
+++ b/setup.sh
@@ -7,19 +7,33 @@ set -euo pipefail
 echo "=== redin development setup ==="
 
 # --- System packages ---
+# Build deps mirror .github/workflows/test.yml; xvfb is needed for the
+# `bash test/ui/run-all.sh --headless` UI test path. We deliberately do
+# NOT install libluajit-5.1-dev — the LuaJIT C library is statically
+# linked from vendor/luajit/lib/libluajit-5.1.a.
 echo ""
 echo "Installing system packages..."
 if command -v apt-get &>/dev/null; then
   sudo apt-get update -qq
-  sudo apt-get install -y luajit libluajit-5.1-dev libssl-dev clang xvfb
+  sudo apt-get install -y luajit libssl-dev \
+    libgl1-mesa-dev libx11-dev libxrandr-dev libxi-dev \
+    libxcursor-dev libxinerama-dev \
+    xvfb
 elif command -v dnf &>/dev/null; then
-  sudo dnf install -y luajit luajit-devel openssl-devel
+  sudo dnf install -y luajit openssl-devel \
+    mesa-libGL-devel libX11-devel libXrandr-devel libXi-devel \
+    libXcursor-devel libXinerama-devel \
+    xorg-x11-server-Xvfb
 elif command -v pacman &>/dev/null; then
-  sudo pacman -S --needed luajit openssl
+  sudo pacman -S --needed luajit openssl \
+    mesa libx11 libxrandr libxi libxcursor libxinerama xorg-server-xvfb
 elif command -v brew &>/dev/null; then
   brew install luajit openssl
 else
-  echo "WARNING: Unknown package manager. Install LuaJIT, libluajit-5.1-dev, and libssl-dev manually."
+  echo "WARNING: Unknown package manager. Install LuaJIT runtime, libssl-dev,"
+  echo "and the GL/X11 dev headers (libgl1-mesa-dev, libx11-dev, libxrandr-dev,"
+  echo "libxi-dev, libxcursor-dev, libxinerama-dev) manually. Add xvfb if you"
+  echo "plan to run UI tests headless."
 fi
 
 # --- Tool checks ---


### PR DESCRIPTION
## Summary

The Ubuntu/Debian dependency lists in \`README.md\`, \`setup.sh\`, and \`.github/workflows/test.yml\` all disagreed. CI is the truth — it builds and runs UI tests on every push — so fold its set back into the developer-facing docs.

- README + setup.sh now install the GL/X11 dev headers Odin's bundled raylib links against on Linux: \`libgl1-mesa-dev\`, \`libx11-dev\`, \`libxrandr-dev\`, \`libxi-dev\`, \`libxcursor-dev\`, \`libxinerama-dev\`.
- Drop \`libluajit-5.1-dev\`. The LuaJIT C library is statically linked from \`vendor/luajit/lib/libluajit-5.1.a\`; the dev package is never used. CI never installed it.
- README's **Test** section now points at \`xvfb\` + Babashka for the UI test path.
- README's **Building from source** gains \`git submodule update --init --recursive\` (CI's \`actions/checkout\` already does this; the README path was the gap). Fixes #121.
- \`setup.sh\` dnf and pacman branches get matching GL/X11 + xvfb equivalents.

Also harden \`build-dev.sh\`: when \`lib/odin-http\` is empty, exit 1 with a one-line instruction (\`run: git submodule update --init --recursive\`) instead of letting Odin emit an opaque \`Empty directory: lib:odin-http\` error.

## Test plan

- [x] \`mv lib/odin-http /tmp/...; ./build-dev.sh\` → \`error: lib/odin-http is not initialized. run: git submodule update --init --recursive\`, exit 1
- [x] (after restore) \`./build-dev.sh\` → exit 0, \`build/redin\` (7.2 MiB) produced
- [x] \`bash -n setup.sh\` / \`bash -n build-dev.sh\` → both parse cleanly
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)