### PR TITLE
chore(devserver): gate destructive dev routes behind b.dev_mode

### DIFF
--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -46,6 +46,7 @@ Bridge :: struct {
 	shell_client:    Shell_Client,
 	hot_reload:      Hot_Reload,
 	dev_server:      Dev_Server,
+	dev_mode:        bool,
 	frame_changed:   bool,
 	source_tree:     bool,
 }
@@ -125,6 +126,9 @@ init :: proc(b: ^Bridge) {
 // otherwise the first /frames request queues up against load_app and
 // can take seconds to respond, which breaks bb-side test timeouts (#132).
 start_devserver :: proc(b: ^Bridge) {
+	when REDIN_DEV {
+		b.dev_mode = true
+	}
 	when REDIN_DEV || REDIN_AGENT {
 		devserver_init(&b.dev_server, b)
 	}

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -758,16 +758,28 @@ process_request :: proc(ds: ^Dev_Server, req: ^Pending_Request) {
 		} else if req.path == "/input/key" {
 			handle_post_input_key(ds, ch, req.body)
 		} else if req.path == "/shutdown" {
-			ds.shutdown_requested = true
-			respond_json_ok(ch)
+			if ds.bridge.dev_mode {
+				ds.shutdown_requested = true
+				respond_json_ok(ch)
+			} else {
+				respond_text(ch, 404, "Not found")
+			}
 		} else if req.path == "/resize" {
 			handle_post_resize(ds, ch, req.body)
 		} else if req.path == "/maximize" {
-			rl.MaximizeWindow()
-			respond_json_ok(ch)
+			if ds.bridge.dev_mode {
+				rl.MaximizeWindow()
+				respond_json_ok(ch)
+			} else {
+				respond_text(ch, 404, "Not found")
+			}
 		} else if req.path == "/restore" {
-			rl.RestoreWindow()
-			respond_json_ok(ch)
+			if ds.bridge.dev_mode {
+				rl.RestoreWindow()
+				respond_json_ok(ch)
+			} else {
+				respond_text(ch, 404, "Not found")
+			}
 		} else {
 			respond_text(ch, 404, "Not found")
 		}
@@ -1589,6 +1601,10 @@ theme_to_json :: proc(b: ^strings.Builder, t: types.Theme) {
 // --- POST handlers ---
 
 handle_post_events :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	if !ds.bridge.dev_mode {
+		respond_text(ch, 404, "Not found")
+		return
+	}
 	L := ds.bridge.L
 	lua_getglobal(L, "redin_events")
 	if lua_isnil(L, -1) {
@@ -1615,6 +1631,10 @@ handle_post_events :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string)
 }
 
 handle_post_click :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	if !ds.bridge.dev_mode {
+		respond_text(ch, 404, "Not found")
+		return
+	}
 	// Issue #78 finding L2: previously this enqueued any (x,y) the
 	// client sent, including NaN, Infinity, negative, and screen-out-of-
 	// bounds values. /resize already validates and returns 400 on bad
@@ -1649,6 +1669,10 @@ handle_post_click :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) 
 }
 
 handle_post_input_takeover :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
+	if !ds.bridge.dev_mode {
+		respond_text(ch, 404, "Not found")
+		return
+	}
 	if input.override.active {
 		respond_json_error(ch, 409, `{"error":"takeover already active"}`)
 		return
@@ -1658,6 +1682,10 @@ handle_post_input_takeover :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
 }
 
 handle_post_input_release :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
