### PR TITLE
docs: sync with post-#129 audit (closes #134 except packaging)

### DIFF
--- a/.claude/skills/redin-dev/SKILL.md
+++ b/.claude/skills/redin-dev/SKILL.md
@@ -257,9 +257,13 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:$PORT/state
 | GET | /state/path.to.value | Nested state lookup |
 | GET | /aspects | Current theme |
 | GET | /selection | Current text/input selection: `{kind: none\|input\|text, start, end, text}` |
+| GET | /window | Current window size: `{"width":N,"height":N}` |
 | GET | /screenshot | PNG screenshot |
-| POST | /events | Dispatch event (JSON: `["event-name", payload]`) |
+| POST | /events | Dispatch event. JSON body is the event vector itself, e.g. `["counter/inc"]` or `["todo/add","Buy milk"]` |
 | POST | /click | Inject click (JSON: `{"x":N,"y":N}`) |
+| POST | /resize | Resize window (JSON: `{"width":N,"height":N}`; each in `[100, 8192]`) |
+| POST | /maximize | Maximize the window |
+| POST | /restore | Restore the window from maximized |
 | POST | /shutdown | Graceful shutdown |
 | PUT | /aspects | Replace theme |
 | POST | /input/takeover | Take over mouse polling for tests. Required before `/input/mouse/*`. Returns 409 if already active. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,11 @@ zero profile instrumentation, and zero tracking-allocator overhead.
 ./build/redin examples/kitchen-sink.fnl
 ```
 
-Whether the dev server starts depends on the build flags. A binary
-built with `./build-dev.sh` starts the dev server unconditionally; a
-bare `odin build` binary never does. There are no runtime CLI flags.
+Exactly one positional argument is accepted — the path to the app
+`.fnl` (or `.lua`) file. Extra positional args exit with status 2.
+There are no runtime CLI flags. Whether the dev server starts depends
+on the build flags: a binary built with `./build-dev.sh` starts it
+unconditionally; a bare `odin build` binary never does.
 
 ## Testing
 
@@ -117,7 +119,8 @@ walks upward (8801, 8802, ...) if busy, and writes the bound port to
 `./.redin-port`. A per-run random auth token is written to
 `./.redin-token` (0600). Every non-`OPTIONS` request must carry
 `Authorization: Bearer <token>`, and the `Host` header must be
-`localhost:<port>` / `127.0.0.1:<port>`.
+`localhost:<port>` / `127.0.0.1:<port>`. Requests are served by an
+acceptor plus a 4-handler worker pool (up to 4 in flight at a time).
 
 | Method | Path | Description |
 |--------|------|-------------|
@@ -125,10 +128,15 @@ walks upward (8801, 8802, ...) if busy, and writes the bound port to
 | `GET` | `/state` | Full app state |
 | `GET` | `/state/<dot.path>` | Nested state lookup (e.g. `/state/form.name`) |
 | `GET` | `/aspects` | Current theme map |
+| `GET` | `/selection` | Active text selection (`{kind, ...}`); `{"kind":"none"}` when nothing is selected |
+| `GET` | `/window` | Current window size (`{"width":N,"height":N}`) |
 | `GET` | `/profile` | Ring-buffered frame timings (requires `-define:REDIN_PROFILE=true`) |
 | `GET` | `/screenshot` | PNG screenshot of the window |
-| `POST` | `/events` | Dispatch an event (JSON body: `[:event-name, payload]`) |
+| `POST` | `/events` | Dispatch an event. JSON body is the event vector itself, e.g. `["counter/inc"]` or `["todo/add","Buy milk"]` |
 | `POST` | `/click` | Inject a mouse click (JSON body: `{"x":N,"y":N}`) |
+| `POST` | `/resize` | Resize the window (JSON body: `{"width":N,"height":N}`; each in `[100, 8192]`) |
+| `POST` | `/maximize` | Maximize the window |
+| `POST` | `/restore` | Restore the window from maximized |
 | `POST` | `/shutdown` | Request graceful shutdown |
 | `PUT` | `/aspects` | Replace the theme map (JSON body) |
 | `POST` | `/input/takeover` | Take over mouse polling for tests. Required before `/input/mouse/*`. |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The CLI downloads a pinned redin binary into `.redin/` — no build tools needed
 
 ### Building from source
 
+The one-step path is `./setup.sh`, which installs system packages (via apt / dnf / pacman / brew), pulls submodules, and runs `./build-dev.sh`. The manual equivalent is below.
+
 ```bash
 # Prerequisites (Ubuntu/Debian)
 sudo apt-get install -y luajit libssl-dev \
@@ -53,7 +55,8 @@ git submodule update --init --recursive
 # Dev build (bakes in REDIN_DEV / REDIN_PROFILE / REDIN_TRACK_MEM)
 ./build-dev.sh
 
-# Run — dev server starts because REDIN_DEV is compiled in
+# Run — dev server starts because REDIN_DEV is compiled in.
+# Exactly one positional argument is accepted; extra args exit 2.
 ./build/redin examples/kitchen-sink.fnl
 ```
 

--- a/docs/app-api.md
+++ b/docs/app-api.md
@@ -465,7 +465,7 @@ Theme is pushed to the host on `set-theme` via `redin.set_theme`.
 
 ## Canvas providers
 
-The `canvas` element supports a `:provider` attribute naming a registered canvas provider. Canvas providers are a planned extension point; the element is parsed by the host but the provider registry is not yet implemented.
+The `canvas` element supports a `:provider` attribute naming a registered canvas provider. The provider registry and lifecycle (`register` / `unregister`, start/update/suspend/stop) are implemented in `src/redin/canvas/canvas.odin`, and Fennel apps can register providers via `(require :canvas)`. See [`docs/reference/canvas.md`](reference/canvas.md) for the full API.
 
 ```fennel
 [:canvas {:provider "sparkline" :width 200 :height 40}]
@@ -485,6 +485,7 @@ The host (Odin + Raylib) exposes a `redin` global table with these functions:
 | `redin.now()`         | Current time as Unix seconds (float)              |
 | `redin.measure_text(text, size)` | Measure text dimensions, returns width, height |
 | `redin.http(id, url, method, headers, body, timeout)` | Queue async HTTP request |
+| `redin.shell(id, cmd_table, stdin)` | Queue async shell command (used by the `:shell` effect) |
 | `redin.json_encode(v)` | Encode Lua value to JSON string                 |
 | `redin.json_decode(s)` | Decode JSON string to Lua value                 |
 

--- a/docs/core-api.md
+++ b/docs/core-api.md
@@ -149,7 +149,7 @@ The flattening is a single pass when the frame enters the pipeline. No fragment 
 | Tag       | Purpose                                                | Status        | Required attrs |
 | --------- | ------------------------------------------------------ | ------------- | -------------- |
 | `text`    | Text content. Last positional arg is the string.       | implemented   | --             |
-| `image`   | Texture from file.                                     | implemented   | `src`          |
+| `image`   | Placeholder slot — themed rect; texture loading TBD.   | placeholder   | --             |
 | `input`   | Editable text field.                                   | implemented   | --             |
 | `button`  | Clickable button. Last positional arg is the label.    | implemented   | --             |
 | `canvas`  | Independent render region. Runs a registered provider. | implemented   | `provider`     |
@@ -616,6 +616,17 @@ PUT calls into Lua (`theme.set-theme`) to replace the theme, which also updates 
 
 Click injects a `MouseEvent` into the input queue, which is processed on the next frame.
 
+### Window
+
+| Method | Path        | Body                              | Response                                |
+| ------ | ----------- | --------------------------------- | --------------------------------------- |
+| GET    | `/window`   | --                                | `{"width": N, "height": N}`             |
+| POST   | `/resize`   | `{"width": N, "height": N}`       | `{"ok": true}`; `400` if outside `[100, 8192]` on either axis |
+| POST   | `/maximize` | --                                | `{"ok": true}`                          |
+| POST   | `/restore`  | --                                | `{"ok": true}`                          |
+
+`GET /window` returns the current Raylib screen dimensions. `POST /resize` calls `rl.SetWindowSize` after JSON validation; `/maximize` and `/restore` are direct passes to the corresponding Raylib calls.
+
 ### Control
 
 | Method | Path        | Body | Response        |
@@ -692,7 +703,7 @@ Per-node-type semantics:
 | `:text` | text string | string → replaces text |
 | `:input` | current value (live) | string → sets value |
 | `:button` | label string | string → sets label |
-| `:image` | source path | string → sets source |
+| `:image` | (none — no source attr is read by the parser yet) | string → stored on the node but currently a no-op (texture loading TBD) |
 | `:vbox` `:hbox` `:stack` `:popout` `:modal` | children list as JSON array | JSON array → replaces children |
 
 #### Endpoints

--- a/docs/guide/lua-guide.md
+++ b/docs/guide/lua-guide.md
@@ -236,7 +236,14 @@ Then run your Lua app:
 ./build/redin todo.lua
 ```
 
-To enable the dev server, build with `-define:REDIN_DEV=true`:
+To enable the dev server, use `./build-dev.sh` (bakes in `REDIN_DEV`, `REDIN_PROFILE`, and `REDIN_TRACK_MEM`):
+
+```sh
+./build-dev.sh
+./build/redin todo.lua
+```
+
+Equivalent manual command (only `REDIN_DEV`, no profiling or memory tracking):
 
 ```sh
 odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -89,7 +89,14 @@ The window opens. Click the button -- the counter increments.
 
 ### Dev mode
 
-Build with the dev server enabled:
+Use `./build-dev.sh`, which bakes in `REDIN_DEV`, `REDIN_PROFILE`, and `REDIN_TRACK_MEM`:
+
+```sh
+./build-dev.sh
+./build/redin counter.fnl
+```
+
+Equivalent manual command (if you want only `REDIN_DEV` and no profiling or memory tracking):
 
 ```sh
 odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit \

--- a/docs/reference/dev-server.md
+++ b/docs/reference/dev-server.md
@@ -10,6 +10,8 @@ Starts when the binary was built with `-define:REDIN_DEV=true` (or `-define:REDI
 
 Read endpoints reflect the last state pushed to the host. Write endpoints queue events into the main input channel as if they came from real user input.
 
+The listener is an acceptor thread plus a fixed pool of 4 handler threads, so up to 4 requests can be in flight at once. Beyond that, new connections queue until a handler frees up.
+
 Implementation: `src/redin/bridge/devserver.odin`.
 
 ### Authentication
@@ -35,6 +37,8 @@ AUTH="Authorization: Bearer $TOKEN"
 ### Runtime caveats
 
 **When built with `-define:REDIN_DEV=true`, the framework trusts its filesystem.** The hot-reload watcher re-requires `src/runtime/*.fnl` whenever their mtimes advance. Anyone who can write to `src/runtime` gets code execution in the running process on the next tick. Don't run a dev build from a world-writable directory, and don't ship dev builds in production.
+
+Hot-reload (and the cwd-relative `src/runtime/?.fnl` / `vendor/fennel/?.lua` package paths it depends on) only activates when the dev binary is run from inside the redin source tree itself — detected by the presence of `src/cmd/redin/main.odin` in the working directory. A dev-flagged binary run from an external app directory still serves the HTTP endpoints, but does not watch any files.
 
 **The bearer token is a capability.** Any holder can dispatch events, which means any app-registered `:shell` or `:http` effect is one authenticated POST away from arbitrary shell execution or network access in the user's context. The token is 0600 and per-run, so this only matters if the token leaks — but plan accordingly when wiring `:shell` handlers.
 
@@ -73,6 +77,22 @@ curl -H "$AUTH" http://localhost:$PORT/aspects
 ```
 
 Response: full theme as JSON object (serialized from host-side `Theme` structs).
+
+### `GET /selection` -- active text selection
+
+```bash
+curl -H "$AUTH" http://localhost:$PORT/selection
+```
+
+Response: a JSON object describing the current text selection. When nothing is selected, returns `{"kind":"none"}`. Otherwise returns the selection kind plus its source node path and resolved text range.
+
+### `GET /window` -- current window size
+
+```bash
+curl -H "$AUTH" http://localhost:$PORT/window
+```
+
+Response: `{"width": N, "height": N}` — the current Raylib screen dimensions in pixels.
 
 ### `GET /profile` -- frame timing ring buffer
 
@@ -117,15 +137,21 @@ Returns binary PNG. Content-Type: `image/png`. Captures the current Raylib windo
 
 ### `POST /events` -- dispatch an event
 
+The JSON body is the event vector itself — the first element is the event name, and any remaining elements are positional args. The handler decodes it, wraps it in a one-element list, and hands it to the Fennel-side `view.deliver-events`.
+
 ```bash
 curl -X POST -H "$AUTH" http://localhost:$PORT/events \
   -H 'Content-Type: application/json' \
-  -d '{"event": ["event/increment"]}'
+  -d '["counter/inc"]'
+```
+
+```bash
+curl -X POST -H "$AUTH" http://localhost:$PORT/events \
+  -H 'Content-Type: application/json' \
+  -d '["todo/add","Buy milk"]'
 ```
 
 Response: `{"ok": true}`
-
-The JSON body is decoded into a Lua value and passed to the event system.
 
 ### `POST /click` -- synthetic click
 
@@ -140,6 +166,31 @@ curl -X POST -H "$AUTH" http://localhost:$PORT/click \
 Response: `{"ok": true}`
 
 Queues a `MouseEvent` with `button = LEFT` into the input event queue.
+
+### `POST /resize` -- resize the window
+
+```bash
+curl -X POST -H "$AUTH" -d '{"width":1280,"height":800}' \
+  http://localhost:$PORT/resize
+```
+
+Response: `{"ok": true}` on success; `400` if the body is not a JSON object or either dimension is outside `[100, 8192]`. Calls `rl.SetWindowSize`.
+
+### `POST /maximize` -- maximize the window
+
+```bash
+curl -X POST -H "$AUTH" http://localhost:$PORT/maximize
+```
+
+Response: `{"ok": true}`. Calls `rl.MaximizeWindow`.
+
+### `POST /restore` -- restore the window from maximized
+
+```bash
+curl -X POST -H "$AUTH" http://localhost:$PORT/restore
+```
+
+Response: `{"ok": true}`. Calls `rl.RestoreWindow`.
 
 ### `POST /shutdown` -- graceful shutdown
 

--- a/docs/reference/elements.md
+++ b/docs/reference/elements.md
@@ -13,7 +13,7 @@ Reference for all element tags in redin frames.
 | `input` | Implemented |
 | `button` | Implemented |
 | `text` | Implemented |
-| `image` | Implemented |
+| `image` | Placeholder (themed rect — no texture loading yet) |
 | `popout` | Implemented |
 | `modal` | Implemented |
 
@@ -102,19 +102,21 @@ Typography (`font-size`, `weight`, `color`) comes from `aspect`.
 
 ### `image`
 
-Renders a texture loaded from a file path.
+Reserved leaf-node tag. Texture loading from a file path is not implemented yet — the renderer draws a themed rectangle with an `"image"` label so the slot is visible in layout. The element exists so that frames, themes, and the agent channel can reference image slots without breaking when texture support lands.
 
-**Required attrs:** `src`
+**Required attrs:** none
 
 **Optional attrs:**
 
 | Attribute | Type | Default | Notes |
 | --------- | ---- | ------- | ----- |
-| `src` | string | -- | File path to the image. **Required.** |
-| `:agent` | `:read \| :edit` | -- | Optional. Pairs with `:id` to expose the node to the agent channel (REDIN_AGENT only). |
+| `aspect` | string | -- | Theme entry used to draw the placeholder rectangle. |
+| `width` | size | -- | Layout width. |
+| `height` | size | -- | Layout height. |
+| `:agent` | `:read \| :edit` | -- | Optional. Pairs with `:id` to expose the node to the agent channel (REDIN_AGENT only). Writes set a `:src` attr, but the parser does not currently read it. |
 
 ```fennel
-[:image {:src "assets/logo.png" :width 120 :height 40}]
+[:image {:aspect :logo :width 120 :height 40}]
 ```
 
 ---
@@ -293,7 +295,7 @@ Main-axis centering only takes effect when every child has an explicit size (a s
 
 ```fennel
 [:hbox {}
-  [:image {:src "assets/avatar.png" :width 32 :height 32}]
+  [:image {:aspect :avatar :width 32 :height 32}]
   [:text {:aspect :body} "Alice"]]
 ```
 
@@ -413,7 +415,7 @@ The frame validator checks the following. Invalid frames are rejected before rea
 | Rule | Detail |
 | ---- | ------ |
 | **Known tag** | The tag must be one of the registered element names. |
-| **Required attributes present** | `image` needs `src`; `canvas` needs `provider`; `input` needs `value`; `button` needs `click`. |
+| **Required attributes present** | `canvas` needs `provider`; `input` needs `value`; `button` needs `click`. |
 | **No visual properties** | `bg`, `color`, `border`, `font-size`, `weight`, `radius`, `border-width`, `opacity` are rejected on any element. |
 | **Leaf nodes have no children** | `text`, `image`, `input`, `button`, `canvas` must not have child frames. |
 | **`modal` and `popout` not at root** | Both must be nested inside a container element. |

--- a/docs/reference/native-bridge.md
+++ b/docs/reference/native-bridge.md
@@ -113,9 +113,13 @@ ok, err := bridge.dispatch_tos(L, "combat/push")
 
 These setters install host-side policy for the built-in `redin.http` and `redin.shell` host functions. Both are global, take a slice of strings (cloned internally), and accept `nil` to clear back to the permissive default. Call before or after `redin.run`; changes apply to subsequent requests.
 
+**Open-default warning.** When the setter has not been called, the first invocation of the corresponding host function prints a one-shot `[redin] WARNING:` block to stderr explaining that the surface is unrestricted and pointing at the setter. Logged once per process. This is an intentional nudge — call the setter explicitly to acknowledge the open default and silence the warning.
+
 ### `bridge.set_http_whitelist(allow: []string)`
 
 When set, `redin.http` accepts only URLs whose host matches an entry. Entries are either hostname literals (case-insensitive — e.g. `"api.example.com"`) or CIDR blocks (IPv4 or IPv6 — e.g. `"127.0.0.0/8"`, `"::1/128"`). CIDR entries are matched only against IP-literal hosts, not DNS names. `nil` (the default) accepts any host.
+
+Hostname comparison is ASCII-byte case-insensitive. IDN hostnames must be passed in their punycode (`xn--...`) form — `münchen.example` is not equivalent to `xn--mnchen-3ya.example`, and the URL parser punycodes the request host before matching.
 
 Rejection failure (delivered to the `:http` effect's `on-error`): `{status: 0, error: "host <name> not in http whitelist"}`.
 

--- a/docs/superpowers/plans/README.md
+++ b/docs/superpowers/plans/README.md
@@ -1,0 +1,11 @@
+# Archived implementation plans
+
+The files in this directory are **historical implementation plans** that were used while building a feature. They are *not* maintained as current documentation.
+
+A plan in here may reference:
+
+- Source paths that have since moved (e.g. `src/host/...` instead of `src/cmd/redin/` + `src/redin/`).
+- Runtime CLI flags that no longer exist (e.g. `--dev`, `--profile`, `--track-mem`). These are now compile-time flags (`-define:REDIN_DEV=true`, etc.).
+- Endpoint shapes or APIs that have since changed.
+
+When in doubt, treat the code, [`CLAUDE.md`](../../../CLAUDE.md), and the maintained references under [`docs/`](../..) as the source of truth. Use these plans only as background reading for *why* a feature was built the way it was.

--- a/docs/superpowers/specs/README.md
+++ b/docs/superpowers/specs/README.md
@@ -1,0 +1,11 @@
+# Archived design specs
+
+The files in this directory are **historical design specs** that fed the corresponding implementation plans in [`../plans/`](../plans/). They are *not* maintained as current documentation.
+
+A spec in here may reference:
+
+- Source paths that have since moved (e.g. `src/host/...` instead of `src/cmd/redin/` + `src/redin/`).
+- Runtime CLI flags that no longer exist (e.g. `--dev`, `--profile`, `--track-mem`). These are now compile-time flags (`-define:REDIN_DEV=true`, etc.).
+- Endpoint shapes, attribute names, or APIs that have since evolved.
+
+When in doubt, treat the code, [`CLAUDE.md`](../../../CLAUDE.md), and the maintained references under [`docs/`](../..) as the source of truth. Use these specs only as background reading for *why* a feature was designed the way it was.


### PR DESCRIPTION
## Summary

Addresses #134 — the doc audit done on 2026-05-14 after the security-audit (#129) work landed. Touches every maintained doc that drifted from the code, plus two new archival READMEs under `docs/superpowers/`.

## Findings closed

| # | Doc finding | Resolution |
|---|---|---|
| 1 | Dev-server endpoint table missing `/selection`, `/window`, `/resize`, `/maximize`, `/restore` | Added to `CLAUDE.md`, `docs/reference/dev-server.md`, `.claude/skills/redin-dev/SKILL.md`, and `docs/core-api.md` |
| 2 | `:image` doc claimed `src` was required | Doc now matches code — placeholder themed rect, no src parsing yet |
| 3 | `docs/app-api.md` said canvas providers were unimplemented | Replaced with pointer to `docs/reference/canvas.md` |
| 4 | README submodule + deps drift | README already has the submodule init step; added a pointer to `./setup.sh` as the one-step path |
| 6 | `docs/superpowers/{plans,specs}/` unmarked as archival | Added `README.md` in each subdir explaining the contents are historical |
| 7 | Handler pool not documented | One sentence in `CLAUDE.md` and `dev-server.md` |
| 8 | `redin.http` / `redin.shell` open-warn undocumented | Added under "Effect policy setters" in `docs/reference/native-bridge.md` |
| 9 | IDN punycode rule missing | Added to `set_http_whitelist` in `docs/reference/native-bridge.md` |
| 10 | CLI extra-positional rejection (#129 L1) undocumented | Noted in `CLAUDE.md` and `README.md` |
| 11 | `redin.shell` missing from `app-api.md` host-bridge table | Added |
| 12 | Source-tree gating for hot-reload | `dev-server.md` "Runtime caveats" now describes the `is_redin_source_tree` marker |
| 13 | `/events` body shape misdocumented in `CLAUDE.md` | Replaced `[:event-name, payload]` with the real event-vector form (`["counter/inc"]`, `["todo/add","Buy milk"]`); also fixed the misleading `{"event": [...]}` example in `dev-server.md` |
| 14 | Guides showed hand-rolled `odin build` instead of `./build-dev.sh` | `quickstart.md` and `lua-guide.md` now lead with `./build-dev.sh`; manual command kept as the equivalent footnote |

## Not in this PR

**#5 — release.sh / release.yml skill packaging mismatch.** The two scripts package the skill under different directories (`.claude/skills/redin-dev/` vs `skills/redin-dev/`) and copy a slightly different doc set into `dist/`. That's automation work, not a doc fix, and deserves a deliberate decision about which layout is canonical. Tracked in #134 and left open.

## Test plan

- [x] All code claims verified against the current source (every file:line reference in #134 cross-checked).
- [ ] Maintainer reads diff; markdown renders cleanly on GitHub.
- [ ] Spot-check a few of the new examples (e.g. `curl -d '["counter/inc"]' /events`) against a running dev binary.

Refs #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)