### PR TITLE
feat(kitchen-sink): redesign demo + drop-handler fix

### DIFF
--- a/docs/superpowers/plans/2026-05-15-kitchen-sink-redesign.md
+++ b/docs/superpowers/plans/2026-05-15-kitchen-sink-redesign.md
@@ -1,0 +1,700 @@
+# Kitchen-sink Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refresh `examples/kitchen-sink.fnl` into a polished framework showcase and fix the drop-handler off-by-one that mis-orders items dragged downward.
+
+**Architecture:** Single-file change. Six tasks: drop-handler fix, theme rewrite, background canvas rewrite, new `:grip-dots` provider, view-tree restructure, visual+drag verification. Each task lands as its own commit so the work can be bisected if anything breaks.
+
+**Tech Stack:** Fennel (compiled to Lua 5.1) running inside the redin binary. No Odin or framework changes. Verification via the redin dev-server HTTP endpoints (`/screenshot`, `/state`, `/events`, `/input/*`).
+
+**Spec:** [`docs/superpowers/specs/2026-05-15-kitchen-sink-redesign-design.md`](../specs/2026-05-15-kitchen-sink-redesign-design.md)
+
+**Branching:** The current working branch (`docs/sync-129-aftermath`) is unrelated to this work. Recommended: cut a new branch `feat/kitchen-sink-redesign` before Task 1. The plan does not enforce this — if the user prefers a different branch strategy, follow their lead.
+
+---
+
+## File map
+
+- **Modify:** `examples/kitchen-sink.fnl` — the only file touched. Sections changed: background canvas provider, theme map, drop-handler body, view tree. New section added: `:grip-dots` canvas provider.
+- **Read only:** `docs/reference/theme.md` (for shadow vector form and hbox shadow support), `docs/core-api.md` § Drag-and-drop and § Viewport.
+
+Verification artifacts written to `/tmp/redin-shots/` (not checked in):
+- `/tmp/redin-shots/kitchen-before.png` — already captured baseline.
+- `/tmp/redin-shots/kitchen-after.png` — captured during Task 6.
+
+---
+
+## Helper: dev-server probe
+
+Several tasks call out to the running app via curl. Standard preamble used in step bodies below:
+
+```bash
+PORT=$(cat .redin-port)
+TOKEN=$(cat .redin-token)
+H="Authorization: Bearer $TOKEN"
+HH="Host: localhost:$PORT"
+```
+
+Standard launch / shutdown (used in Tasks 1 and 6):
+
+```bash
+# Launch (background)
+./build/redin examples/kitchen-sink.fnl > /tmp/redin-kitchen.log 2>&1 &
+APP_PID=$!
+# Wait for port/token files
+for i in $(seq 1 20); do [ -f .redin-port ] && [ -f .redin-token ] && break; sleep 0.2; done
+
+# Shutdown (clean)
+curl -sS -X POST -H "$H" -H "$HH" "http://localhost:$PORT/shutdown" > /dev/null
+wait "$APP_PID" 2>/dev/null
+```
+
+The existing `build/redin` is a dev build (`REDIN_DEV` + `REDIN_PROFILE` + `REDIN_TRACK_MEM`). No rebuild is needed for any task — `.fnl` files are loaded at runtime.
+
+---
+
+## Task 1: Fix drop-handler off-by-one
+
+**Files:**
+- Modify: `examples/kitchen-sink.fnl:158-178` (the `:event/drop` handler body)
+
+- [ ] **Step 1: Reproduce the bug against the current code**
+
+Launch the app (using the launch preamble above), then:
+
+```bash
+# Reset by removing all items would be ideal, but kitchen-sink has no reset
+# handler. Just observe the initial state: items 1..24 = "Test 1".."Test 24".
+curl -sS -H "$H" -H "$HH" "http://localhost:$PORT/state/items" | head -c 200; echo
+
+# Drag "Test 1" (from=1) onto position 5
+curl -sS -X POST -H "$H" -H "$HH" \
+     -d '["event/drop",{"from":1,"to":5}]' \
+     "http://localhost:$PORT/events"
+
+# Inspect the first six item texts
+curl -sS -H "$H" -H "$HH" "http://localhost:$PORT/state/items" \
+  | python3 -c 'import json,sys; xs=json.load(sys.stdin); print([x["text"] for x in xs[:6]])'
+```
+
+Expected (buggy) output: `['Test 2', 'Test 3', 'Test 4', 'Test 1', 'Test 5', 'Test 6']` — `Test 1` lands at slot 4 instead of slot 5. Confirm before continuing. Shutdown the app.
+
+- [ ] **Step 2: Replace the drop-handler body**
+
+The current handler is:
+
+```fennel
+(reg-handler :event/drop (fn [db event]
+                           (let [ctx (. event 2)
+                                 from-idx ctx.from
+                                 to-idx ctx.to
+                                 items (get db :items [])]
+                             (when (and from-idx to-idx (> from-idx 0)
+                                        (<= from-idx (length items))
+                                        (> to-idx 0) (<= to-idx (length items))
+                                        (not= from-idx to-idx))
+                               (let [item (. items from-idx)
+                                     new-items (icollect [i v (ipairs items)]
+                                                 (when (not= i from-idx) v))]
+                                 (let [insert-at (if (> from-idx to-idx) to-idx
+                                                     (- to-idx 1))]
+                                   (table.insert new-items
+                                                 (math.min insert-at
+                                                           (+ (length new-items)
+                                                              1))
+                                                 item)
+                                   (assoc db :items new-items)))))
+                           db))
+```
+
+Replace with:
+
+```fennel
+(reg-handler :event/drop (fn [db event]
+                           (let [ctx (. event 2)
+                                 from-idx ctx.from
+                                 to-idx ctx.to
+                                 items (get db :items [])]
+                             (when (and from-idx to-idx
+                                        (> from-idx 0) (<= from-idx (length items))
+                                        (> to-idx   0) (<= to-idx   (length items))
+                                        (not= from-idx to-idx))
+                               (let [item (. items from-idx)
+                                     new-items (icollect [i v (ipairs items)]
+                                                 (when (not= i from-idx) v))]
+                                 (table.insert new-items to-idx item)
+                                 (assoc db :items new-items))))
+                           db))
+```
+
+The conditional `insert-at` is gone — after `icollect` removes the source, `to-idx` already points at the correct insertion slot in both directions. The outer guard is identical to before. The outer `db` return at the very end is preserved (when the `when` doesn't fire, the handler still returns `db`).
+
+- [ ] **Step 3: Verify the fix**
+
+Launch the app, run the same probe from Step 1:
+
+```bash
+curl -sS -X POST -H "$H" -H "$HH" \
+     -d '["event/drop",{"from":1,"to":5}]' \
+     "http://localhost:$PORT/events"
+curl -sS -H "$H" -H "$HH" "http://localhost:$PORT/state/items" \
+  | python3 -c 'import json,sys; xs=json.load(sys.stdin); print([x["text"] for x in xs[:6]])'
+```
+
+Expected (fixed): `['Test 2', 'Test 3', 'Test 4', 'Test 5', 'Test 1', 'Test 6']` — `Test 1` now at slot 5.
+
+Also probe two more cases to cover both directions and an edge:
+
+```bash
+# Restart the app so item state is fresh
+curl -sS -X POST -H "$H" -H "$HH" "http://localhost:$PORT/shutdown" > /dev/null
+wait
+./build/redin examples/kitchen-sink.fnl > /tmp/redin-kitchen.log 2>&1 &
+for i in $(seq 1 20); do [ -f .redin-port ] && [ -f .redin-token ] && break; sleep 0.2; done
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token); H="Authorization: Bearer $TOKEN"; HH="Host: localhost:$PORT"
+
+# Drag upward: from=5 → to=1. Expect Test 5 first.
+curl -sS -X POST -H "$H" -H "$HH" -d '["event/drop",{"from":5,"to":1}]' "http://localhost:$PORT/events"
+curl -sS -H "$H" -H "$HH" "http://localhost:$PORT/state/items" \
+  | python3 -c 'import json,sys; xs=json.load(sys.stdin); print([x["text"] for x in xs[:6]])'
+# Expected: ['Test 5', 'Test 1', 'Test 2', 'Test 3', 'Test 4', 'Test 6']
+
+# Drag to the end: from=1 → to=24 (the current last slot).
+curl -sS -X POST -H "$H" -H "$HH" -d '["event/drop",{"from":1,"to":24}]' "http://localhost:$PORT/events"
+curl -sS -H "$H" -H "$HH" "http://localhost:$PORT/state/items" \
+  | python3 -c 'import json,sys; xs=json.load(sys.stdin); print([xs[-3]["text"], xs[-2]["text"], xs[-1]["text"]])' \
+  || true
+# Expected last three: Test 3, Test 4 (or similar), Test 5
+# The exact tail depends on the previous mutation; the key check is that
+# the item moved from slot 1 lands at slot 24 (the new tail), not slot 23.
+```
+
+Shutdown the app after the probe.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/kitchen-sink.fnl
+git commit -m "fix(kitchen-sink): drop handler off-by-one when dragging downward
+
+Removing the source from new-items already absorbs the index shift;
+the previous '(- to-idx 1)' conditional re-applied it, so dragging
+from=1 to=5 landed the row at slot 4. Insert at to-idx directly."
+```
+
+---
+
+## Task 2: Replace theme block with refreshed palette + new tokens
+
+**Files:**
+- Modify: `examples/kitchen-sink.fnl:62-98` (the `(theme-mod.set-theme …)` call)
+
+- [ ] **Step 1: Replace the theme map**
+
+Find the block beginning `(theme-mod.set-theme {:surface …` and ending with the closing `})` of `:button#active {:bg [59 66 82]}`. Replace it entirely with:
+
+```fennel
+(theme-mod.set-theme {;; --- Surfaces / text ---
+                      :surface       {:bg [46 52 64]
+                                      :padding [20 20 20 20]
+                                      :radius 8}
+                      :surface-elev  {:bg [59 66 82]
+                                      :padding [12 16 12 16]
+                                      :radius 6}
+                      :heading       {:font-size 22 :weight 1 :color [236 239 244]}
+                      :body          {:font-size 14 :color [216 222 233]}
+                      :muted         {:font-size 13 :color [129 138 155]}
+                      :count-badge   {:font-size 12 :color [129 138 155]}
+
+                      ;; --- Rows ---
+                      :row           {:padding [4 4 4 4] :radius 4}
+                      :row#hover     {:bg [59 66 82] :padding [4 4 4 4] :radius 4}
+                      :row-dragging  {:bg [94 129 172]
+                                      :color [30 34 46]
+                                      :padding [4 4 4 4]
+                                      :radius 4
+                                      :shadow [0 4 16 [0 0 0 120]]}
+                      :row-drop-hot  {:bg [59 66 82]
+                                      :border [136 192 208]
+                                      :border_width 2
+                                      :radius 4
+                                      :padding [4 4 4 4]}
+
+                      ;; --- Drag-over list zone ---
+                      :muted-armed   {:font-size 13
+                                      :color [129 138 155]
+                                      :bg [54 60 72]}
+
+                      ;; --- Input ---
+                      :input         {:bg [59 66 82]
+                                      :color [236 239 244]
+                                      :border [76 86 106]
+                                      :border-width 1
+                                      :radius 4
+                                      :padding [8 12 8 12]
+                                      :font-size 14}
+                      :input#focus   {:border [136 192 208]}
+
+                      ;; --- Buttons ---
+                      :button-primary       {:bg [136 192 208]
+                                             :color [30 34 46]
+                                             :radius 6
+                                             :padding [6 14 6 14]
+                                             :font-size 13
+                                             :weight 1}
+                      :button-primary#hover {:bg [143 188 187]}
+                      :button-primary#active{:bg [122 162 175]}
+                      :button-icon          {:bg [59 66 82]
+                                             :color [129 138 155]
+                                             :radius 6
+                                             :padding [4 4 4 4]
+                                             :font-size 16}
+                      :button-icon#hover    {:bg [59 66 82] :color [191 97 106]}
+                      :button-icon#active   {:bg [76 86 106]}}) 
+```
+
+Notes:
+- `:surface` opacity is removed (was `0.5`, made the card disappear). Default opacity = 1.0.
+- `:surface` gains `:radius 8` so the card edge is soft.
+- Shadow uses the documented vector form `[x y blur [r g b a]]` (theme.md:209).
+- The two button aspects (`:button-primary` and `:button-icon`) replace the single `:button` aspect; the view tree in Task 5 swaps callers over. The old `:button` aspect is gone — leaving it would invite future drift.
+- `:status-field` and `:drag-handle` aspects from the original theme are dropped: the status footer goes away in Task 5, and the drag handle is now a canvas (no chrome to theme).
+
+- [ ] **Step 2: Sanity-check that the app still loads**
+
+Launch:
+
+```bash
+./build/redin examples/kitchen-sink.fnl > /tmp/redin-kitchen.log 2>&1 &
+for i in $(seq 1 20); do [ -f .redin-port ] && [ -f .redin-token ] && break; sleep 0.2; done
+tail -n 20 /tmp/redin-kitchen.log
+```
+
+The app must come up. The view tree still references the old aspect names (`:button`, `:drag-handle`, `:status-field`) at this point — that is expected: the renderer treats unknown aspects as "no chrome", so the layout will look uglier than before but must not crash.
+
+Expected log: no `[fennel]` error traces, no panic. If there is an error, check the theme map for a syntax slip and fix before committing.
+
+Shutdown:
+
+```bash
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -sS -X POST -H "Authorization: Bearer $TOKEN" -H "Host: localhost:$PORT" "http://localhost:$PORT/shutdown" > /dev/null
+wait
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/kitchen-sink.fnl
+git commit -m "refactor(kitchen-sink): theme tokens for new palette
+
+Raise surface opacity to 1.0, add accent (frost-blue), danger (Nord
+red), surface-elev, button-primary / button-icon, row#hover, refreshed
+row-dragging without the magenta clash. View tree still uses the old
+aspect names — wiring follows in subsequent commits."
+```
+
+---
+
+## Task 3: Quiet the background canvas
+
+**Files:**
+- Modify: `examples/kitchen-sink.fnl:7-44` (the `:background` provider registration block)
+
+- [ ] **Step 1: Replace the provider body**
+
+Find `(canvas.register :background …` and the matching closing `))))))` that ends the second `for` loop (the "accent orbs" block). Replace the entire registration with:
+
+```fennel
+(canvas.register :background
+                 (fn [ctx]
+                   (let [t (redin.now)
+                         w ctx.width
+                         h ctx.height]
+                     ;; Polar night base
+                     (ctx.rect 0 0 w h {:fill [30 34 46]})
+                     ;; Three slow orbs — large radius, very low alpha, single hue.
+                     (for [i 1 3]
+                       (let [speed (* 0.08 (+ 1 (* i 0.4)))
+                             phase (* i 2.1)
+                             r     (+ 180 (* 40 i))
+                             x (+ (* w 0.5)
+                                  (* (* w 0.35) (math.sin (+ (* t speed) phase))))
+                             y (+ (* h 0.5)
+                                  (* (* h 0.3)
+                                     (math.cos (+ (* t speed 0.7) (* phase 1.3)))))
+                             alpha 14]
+                         (ctx.circle x y r {:fill [94 129 172 alpha]})))
+                     ;; Cheap vignette: nested rect strokes from the edges in,
+                     ;; alpha ramping up toward the outside.
+                     (for [i 1 12]
+                       (let [inset (* 6 (- 12 i))
+                             a (math.floor (* 2.5 i))]
+                         (ctx.rect inset inset
+                                   (- w (* inset 2)) (- h (* inset 2))
+                                   {:stroke [0 0 0 a] :width 1}))))))
+```
+
+The second loop builds a stack of progressively-inset 1-px rect strokes; outer strokes carry darker alpha than inner ones. This fakes a radial vignette using only `ctx.rect`. If the rendering reads as visible stepping or banding when tested in Task 6, delete the vignette loop — the three quiet orbs alone are enough.
+
+The `:pulse-dot` provider directly below the `:background` registration is **not** touched.
+
+- [ ] **Step 2: Sanity-check the canvas renders**
+
+```bash
+./build/redin examples/kitchen-sink.fnl > /tmp/redin-kitchen.log 2>&1 &
+for i in $(seq 1 20); do [ -f .redin-port ] && [ -f .redin-token ] && break; sleep 0.2; done
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -sS -H "Authorization: Bearer $TOKEN" -H "Host: localhost:$PORT" -o /tmp/redin-shots/kitchen-bg-only.png "http://localhost:$PORT/screenshot"
+ls -la /tmp/redin-shots/kitchen-bg-only.png
+curl -sS -X POST -H "Authorization: Bearer $TOKEN" -H "Host: localhost:$PORT" "http://localhost:$PORT/shutdown" > /dev/null
+wait
+```
+
+Open the PNG and confirm: dark background visible, 3 soft blue blobs visible, faint vignette at corners. Don't fret about exact orb positions (they drift). If the screen is solid black, the orbs are clipped — check `:fill` arity.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/kitchen-sink.fnl
+git commit -m "feat(kitchen-sink): quieter background canvas
+
+Three large slow orbs at low alpha plus a cheap rect-stroke vignette.
+Reads as ambient instead of as smudges, single hue ties into the
+drag-active color."
+```
+
+---
+
+## Task 4: Register the `:grip-dots` canvas provider
+
+**Files:**
+- Modify: `examples/kitchen-sink.fnl` — insert after the `:pulse-dot` provider registration (around line 58 in the pre-task file; line numbers will have shifted after Tasks 1–3).
+
+- [ ] **Step 1: Add the provider**
+
+Below the closing `)))))` of `(canvas.register :pulse-dot …)`, insert a blank line then:
+
+```fennel
+;; A six-dot grip pattern, drawn into a 24×42 canvas. Kept deliberately small
+;; and static — the row's own #hover variant carries the hover feedback.
+(canvas.register :grip-dots
+                 (fn [ctx]
+                   (let [cx (/ ctx.width 2)
+                         cy (/ ctx.height 2)
+                         gap 5
+                         r 1.5
+                         color [129 138 155]]
+                     (for [row -1 1]
+                       (for [col 0 1]
+                         (let [dx (* (- (* 2 col) 1) (* gap 0.5))
+                               dy (* row (+ gap (* 2 r)))]
+                           (ctx.circle (+ cx dx) (+ cy dy) r {:fill color})))))))
+```
+
+Two-column × three-row dot grid, ~10px wide × ~17px tall, centered.
+
+- [ ] **Step 2: Sanity-check by rendering once standalone**
+
+Until Task 5 wires it into the view, the provider is registered but unused. Confirm registration doesn't crash:
+
+```bash
+./build/redin examples/kitchen-sink.fnl > /tmp/redin-kitchen.log 2>&1 &
+for i in $(seq 1 20); do [ -f .redin-port ] && [ -f .redin-token ] && break; sleep 0.2; done
+grep -i "error\|panic\|traceback" /tmp/redin-kitchen.log && echo "BAD" || echo "ok"
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -sS -X POST -H "Authorization: Bearer $TOKEN" -H "Host: localhost:$PORT" "http://localhost:$PORT/shutdown" > /dev/null
+wait
+```
+
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/kitchen-sink.fnl
+git commit -m "feat(kitchen-sink): register :grip-dots canvas provider
+
+Six-dot grip pattern for the drag handle column. Registered now,
+used by the view tree in the next commit."
+```
+
+---
+
+## Task 5: Restructure the view tree
+
+This is the load-bearing task — it wires up Tasks 2–4 and removes the layout bugs.
+
+**Files:**
+- Modify: `examples/kitchen-sink.fnl` — the entire `(global main_view (fn [] …))` block at the bottom of the file (currently lines 187–254 of the pre-task file).
+
+- [ ] **Step 1: Replace `main_view` end-to-end**
+
+Replace the whole `(global main_view (fn [] …))` block with:
+
+```fennel
+(global main_view
+        (fn []
+          (let [items     (subscribe :items)
+                input-val (subscribe :input-value)
+                count     (length (or items []))]
+            [:stack
+             {:viewport [[:top_left 0 0 :full :full]
+                         [:top_center 0 32 480 :full]]}
+             [:canvas {:provider :background :width :full :height :full}]
+             [:vbox
+              {:aspect :surface}
+              ;; Header — title left, count right.
+              [:hbox
+               {:height 32 :layout :center}
+               [:text {:aspect :heading} "Todo List"]
+               [:vbox {:width :full}]                ; flexible spacer
+               [:text {:aspect :count-badge} (.. count " items")]]
+              ;; Input + Add side by side.
+              [:hbox
+               {:height 42}
+               [:input {:aspect :input
+                        :width :full
+                        :height 42
+                        :value input-val
+                        :change [:test/input]
+                        :key [:test/add]}]
+               [:vbox {:width 8}]                    ; gap
+               [:button {:aspect :button-primary
+                         :width 72
+                         :height 42
+                         :click [:test/add]
+                         :animate {:provider :pulse-dot
+                                   :rect [:top_right -8 -8 16 16]
+                                   :z :above}}
+                "Add"]]
+              [:vbox {:height 8}]                    ; gap before list
+              ;; Scrollable list.
+              [:vbox
+               {:overflow :scroll-y
+                :drag-over [:row-drag
+                            {:event :event/over
+                             :aspect :muted-armed}]}
+               (icollect [i item (ipairs (or items []))]
+                 [:hbox {:layout :center
+                         :aspect :row
+                         :height 42
+                         :draggable [:row-drag
+                                     {:mode :preview
+                                      :handle false
+                                      :event :event/drag
+                                      :aspect :row-dragging}
+                                     i]
+                         :dropable [:row-drag
+                                    {:event :event/drop
+                                     :aspect :row-drop-hot}
+                                    i]}
+                  ;; Grip handle — fixed 24px column, canvas-drawn dots.
+                  [:vbox {:width 24 :height 42 :drag-handle true}
+                   [:canvas {:provider :grip-dots
+                             :width 24 :height 42}]]
+                  ;; Item text — fills remaining width.
+                  [:text {:aspect :body :width :full} item.text]
+                  ;; Remove icon button.
+                  [:button {:aspect :button-icon
+                            :width 32 :height 32
+                            :click [:test/remove i]}
+                   "×"]])]]])))
+```
+
+Key changes vs. the original view:
+
+- **Layout root** is `:stack` with a 2-entry `:viewport` (background full-screen, card centered with 480 width and 32px top inset). The window-bottom status strip is gone.
+- **Heading row** combines the title and the live count badge (`:count-badge` aspect). The flexible spacer is an empty `:vbox` with `:width :full` — standard idiom in this codebase (cf. button-row patterns); if a more explicit `:layout :space-between` exists, prefer it during implementation. If it doesn't, the spacer is fine.
+- **Input + Add** sit in an hbox with the input filling and the button at fixed 72-px width, so neither stretches edge-to-edge.
+- **Rows** now have three children: grip (24×42 with `:drag-handle true` and a `:canvas` child rendering `:grip-dots`), text (fills), and a 32×32 `:button-icon` with `"×"` glyph. The grip vbox no longer carries `:aspect :drag-handle` — chrome lives at the row level.
+- **Drop visuals** are unchanged at the wiring level — the renamed/refreshed aspects `:row-dragging` and `:row-drop-hot` from Task 2 take effect automatically.
+- **`:animate :pulse-dot`** on the dragging row is dropped: the row is already very visible while dragging (shadow + frost-steel fill), and the pulse adds nothing. The Add button keeps its pulse decoration.
+
+- [ ] **Step 2: Launch and visually inspect**
+
+```bash
+./build/redin examples/kitchen-sink.fnl > /tmp/redin-kitchen.log 2>&1 &
+for i in $(seq 1 20); do [ -f .redin-port ] && [ -f .redin-token ] && break; sleep 0.2; done
+grep -i "error\|panic\|traceback" /tmp/redin-kitchen.log && echo "ERROR — DO NOT COMMIT YET"
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -sS -H "Authorization: Bearer $TOKEN" -H "Host: localhost:$PORT" -o /tmp/redin-shots/kitchen-task5.png "http://localhost:$PORT/screenshot"
+```
+
+Open `/tmp/redin-shots/kitchen-task5.png` and check:
+
+1. Card is centered, ~480px wide, with margin around it. Background is visible around the card.
+2. Header shows `Todo List` on the left and `24 items` on the right.
+3. Input and Add sit on one row; Add is a small accent-coloured button, not a window-wide stripe.
+4. Each row shows a faint dot grip on the far left, the item text in the middle, and a `×` button on the right.
+5. Dragging color (try a drag manually if you want — but the screenshot alone won't show this).
+
+If the spacer idiom (`[:vbox {:width :full}]` inside an `:hbox`) doesn't flex as expected, the count badge will be flush against the title. Fix by inspecting the relevant width-distribution behavior — `docs/reference/elements.md` § hbox is the source. Acceptable fallbacks if needed:
+- Give the title an explicit width (e.g. `:width 200`) and let the badge sit at far right via a different mechanism.
+- Use `:layout :space-between` on the hbox if supported.
+
+Don't commit until the screenshot looks right.
+
+Shutdown:
+
+```bash
+curl -sS -X POST -H "Authorization: Bearer $TOKEN" -H "Host: localhost:$PORT" "http://localhost:$PORT/shutdown" > /dev/null
+wait
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/kitchen-sink.fnl
+git commit -m "feat(kitchen-sink): centered card layout with grip rows
+
+480-px wide card centered over the background canvas, header with
+live item count, input + Add side by side, rows with canvas-drawn
+6-dot grip column and a 32-px × remove button. Old bottom-center
+status strip removed."
+```
+
+---
+
+## Task 6: Final visual + drag verification
+
+**Files:** None modified. Verification only.
+
+- [ ] **Step 1: Capture the after-screenshot**
+
+```bash
+./build/redin examples/kitchen-sink.fnl > /tmp/redin-kitchen.log 2>&1 &
+for i in $(seq 1 20); do [ -f .redin-port ] && [ -f .redin-token ] && break; sleep 0.2; done
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token); H="Authorization: Bearer $TOKEN"; HH="Host: localhost:$PORT"
+curl -sS -H "$H" -H "$HH" -o /tmp/redin-shots/kitchen-after.png "http://localhost:$PORT/screenshot"
+ls -la /tmp/redin-shots/kitchen-before.png /tmp/redin-shots/kitchen-after.png
+```
+
+Open both side by side. Confirm:
+- Card lift and centering visible.
+- Drag handle now reads as a grip (6 dots).
+- `Add` button is small and accent-coloured.
+- `×` buttons replace wide `remove` buttons.
+- Background reads ambient, not smudged.
+
+If the vignette stepping is obtrusive, delete the vignette `for` loop from the `:background` provider added in Task 3 and recapture. Amend Task 3's commit with `git commit --amend` only if no commits have followed it; otherwise add a new commit.
+
+- [ ] **Step 2: End-to-end drag via real input**
+
+Verify a real mouse drag still produces the corrected ordering:
+
+```bash
+# Find a row's rect from /frames
+ROW_RECT=$(curl -sS -H "$H" -H "$HH" "http://localhost:$PORT/frames" \
+  | python3 - <<'PY'
+import json, sys
+frame = json.load(sys.stdin)
+# Locate the first row's rect by walking the JSON; redin attaches "rect":[x,y,w,h]
+def walk(node):
+    if isinstance(node, dict):
+        for k, v in node.items(): yield from walk(v)
+        if "tag" in node and node.get("tag") == "hbox" and node.get("attrs", {}).get("aspect") == "row":
+            r = node["attrs"].get("rect")
+            if r: print(*r); return
+    elif isinstance(node, list):
+        for x in node: yield from walk(x)
+list(walk(frame))
+PY
+)
+echo "first row rect: $ROW_RECT"
+```
+
+(If the walker doesn't print, the JSON shape differs from the assumed `{"tag", "attrs"}` and the picker needs adjusting — `/frames` is the source of truth; tweak the walker until it prints the first row's `[x y w h]`.)
+
+Take over the mouse and drag row 1 onto row 5:
+
+```bash
+curl -sS -X POST -H "$H" -H "$HH" "http://localhost:$PORT/input/takeover" > /dev/null
+
+# Replace SX/SY/DX/DY with values from the rects of row-1 and row-5.
+# A sensible y is the row center; x is somewhere in the grip column (x + ~12).
+# Drag:
+curl -sS -X POST -H "$H" -H "$HH" -d '{"x":SX,"y":SY}' "http://localhost:$PORT/input/mouse/move"
+curl -sS -X POST -H "$H" -H "$HH" -d '{"button":"left"}' "http://localhost:$PORT/input/mouse/down"
+sleep 0.05
+curl -sS -X POST -H "$H" -H "$HH" -d '{"x":SX2,"y":SY}' "http://localhost:$PORT/input/mouse/move"  # cross 4px threshold
+sleep 0.1
+curl -sS -X POST -H "$H" -H "$HH" -d '{"x":DX,"y":DY}' "http://localhost:$PORT/input/mouse/move"
+sleep 0.1
+curl -sS -H "$H" -H "$HH" -o /tmp/redin-shots/kitchen-drag-preview.png "http://localhost:$PORT/screenshot"
+curl -sS -X POST -H "$H" -H "$HH" -d '{"button":"left"}' "http://localhost:$PORT/input/mouse/up"
+sleep 0.1
+curl -sS -X POST -H "$H" -H "$HH" "http://localhost:$PORT/input/release" > /dev/null
+
+# Confirm Test 1 landed at slot 5
+curl -sS -H "$H" -H "$HH" "http://localhost:$PORT/state/items" \
+  | python3 -c 'import json,sys; xs=json.load(sys.stdin); print([x["text"] for x in xs[:6]])'
+# Expected: ['Test 2', 'Test 3', 'Test 4', 'Test 5', 'Test 1', 'Test 6']
+```
+
+Inspect `kitchen-drag-preview.png` — the row being dragged should appear shadowed under the cursor, and the row 5 area should show a 2-px accent left border (drop-hot).
+
+If the drag preview does not appear shadowed: `shadow` may not be honored on `hbox` in the current renderer despite the theme.md table. Drop the `:shadow` key from `:row-dragging` in the theme (Task 2 block), recapture, and commit the fix as a new commit:
+
+```bash
+# Only if needed:
+git commit -am "fix(kitchen-sink): drop :shadow on :row-dragging (hbox shadow unsupported)"
+```
+
+- [ ] **Step 3: Existing test suite still green**
+
+The drag UI test is independent of `kitchen-sink.fnl` (it uses `test/ui/drag_app.fnl`), but run it to be safe:
+
+```bash
+./build/redin test/ui/drag_app.fnl > /tmp/redin-drag-app.log 2>&1 &
+for i in $(seq 1 20); do [ -f .redin-port ] && [ -f .redin-token ] && break; sleep 0.2; done
+bb test/ui/test_drag.bb
+EXIT=$?
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -sS -X POST -H "Authorization: Bearer $TOKEN" -H "Host: localhost:$PORT" "http://localhost:$PORT/shutdown" > /dev/null
+wait
+test "$EXIT" -eq 0 && echo "ok" || (echo "FAIL"; false)
+```
+
+Expected: `ok`.
+
+- [ ] **Step 4: Release build still compiles**
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:/tmp/redin-release-check
+echo "exit=$?"
+ls -la /tmp/redin-release-check
+rm -f /tmp/redin-release-check
+```
+
+Expected: exit 0 and a binary written to `/tmp/redin-release-check`. Sanity check that the release build still links — no kitchen-sink-related code paths are in the binary, but if a global `init.fnl` ever depends on examples for runtime tests, this catches regressions.
+
+- [ ] **Step 5: No commit**
+
+Verification only. If issues surfaced, address them in their own commits referencing this task.
+
+---
+
+## Self-review (against spec)
+
+| Spec requirement | Implementing task |
+|---|---|
+| Centered card max width 480, header / input+Add / list, no bottom strip | Task 5 |
+| Palette table (surface 1.0, accent, danger, drag-active, muted lift, surface-elev) | Task 2 |
+| Heading 22pt + count badge in header | Tasks 2 (token) + 5 (placement) |
+| Primary button only at `Add`; secondary `button-icon` for `×` | Tasks 2 + 5 |
+| `:grip-dots` canvas provider — 6 dots in 2×3 pattern | Tasks 4 (provider) + 5 (wiring) |
+| Row hover at row level (not grip canvas) — design pivot from spec | Task 2 (`:row#hover`) |
+| Drop-hot left-border indicator (accent, 2-px) | Task 2 |
+| Drag preview palette + shadow `[0 4 16 [0 0 0 120]]` | Task 2 |
+| Background: 3 orbs + vignette, accent orbs removed | Task 3 |
+| Drop-handler fix: insert at `to-idx`, drop conditional | Task 1 |
+| Visual diff against `kitchen-before.png` | Task 6 step 1 |
+| Manual drag sanity (events + real input) | Task 1 step 3 + Task 6 step 2 |
+| Release build still compiles | Task 6 step 4 |
+| Existing UI tests still green | Task 6 step 3 |
+
+The spec mentioned "grip hover via theme attr-to-ctx (option 1) or sibling provider (option 2)". This plan picks neither: row-level `:row#hover` covers the hover affordance without needing a per-canvas mechanism. This is a deliberate, documented deviation from the spec's two-option list; flagged in the table above.
+
+No placeholder text in the steps. Every step has either exact code or exact commands.

--- a/docs/superpowers/specs/2026-05-15-kitchen-sink-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-15-kitchen-sink-redesign-design.md
@@ -1,0 +1,270 @@
+# Kitchen-sink redesign
+
+Refresh the `examples/kitchen-sink.fnl` demo so it works as a showcase for the
+framework instead of looking like a maintenance scratchpad. Fix one drop-handler
+off-by-one along the way.
+
+Scope: a single file. No framework, theme schema, or canvas API changes.
+
+## Motivation
+
+The current kitchen-sink has three real problems:
+
+1. **Layout bugs read as "broken framework".** `:width 250` on the `Add`
+   button and `remove` buttons stretches edge-to-edge because the parent
+   `vbox` does not constrain — the literal width attribute looks ignored even
+   though it is not. Bad first impression in screenshots / demos.
+2. **Visual hierarchy is flat.** The surface card at `0.5` opacity dissolves
+   into the background; the bright magenta `[136 46 106]` dragging color
+   clashes with the Nord palette; the drag handle is a 24×42 dark-gray block
+   that reads as decoration rather than a grip.
+3. **Drop reorder is off-by-one in one direction.** Dragging a row downward
+   lands it one slot above the target.
+
+Fixing these makes the demo do its job (sell the framework) without expanding
+its scope.
+
+## Non-goals
+
+- No new framework features. Canvas API, theme schema, drag-and-drop event
+  shape — all untouched.
+- No new test file. `test/ui/test_drag.bb` exercises the drag mechanics on a
+  separate app (`drag_app.fnl`) and stays untouched.
+- No light theme. The dark Nord identity is part of redin's look; we refine,
+  not replace.
+- No new UI test for kitchen-sink (it is a demo, not a test surface).
+
+## Design
+
+### Layout
+
+A centered card with a fixed max width, surrounded by the background canvas.
+
+```
+┌─────────────── window ────────────────┐
+│           [background canvas]          │
+│                                        │
+│      ╭───────── 480px ──────────╮      │
+│      │  Todo List           24  │  ← header: title + count
+│      │  ────────────────────────│
+│      │  ┌────────────┐ ┌──────┐ │  ← input + Add side by side
+│      │  │ new todo…  │ │  Add │ │
+│      │  └────────────┘ └──────┘ │
+│      │                          │
+│      │  ⋮⋮  Test 1          ×  │  ← grip · text · remove
+│      │  ⋮⋮  Test 2          ×  │
+│      │  …  (scrolls)            │
+│      ╰──────────────────────────╯
+│                                        │
+└────────────────────────────────────────┘
+```
+
+- Card centered via `stack`'s `:viewport`. The stack now has two children
+  (background canvas + card), so `:viewport` is a 2-entry vector:
+  `[[:top_left 0 0 :full :full] [:center 0 32 480 :full-64]]` — full-size
+  background, card anchored center with 480 width and 32px top/bottom inset.
+  Exact anchor token (`:center` vs `:top_center` with explicit y) confirmed
+  during implementation against `docs/core-api.md § Viewport`.
+- Card padding: `[20 20 20 20]`.
+- Header → input gap: 16px. Input row → list gap: 12px.
+- Row height: 42px (unchanged).
+- Grip column: 24px fixed. Text fills. Remove becomes a 32×32 `button`
+  with `"×"` as its label (no icon system in redin) and a `:button#hover`
+  variant that swaps text color to `danger`.
+- The current bottom-center status strip is removed; the count moves into the
+  header.
+
+### Palette
+
+Token map (kept in the existing `set-theme` call):
+
+| Token | Value | Use |
+|---|---|---|
+| `bg` (window) | `[30 34 46]` | Polar night base (unchanged). |
+| `surface` | `[46 52 64]` opacity `1.0` | Card fill (was `0.5` — ghosting). |
+| `surface-elev` | `[59 66 82]` | Header strip, row hover, drop-hot bg. |
+| `text` | `[236 239 244]` | Heading. |
+| `body` | `[216 222 233]` | Item text. |
+| `muted` | `[129 138 155]` | Count badge, grip default, placeholder. |
+| `accent` | `[136 192 208]` | Add button bg, focused input border, drop-hot left border, grip hover. |
+| `danger` | `[191 97 106]` | Remove `×` on hover only. |
+| `drag-active` | `[94 129 172]` | Dragging row bg (replaces magenta). |
+
+Typography:
+
+- Heading 22pt, weight 1.
+- Count badge 12pt, `muted`, right-aligned in header row.
+- Body 14pt, `body`.
+- Button label 13pt; weight 1 on primary (`Add`), weight 0 on secondary.
+- Input value 14pt, 12px horizontal padding.
+
+Primary fill (`accent`) is used **only** on the `Add` button. Everywhere else
+the accent is a hairline (focused input border, drop-hot left border, grip
+hover). This keeps it special.
+
+### Drag-and-drop visuals
+
+**Grip handle.** New canvas provider `:grip-dots` draws six dots in a 2×3
+pattern centered in its rect:
+
+```fennel
+(canvas.register :grip-dots
+  (fn [ctx]
+    (let [cx (/ ctx.width 2)
+          cy (/ ctx.height 2)
+          gap 5
+          r  1.5
+          color (or ctx.color [129 138 155])]
+      (for [row -1 1]
+        (for [col 0 1]
+          (ctx.circle (+ cx (* (- (* 2 col) 1) (* gap 0.5)))
+                      (+ cy (* row (+ gap (* 2 r))))
+                      r {:fill color}))))))
+```
+
+The grip `vbox` keeps `:drag-handle true` and renders a `[:canvas {:provider
+:grip-dots}]` child filling its 24×42 box.
+
+Hover affordance: a `:drag-handle#hover` aspect lightens the visible fill.
+Two implementation routes exist; pick at implementation time:
+
+1. Pass `color` to the canvas via attrs and theme it.
+2. Register a sibling `:grip-dots-hot` provider and switch via `:aspect#hover`.
+
+Either is one or two lines. Option 1 is cleaner if the canvas API forwards
+attrs to `ctx` (verify against `docs/core-api.md § Animation`); option 2 is
+the unconditional fallback.
+
+**Drop-hot indicator.** Replace the bg flash with a 2-px accent left border:
+
+```fennel
+:row-drop-hot {:bg [59 66 82]
+               :border [136 192 208]
+               :border_width 2
+               :radius 4
+               :padding [4 4 4 4]}
+```
+
+Theme borders apply to all sides; on a 42-px row the side/bottom strokes are
+subtle and the eye still lands on the left edge. If it reads as too heavy
+during implementation, drop to `:border_width 1`.
+
+**Drag preview.** Already uses `:mode :preview`. Update its aspect to a
+palette-matching fill plus a drop shadow:
+
+```fennel
+:row-dragging {:bg [94 129 172]
+               :color [30 34 46]
+               :padding [4 4 4 4]
+               :radius 4
+               :shadow {:x 0 :y 4 :blur 16 :color [0 0 0 120]}}
+```
+
+`shadow` is documented in `docs/reference/theme.md` as a theme struct. Confirm
+during implementation that it applies to `hbox` rows (not only buttons); if
+hbox-shadow is unsupported, drop the `:shadow` key — the color change alone
+is enough to differentiate.
+
+### Background canvas
+
+Quiet the current 12-orb soup down to 3 large slow orbs plus a vignette:
+
+- 3 orbs (was 8 + 4). Radius 180–260 px, speed ~0.08 (current ~0.15–0.6),
+  alpha 14 (current 18 + 10). Fill `[94 129 172]` — same as `drag-active`,
+  ties the screen together.
+- Vignette: single overlay pass at the end of the canvas — concentric rect
+  strokes from the edges inward, alpha tapering from 0 to ~30 at the corners.
+  Crude radial darkening using only `ctx.rect`. Treat as cosmetic: if the
+  result looks blocky during implementation (visible stepping), drop the
+  vignette — 3 quiet orbs alone is acceptable.
+- Drop the second "accent orbs" loop entirely.
+
+Aurora-band alternative was considered and rejected: the canvas API has
+`rect` + `circle` only, no native gradient. Faked gradient is more code than
+3 orbs for the same end effect.
+
+### Drop-handler fix
+
+Current logic at `examples/kitchen-sink.fnl:170-176`:
+
+```fennel
+(let [insert-at (if (> from-idx to-idx) to-idx (- to-idx 1))]
+  (table.insert new-items
+                (math.min insert-at (+ (length new-items) 1))
+                item))
+```
+
+After `icollect` removes the source, the index shift is already absorbed.
+The conditional re-applies the shift, so dragging downward lands one slot
+short.
+
+Trace `[A,B,C,D,E,F,G]` with `from=1, to=5`:
+
+- `new-items` after removing A = `[B,C,D,E,F,G]` (length 6).
+- `from < to` → `insert-at = 4`.
+- result: `[B,C,D,A,E,F,G]` — A at slot 4, expected slot 5.
+
+Fix — drop the conditional, insert at `to-idx`:
+
+```fennel
+(let [item (. items from-idx)
+      new-items (icollect [i v (ipairs items)]
+                  (when (not= i from-idx) v))]
+  (table.insert new-items to-idx item)
+  (assoc db :items new-items))
+```
+
+Verified by tracing:
+
+| from | to | input | `new-items` | insert | result |
+|---|---|---|---|---|---|
+| 1 | 5 | `[A,B,C,D,E,F,G]` | `[B,C,D,E,F,G]` | A @ 5 | `[B,C,D,E,A,F,G]` |
+| 5 | 1 | `[A,B,C,D,E,F,G]` | `[A,B,C,D,F,G]` | E @ 1 | `[E,A,B,C,D,F,G]` |
+| 1 | 2 | `[A,B,C,D]` | `[B,C,D]` | A @ 2 | `[B,A,C,D]` |
+| 2 | 1 | `[A,B,C,D]` | `[A,C,D]` | B @ 1 | `[B,A,C,D]` |
+| 1 | 7 | `[A,B,C,D,E,F,G]` | `[B,C,D,E,F,G]` | A @ 7 | `[B,C,D,E,F,G,A]` |
+
+Guard against out-of-range `to-idx` (defensive — the framework only emits
+indices that exist, but the handler already does range validation):
+
+```fennel
+(when (and from-idx to-idx
+           (> from-idx 0) (<= from-idx (length items))
+           (> to-idx   0) (<= to-idx   (length items))
+           (not= from-idx to-idx))
+  …)
+```
+
+This existing guard is kept verbatim; the body inside it is what changes.
+
+## Affected files
+
+- `examples/kitchen-sink.fnl` — only file modified.
+
+## Verification plan
+
+- **Visual diff.** Existing `/tmp/redin-shots/kitchen-before.png` is the
+  baseline. After landing changes, capture `kitchen-after.png` via the dev
+  server `/screenshot` endpoint. Side-by-side eyeball check — no automated
+  pixel diff (would over-trigger).
+- **Manual drag sanity.** Two paths:
+  1. POST `/events` with `["event/drop" {:from N :to M}]` for a few
+     `(N, M)` pairs from the trace table; assert state via `/state/items`.
+  2. Real mouse via `/input/takeover` + `/input/mouse/{move,down,up}`:
+     drag row 1 onto row 5, confirm new ordering matches the table.
+- **Release build.** `odin build src/cmd/redin
+  -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin`
+  must succeed unchanged.
+- **Existing tests.** `bb test/ui/test_drag.bb` (and other UI tests) must
+  remain green. Kitchen-sink isn't part of `run-all.sh`, so no regression
+  vector there.
+
+## Implementation notes (carry into the plan)
+
+- All work is in one file; do not split.
+- The `canvas` provider for `:grip-dots` registers at top level alongside
+  `:background` and `:pulse-dot`.
+- The hover-color route for the grip is decided at implementation time after
+  a 30-second check of how `canvas` attrs flow to `ctx`.
+- The `shadow` aspect key on `:row-dragging` is conditional on hbox-shadow
+  support; remove if it errors at render.

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -48,6 +48,21 @@
                      (ctx.circle (/ ctx.width 2) (/ ctx.height 2) r
                                  {:fill [235 203 139 alpha]}))))
 