+	if !ds.bridge.dev_mode {
+		respond_text(ch, 404, "Not found")
+		return
+	}
 	if !input.override.active {
 		respond_json_error(ch, 409, `{"error":"takeover not active"}`)
 		return
@@ -1681,6 +1709,10 @@ read_mouse_button :: proc(L: ^Lua_State) -> (rl.MouseButton, bool) {
 }
 
 handle_post_input_mouse_move :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	if !ds.bridge.dev_mode {
+		respond_text(ch, 404, "Not found")
+		return
+	}
 	if !input.override.active {
 		respond_json_error(ch, 409, `{"error":"takeover not active"}`)
 		return
@@ -1711,6 +1743,10 @@ handle_post_input_mouse_move :: proc(ds: ^Dev_Server, ch: ^Response_Channel, bod
 }
 
 handle_post_input_mouse_down :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	if !ds.bridge.dev_mode {
+		respond_text(ch, 404, "Not found")
+		return
+	}
 	if !input.override.active {
 		respond_json_error(ch, 409, `{"error":"takeover not active"}`)
 		return
@@ -1761,6 +1797,10 @@ handle_post_input_mouse_down :: proc(ds: ^Dev_Server, ch: ^Response_Channel, bod
 }
 
 handle_post_input_mouse_up :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	if !ds.bridge.dev_mode {
+		respond_text(ch, 404, "Not found")
+		return
+	}
 	if !input.override.active {
 		respond_json_error(ch, 409, `{"error":"takeover not active"}`)
 		return
@@ -1839,6 +1879,10 @@ key_string_to_raylib :: proc(s: string) -> (rl.KeyboardKey, bool) {
 }
 
 handle_post_input_key :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	if !ds.bridge.dev_mode {
+		respond_text(ch, 404, "Not found")
+		return
+	}
 	L := ds.bridge.L
 	pos := 0
 	if !json_decode_value(L, body, &pos) {
@@ -1888,6 +1932,10 @@ handle_get_window :: proc(ch: ^Response_Channel) {
 }
 
 handle_post_resize :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	if !ds.bridge.dev_mode {
+		respond_text(ch, 404, "Not found")
+		return
+	}
 	// Proper JSON decode. The previous `strings.index(body, "\"width\"")`
 	// approach parsed `{"widthless":999,"width":150}` as width=999 —
 	// still bounded by the 100..8192 clamp, but fragile enough that a
@@ -1927,6 +1975,10 @@ handle_post_resize :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string)
 // --- PUT handlers ---
 
 handle_put_aspects :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	if !ds.bridge.dev_mode {
+		respond_text(ch, 404, "Not found")
+		return
+	}
 	L := ds.bridge.L
 	lua_getglobal(L, "require")
 	lua_pushstring(L, "theme")


### PR DESCRIPTION
## Summary

Follow-up to #101 (feat/agent-channel), which widened the HTTP listener to start under either `REDIN_DEV` OR `REDIN_AGENT`. Before this PR, an agent-only build (`REDIN_AGENT=true`, no `--dev`) inadvertently exposed every dev endpoint, not just `/agent/*`. The auth (Bearer token + Host check) kept them local-only, but the spec implied only read-only routes plus `/agent/*` should be reachable in agent-only mode.

**Changes:**
- Added `dev_mode: bool` field to `Bridge` struct; set to `true` in `start_devserver` when `REDIN_DEV` is compiled in.
- Added a `!ds.bridge.dev_mode → 404` gate at the top of each destructive handler and inline route arm:
  - `POST /click`, `POST /events`, `POST /resize`, `POST /shutdown`
  - `POST /maximize`, `POST /restore`
  - `POST /input/takeover`, `POST /input/release`
  - `POST /input/mouse/move`, `POST /input/mouse/down`, `POST /input/mouse/up`
  - `POST /input/key`
  - `PUT /aspects`
- Routes **not** gated (serve in both dev and agent-only builds):
  - `GET /state`, `GET /state/<path>`, `GET /frames`, `GET /aspects`, `GET /screenshot`, `GET /selection`, `GET /window`, `GET /profile`
  - `/agent/*` (already gated by `when REDIN_AGENT`)

## Test plan

- [x] Release build compiles: `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin`
- [x] Agent-only build compiles: `odin build src/cmd/redin ... -define:REDIN_AGENT=true -out:build/redin-agent`
- [x] Dev build compiles: `./build-dev.sh`
- [x] Full UI suite green: `bash test/ui/run-all.sh --headless` — all test suites passed (0 failures)
- [x] Smoke test: agent-only binary (`redin-agent`) returns `HTTP/1.1 404` on `/click`, `/events`, `/shutdown`, `/input/takeover`, `PUT /aspects`, `/resize`, `/maximize`, `/restore`; returns `HTTP/1.1 200` on `/agent/nodes`, `/state`, `/frames`, `GET /aspects`, `/screenshot`

https://claude.ai/code/session_017YVcgVP2VjTKdGtjyyMy8y

---
_Generated by [Claude Code](https://claude.ai/code/session_017YVcgVP2VjTKdGtjyyMy8y)_