+;; A six-dot grip pattern, drawn into a 24×42 canvas. Kept deliberately small
+;; and static — the row's own #hover variant carries the hover feedback.
+(canvas.register :grip-dots
+                 (fn [ctx]
+                   (let [cx (/ ctx.width 2)
+                         cy (/ ctx.height 2)
+                         gap 5
+                         r 1.5
+                         color [129 138 155]]
+                     (for [row -1 1]
+                       (for [col 0 1]
+                         (let [dx (* (- (* 2 col) 1) (* gap 0.5))
+                               dy (* row (+ gap (* 2 r)))]
+                           (ctx.circle (+ cx dx) (+ cy dy) r {:fill color})))))))
+
 ;; ===== Theme =====
 
 (theme-mod.set-theme {;; --- Surfaces / text ---

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -63,12 +63,8 @@
                       :surface       {:bg [46 52 64]
                                       :padding [20 20 20 20]
                                       :radius 8}
-                      :surface-elev  {:bg [59 66 82]
-                                      :padding [12 16 12 16]
-                                      :radius 6}
                       :heading       {:font-size 22 :weight 1 :color [236 239 244]}
                       :body          {:font-size 14 :color [216 222 233]}
-                      :muted         {:font-size 13 :color [129 138 155]}
                       :count-badge   {:font-size 12 :color [129 138 155]}
 
                       ;; --- Rows ---
@@ -81,7 +77,7 @@
                                       :shadow [0 4 16 [0 0 0 120]]}
                       :row-drop-hot  {:bg [59 66 82]
                                       :border [136 192 208]
-                                      :border_width 2
+                                      :border-width 2
                                       :radius 4
                                       :padding [4 4 4 4]}
 
@@ -114,7 +110,7 @@
                                              :radius 6
                                              :padding [4 4 4 4]
                                              :font-size 16}
-                      :button-icon#hover    {:bg [59 66 82] :color [191 97 106]}
+                      :button-icon#hover    {:color [191 97 106]}
                       :button-icon#active   {:bg [76 86 106]}})
 
 ;; ===== State =====

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -202,71 +202,70 @@
 
 ;; ===== View =====
 
-(global main_view (fn []
-                    (let [items (subscribe :items)
-                          input-val (subscribe :input-value)]
-                      [:vbox
-                       {}
-                       [:stack
-                        {:viewport [[:top_left 0 0 :full :full]
-                                    [:top_left 0 0 :full :full]
-                                    [:bottom_center 0 0 :1_4 42]]}
-                        [:canvas
-                         {:provider :background :width :full :height :full}]
-                        [:vbox
-                         {:aspect :surface}
-                         [:text {:aspect :heading :layout :center} "Todo List"]
-                         [:input
-                          {:aspect :input
-                           :width 250
-                           :height 42
-                           :value input-val
-                           :change [:test/input]
-                           :key [:test/add]}]
-                         [:button
-                          {:width 250
-                           :height 42
-                           :aspect :button
-                           :click [:test/add]
-                           :animate {:provider :pulse-dot
-                                     :rect [:top_right -8 -8 16 16]
-                                     :z :above}}
-                          "Add"]
-                         [:vbox
-                          {:overflow :scroll-y
-                           :aspect :muted
-                           :drag-over [:row-drag
-                                       {:event :event/over
-                                        :aspect :muted-armed}]}
-                          (icollect [i item (ipairs (or items []))]
-                            [:hbox
-                             {:layout :center
-                              :aspect :row
-                              :height 42
-                              :draggable [:row-drag
-                                          {:mode :preview
-                                           :handle false
-                                           :event :event/drag
-                                           :aspect :row-dragging
-                                           :animate {:provider :pulse-dot
-                                                     :rect [:top_right -6 -6 12 12]
-                                                     :z :above}}
-                                          i]
-                              :dropable [:row-drag
-                                         {:event :event/drop
-                                          :aspect :row-drop-hot}
-                                         i]}
-                             [:vbox {:width 24
-                                     :aspect :drag-handle
-                                     :drag-handle true}]
-                             [:text {:aspect :body} item.text]
-                             [:button
-                              {:width 250
-                               :aspect :button
-                               :click [:test/remove i]}
-                              "remove"]])]]
-                        [:hbox
-                         {:height 42 :aspect :status-field :layout :center}
-                         [:text
-                          {:aspect :body :layout :center}
-                          (.. "Todos: " (length items))]]]])))
+(global main_view
+        (fn []
+          (let [items     (subscribe :items)
+                input-val (subscribe :input-value)
+                count     (length (or items []))]
+            [:stack
+             {:viewport [[:top_left 0 0 :full :full]
+                         [:top_center 0 32 480 :full]]}
+             [:canvas {:provider :background :width :full :height :full}]
+             [:vbox
+              {:aspect :surface}
+              ;; Header — title left, count right.
+              [:hbox
+               {:height 32 :layout :center}
+               [:text {:aspect :heading} "Todo List"]
+               [:vbox {:width :full}]
+               [:text {:aspect :count-badge} (.. count " items")]]
+              ;; Input + Add side by side.
+              [:hbox
+               {:height 42}
+               [:input {:aspect :input
+                        :width :full
+                        :height 42
+                        :value input-val
+                        :change [:test/input]
+                        :key [:test/add]}]
+               [:vbox {:width 8}]
+               [:button {:aspect :button-primary
+                         :width 72
+                         :height 42
+                         :click [:test/add]
+                         :animate {:provider :pulse-dot
+                                   :rect [:top_right -8 -8 16 16]
+                                   :z :above}}
+                "Add"]]
+              [:vbox {:height 8}]
+              ;; Scrollable list.
+              [:vbox
+               {:overflow :scroll-y
+                :drag-over [:row-drag
+                            {:event :event/over
+                             :aspect :muted-armed}]}
+               (icollect [i item (ipairs (or items []))]
+                 [:hbox {:layout :center
+                         :aspect :row
+                         :height 42
+                         :draggable [:row-drag
+                                     {:mode :preview
+                                      :handle false
+                                      :event :event/drag
+                                      :aspect :row-dragging}
+                                     i]
+                         :dropable [:row-drag
+                                    {:event :event/drop
+                                     :aspect :row-drop-hot}
+                                    i]}
+                  ;; Grip handle — fixed 24px column, canvas-drawn dots.
+                  [:vbox {:width 24 :height 42 :drag-handle true}
+                   [:canvas {:provider :grip-dots
+                             :width 24 :height 42}]]
+                  ;; Item text — fills remaining width.
+                  [:text {:aspect :body :width :full} item.text]
+                  ;; Remove icon button.
+                  [:button {:aspect :button-icon
+                            :width 32 :height 32
+                            :click [:test/remove i]}
+                   "×"]])]]])))

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -268,4 +268,4 @@
                   [:button {:aspect :button-icon
                             :width 32 :height 32
                             :click [:test/remove i]}
-                   "×"]])]]])))
+                   "x"]])]]])))

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -74,17 +74,13 @@
                       :count-badge   {:font-size 12 :color [129 138 155]}
 
                       ;; --- Rows ---
-                      :row           {:padding [4 4 4 4] :radius 4}
-                      :row#hover     {:bg [59 66 82] :padding [4 4 4 4] :radius 4}
+                      :row           {:padding [4 4 4 4]}
+                      :row#hover     {:bg [59 66 82] :padding [4 4 4 4]}
                       :row-dragging  {:bg [94 129 172]
                                       :color [30 34 46]
                                       :padding [4 4 4 4]
-                                      :radius 4
                                       :shadow [0 4 16 [0 0 0 120]]}
-                      :row-drop-hot  {:bg [59 66 82]
-                                      :border [136 192 208]
-                                      :border-width 2
-                                      :radius 4
+                      :row-drop-hot  {:bg [60 90 110]
                                       :padding [4 4 4 4]}
 
                       ;; --- Drag-over list zone ---
@@ -217,7 +213,7 @@
               [:hbox
                {:height 32 :layout :center}
                [:text {:aspect :heading} "Todo List"]
-               [:vbox {:width :full}]
+               [:vbox {:width :full}] ; flex spacer
                [:text {:aspect :count-badge} (.. count " items")]]
               ;; Input + Add side by side.
               [:hbox
@@ -228,7 +224,7 @@
                         :value input-val
                         :change [:test/input]
                         :key [:test/add]}]
-               [:vbox {:width 8}]
+               [:vbox {:width 8}] ; 8px gap
                [:button {:aspect :button-primary
                          :width 72
                          :height 42
@@ -237,7 +233,7 @@
                                    :rect [:top_right -8 -8 16 16]
                                    :z :above}}
                 "Add"]]
-              [:vbox {:height 8}]
+              [:vbox {:height 8}] ; 8px gap before list
               ;; Scrollable list.
               [:vbox
                {:overflow :scroll-y

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -80,7 +80,7 @@
                                       :color [30 34 46]
                                       :padding [4 4 4 4]
                                       :shadow [0 4 16 [0 0 0 120]]}
-                      :row-drop-hot  {:bg [60 90 110]
+                      :row-drop-hot  {:bg [75 110 135]
                                       :padding [4 4 4 4]}
 
                       ;; --- Drag-over list zone ---
@@ -215,6 +215,7 @@
                [:text {:aspect :heading} "Todo List"]
                [:vbox {:width :full}] ; flex spacer
                [:text {:aspect :count-badge} (.. count " items")]]
+              [:vbox {:height 16}]                                 ; 16px gap before input
               ;; Input + Add side by side.
               [:hbox
                {:height 42}
@@ -233,7 +234,7 @@
                                    :rect [:top_right -8 -8 16 16]
                                    :z :above}}
                 "Add"]]
-              [:vbox {:height 8}] ; 8px gap before list
+              [:vbox {:height 12}]                                  ; 12px gap before list
               ;; Scrollable list.
               [:vbox
                {:overflow :scroll-y

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -99,6 +99,8 @@
 
 ;; ===== State =====
 
+(global redin_get_state (. dataflow :_get-raw-db))
+
 (dataflow.init {:items [{:text "Test 1"}
                         {:text "Test 2"}
                         {:text "Test 3"}
@@ -160,21 +162,15 @@
                                  from-idx ctx.from
                                  to-idx ctx.to
                                  items (get db :items [])]
-                             (when (and from-idx to-idx (> from-idx 0)
-                                        (<= from-idx (length items))
-                                        (> to-idx 0) (<= to-idx (length items))
+                             (when (and from-idx to-idx
+                                        (> from-idx 0) (<= from-idx (length items))
+                                        (> to-idx   0) (<= to-idx   (length items))
                                         (not= from-idx to-idx))
                                (let [item (. items from-idx)
                                      new-items (icollect [i v (ipairs items)]
                                                  (when (not= i from-idx) v))]
-                                 (let [insert-at (if (> from-idx to-idx) to-idx
-                                                     (- to-idx 1))]
-                                   (table.insert new-items
-                                                 (math.min insert-at
-                                                           (+ (length new-items)
-                                                              1))
-                                                 item)
-                                   (assoc db :items new-items)))))
+                                 (table.insert new-items to-idx item)
+                                 (assoc db :items new-items))))
                            db))
 
 ;; ===== Subscriptions =====

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -32,7 +32,7 @@
                              a (math.floor (* 2.5 i))]
                          (ctx.rect inset inset
                                    (- w (* inset 2)) (- h (* inset 2))
-                                   {:stroke [0 0 0 a] :width 1}))))))
+                                   {:stroke [0 0 0 a] :stroke-width 1}))))))
 
 ;; ===== Micro-animation =====
 ;; A small pulsing dot used as an :animate decoration on the Add button —

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -59,43 +59,63 @@
 
 ;; ===== Theme =====
 
-(theme-mod.set-theme {:surface {:bg [46 52 64]
-                                :padding [24 24 24 24]
-                                :opacity 0.5}
-                      :heading {:font-size 24 :color [236 239 244] :weight 1}
-                      :body {:font-size 14 :color [216 222 233]}
-                      :status-field {:font-size 14
-                                     :bg [26 32 34]
-                                     :color [216 222 233]
-                                     :border [255 255 255]
-                                     :border_width 2
-                                     :radius 4}
-                      :row {:padding [4 4 4 4]}
-                      :row-dragging {:bg [136 46 106]
-                                     :padding [4 4 4 4]
-                                     :radius 4}
-                      :row-drop-hot {:bg [76 86 106]
-                                     :padding [4 4 4 4]}
-                      :muted {:font-size 13 :color [76 86 106]}
-                      :muted-armed {:font-size 13
-                                    :color [76 86 106]
-                                    :bg [54 60 72]}
-                      :drag-handle {:bg [66 66 86]}
-                      :input {:bg [59 66 82]
-                              :color [236 239 244]
-                              :border [76 86 106]
-                              :border-width 1
-                              :radius 4
-                              :padding [8 12 8 12]
-                              :font-size 14}
-                      :input#focus {:border [136 192 208]}
-                      :button {:bg [76 86 106]
-                               :color [236 239 244]
-                               :radius 6
-                               :padding [6 14 6 14]
-                               :font-size 13}
-                      :button#hover {:bg [94 105 126]}
-                      :button#active {:bg [59 66 82]}})
+(theme-mod.set-theme {;; --- Surfaces / text ---
+                      :surface       {:bg [46 52 64]
+                                      :padding [20 20 20 20]
+                                      :radius 8}
+                      :surface-elev  {:bg [59 66 82]
+                                      :padding [12 16 12 16]
+                                      :radius 6}
+                      :heading       {:font-size 22 :weight 1 :color [236 239 244]}
+                      :body          {:font-size 14 :color [216 222 233]}
+                      :muted         {:font-size 13 :color [129 138 155]}
+                      :count-badge   {:font-size 12 :color [129 138 155]}
+
+                      ;; --- Rows ---
+                      :row           {:padding [4 4 4 4] :radius 4}
+                      :row#hover     {:bg [59 66 82] :padding [4 4 4 4] :radius 4}
+                      :row-dragging  {:bg [94 129 172]
+                                      :color [30 34 46]
+                                      :padding [4 4 4 4]
+                                      :radius 4
+                                      :shadow [0 4 16 [0 0 0 120]]}
+                      :row-drop-hot  {:bg [59 66 82]
+                                      :border [136 192 208]
+                                      :border_width 2
+                                      :radius 4
+                                      :padding [4 4 4 4]}
+
+                      ;; --- Drag-over list zone ---
+                      :muted-armed   {:font-size 13
+                                      :color [129 138 155]
+                                      :bg [54 60 72]}
+
+                      ;; --- Input ---
+                      :input         {:bg [59 66 82]
+                                      :color [236 239 244]
+                                      :border [76 86 106]
+                                      :border-width 1
+                                      :radius 4
+                                      :padding [8 12 8 12]
+                                      :font-size 14}
+                      :input#focus   {:border [136 192 208]}
+
+                      ;; --- Buttons ---
+                      :button-primary       {:bg [136 192 208]
+                                             :color [30 34 46]
+                                             :radius 6
+                                             :padding [6 14 6 14]
+                                             :font-size 13
+                                             :weight 1}
+                      :button-primary#hover {:bg [143 188 187]}
+                      :button-primary#active {:bg [122 162 175]}
+                      :button-icon          {:bg [59 66 82]
+                                             :color [129 138 155]
+                                             :radius 6
+                                             :padding [4 4 4 4]
+                                             :font-size 16}
+                      :button-icon#hover    {:bg [59 66 82] :color [191 97 106]}
+                      :button-icon#active   {:bg [76 86 106]}})
 
 ;; ===== State =====
 

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -11,37 +11,28 @@
                    (let [t (redin.now)
                          w ctx.width
                          h ctx.height]
-                     ;; Dark base
+                     ;; Polar night base
                      (ctx.rect 0 0 w h {:fill [30 34 46]})
-                     ;; Drifting orbs — slow sine/cosine motion, muted colors, low alpha
-                     (for [i 1 8]
-                       (let [speed (* 0.15 (+ 1 (* i 0.3)))
-                             phase (* i 1.7)
-                             r (+ 40 (* 30 i))
+                     ;; Three slow orbs — large radius, very low alpha, single hue.
+                     (for [i 1 3]
+                       (let [speed (* 0.08 (+ 1 (* i 0.4)))
+                             phase (* i 2.1)
+                             r     (+ 180 (* 40 i))
                              x (+ (* w 0.5)
-                                  (* (* w 0.4) (math.sin (+ (* t speed) phase))))
+                                  (* (* w 0.35) (math.sin (+ (* t speed) phase))))
                              y (+ (* h 0.5)
-                                  (* (* h 0.35)
+                                  (* (* h 0.3)
                                      (math.cos (+ (* t speed 0.7) (* phase 1.3)))))
-                             pulse (+ 0.7
-                                      (* 0.3 (math.sin (+ (* t 0.5) phase))))
-                             alpha (math.floor (* 18 pulse))]
-                         (ctx.circle x y r {:fill [67 76 94 alpha]})))
-                     ;; Subtle accent orbs — brighter, smaller
-                     (for [i 1 4]
-                       (let [speed (* 0.1 (+ 1 (* i 0.5)))
-                             phase (* i 2.3)
-                             r (+ 20 (* 15 i))
-                             x (+ (* w 0.3)
-                                  (* (* w 0.5) (math.cos (+ (* t speed) phase))))
-                             y (+ (* h 0.4)
-                                  (* (* h 0.4)
-                                     (math.sin (+ (* t speed 0.8) (* phase 0.9)))))
-                             alpha (math.floor (+ 10
-                                                  (* 8
-                                                     (math.sin (+ (* t 0.4)
-                                                                  phase)))))]
-                         (ctx.circle x y r {:fill [94 129 172 alpha]}))))))
+                             alpha 14]
+                         (ctx.circle x y r {:fill [94 129 172 alpha]})))
+                     ;; Cheap vignette: nested rect strokes from the edges in,
+                     ;; alpha ramping up toward the outside.
+                     (for [i 1 12]
+                       (let [inset (* 6 (- 12 i))
+                             a (math.floor (* 2.5 i))]
+                         (ctx.rect inset inset
+                                   (- w (* inset 2)) (- h (* inset 2))
+                                   {:stroke [0 0 0 a] :width 1}))))))
 
 ;; ===== Micro-animation =====
 ;; A small pulsing dot used as an :animate decoration on the Add button —


### PR DESCRIPTION
## Summary

Refresh `examples/kitchen-sink.fnl` into a polished showcase, and fix a drop-handler off-by-one that mis-ordered items dragged downward. Single-file change; no framework, theme schema, or canvas API touch.

- **Drop bug fix.** `:event/drop` now inserts at `to-idx` directly. Previously, `(- to-idx 1)` re-applied the index shift that `icollect` already absorbed, so dragging row 1 onto row 5 landed it at slot 4. Verified via dev-server probe — see Test Plan below.
- **Visual redesign.** Centered 480-px card over a quieter background canvas; new Nord-family palette with a single frost-blue accent (`Add` button, focused-input border, drop-hot tint); canvas-drawn 6-dot drag grip column replaces the dark vbox handle; 32×32 icon-style remove button replaces the wide "remove" stripe; bottom-center status footer dropped, count moved into the header.
- **Background canvas.** 12-orb soup → 3 large slow orbs at single hue `[94 129 172]` + a cheap rect-stroke vignette. Reads as ambient, ties into the drag-active color.

Spec: `docs/superpowers/specs/2026-05-15-kitchen-sink-redesign-design.md`
Plan: `docs/superpowers/plans/2026-05-15-kitchen-sink-redesign.md`

### Plan defects surfaced during review

Five small framework mismatches the design phase had wrong, all caught by per-task code review and fixed inline:

1. `:border_width` (underscore) silently dropped by bridge — bridge reads `border-width` (hyphen).
2. `:width 1` on `ctx.rect` ignored — `ctx.rect` reads `:stroke-width`; `:width` is `ctx.line` only.
3. `×` (U+00D7) rendered as `?` — raylib's default font atlas is ASCII-only.
4. `hbox` doesn't consume `:border` / `:radius` — drop-hot border indicator silently never rendered; replaced with an accent-tinted bg `[75 110 135]` that's visibly distinct from row hover.
5. `redin_get_state` global needed for `/state/<path>` dev-server probes — added to match the pattern in `examples/perf-10k.fnl` and `test/ui/*_app.fnl`.

## Test Plan

- [x] `bb test/ui/test_drag.bb` — passes (unaffected; drag mechanics tested against `test/ui/drag_app.fnl`).
- [x] Release build compiles — `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:/tmp/check`.
- [x] Drop-handler fix verified — `POST /events ["event/drop",{"from":1,"to":5}]` then `GET /state/items` returns `['Test 2','Test 3','Test 4','Test 5','Test 1','Test 6']` (Test 1 now at slot 5, not slot 4).
- [x] Drop-handler upward verified — `from=5, to=1` returns `['Test 5','Test 1','Test 2','Test 3','Test 4','Test 6']`.
- [x] Visual before/after — captured at `/tmp/redin-shots/kitchen-before.png` and `/tmp/redin-shots/kitchen-final.png` during implementation; layout verified centered, header + count, grip column, accent Add button, ambient background.
- [x] (Reviewer) Run `./build-dev.sh && ./build/redin examples/kitchen-sink.fnl` and try a manual drag — the drop-hot tint should be visible as a steel-blue glow on the target row.

## Notes on PR base

This PR targets `docs/sync-129-aftermath` because the spec + plan commits were authored on that branch before this work began. The PR is stacked on top of in-flight #134 — if #134 lands first, this becomes a clean diff against main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)