### PR TITLE
Kitchen-sink redesign + #hover / #active rendering

### DIFF
--- a/docs/superpowers/plans/2026-05-15-kitchen-sink-redesign.md
+++ b/docs/superpowers/plans/2026-05-15-kitchen-sink-redesign.md
@@ -1,0 +1,700 @@
+# Kitchen-sink Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refresh `examples/kitchen-sink.fnl` into a polished framework showcase and fix the drop-handler off-by-one that mis-orders items dragged downward.
+
+**Architecture:** Single-file change. Six tasks: drop-handler fix, theme rewrite, background canvas rewrite, new `:grip-dots` provider, view-tree restructure, visual+drag verification. Each task lands as its own commit so the work can be bisected if anything breaks.
+
+**Tech Stack:** Fennel (compiled to Lua 5.1) running inside the redin binary. No Odin or framework changes. Verification via the redin dev-server HTTP endpoints (`/screenshot`, `/state`, `/events`, `/input/*`).
+
+**Spec:** [`docs/superpowers/specs/2026-05-15-kitchen-sink-redesign-design.md`](../specs/2026-05-15-kitchen-sink-redesign-design.md)
+
+**Branching:** The current working branch (`docs/sync-129-aftermath`) is unrelated to this work. Recommended: cut a new branch `feat/kitchen-sink-redesign` before Task 1. The plan does not enforce this — if the user prefers a different branch strategy, follow their lead.
+
+---
+
+## File map
+
+- **Modify:** `examples/kitchen-sink.fnl` — the only file touched. Sections changed: background canvas provider, theme map, drop-handler body, view tree. New section added: `:grip-dots` canvas provider.
+- **Read only:** `docs/reference/theme.md` (for shadow vector form and hbox shadow support), `docs/core-api.md` § Drag-and-drop and § Viewport.
+
+Verification artifacts written to `/tmp/redin-shots/` (not checked in):
+- `/tmp/redin-shots/kitchen-before.png` — already captured baseline.
+- `/tmp/redin-shots/kitchen-after.png` — captured during Task 6.
+
+---
+
+## Helper: dev-server probe
+
+Several tasks call out to the running app via curl. Standard preamble used in step bodies below:
+
+```bash
+PORT=$(cat .redin-port)
+TOKEN=$(cat .redin-token)
+H="Authorization: Bearer $TOKEN"
+HH="Host: localhost:$PORT"
+```
+
+Standard launch / shutdown (used in Tasks 1 and 6):
+
+```bash
+# Launch (background)
+./build/redin examples/kitchen-sink.fnl > /tmp/redin-kitchen.log 2>&1 &
+APP_PID=$!
+# Wait for port/token files
+for i in $(seq 1 20); do [ -f .redin-port ] && [ -f .redin-token ] && break; sleep 0.2; done
+
+# Shutdown (clean)
+curl -sS -X POST -H "$H" -H "$HH" "http://localhost:$PORT/shutdown" > /dev/null
+wait "$APP_PID" 2>/dev/null
+```
+
+The existing `build/redin` is a dev build (`REDIN_DEV` + `REDIN_PROFILE` + `REDIN_TRACK_MEM`). No rebuild is needed for any task — `.fnl` files are loaded at runtime.
+
+---
+
+## Task 1: Fix drop-handler off-by-one
+
+**Files:**
+- Modify: `examples/kitchen-sink.fnl:158-178` (the `:event/drop` handler body)
+
+- [ ] **Step 1: Reproduce the bug against the current code**
+
+Launch the app (using the launch preamble above), then:
+
+```bash
+# Reset by removing all items would be ideal, but kitchen-sink has no reset
+# handler. Just observe the initial state: items 1..24 = "Test 1".."Test 24".
+curl -sS -H "$H" -H "$HH" "http://localhost:$PORT/state/items" | head -c 200; echo
+
+# Drag "Test 1" (from=1) onto position 5
+curl -sS -X POST -H "$H" -H "$HH" \
+     -d '["event/drop",{"from":1,"to":5}]' \
+     "http://localhost:$PORT/events"
+
+# Inspect the first six item texts
+curl -sS -H "$H" -H "$HH" "http://localhost:$PORT/state/items" \
+  | python3 -c 'import json,sys; xs=json.load(sys.stdin); print([x["text"] for x in xs[:6]])'
+```
+
+Expected (buggy) output: `['Test 2', 'Test 3', 'Test 4', 'Test 1', 'Test 5', 'Test 6']` — `Test 1` lands at slot 4 instead of slot 5. Confirm before continuing. Shutdown the app.
+
+- [ ] **Step 2: Replace the drop-handler body**
+
+The current handler is:
+
+```fennel
+(reg-handler :event/drop (fn [db event]
+                           (let [ctx (. event 2)
+                                 from-idx ctx.from
+                                 to-idx ctx.to
+                                 items (get db :items [])]
+                             (when (and from-idx to-idx (> from-idx 0)
+                                        (<= from-idx (length items))
+                                        (> to-idx 0) (<= to-idx (length items))
+                                        (not= from-idx to-idx))
+                               (let [item (. items from-idx)
+                                     new-items (icollect [i v (ipairs items)]
+                                                 (when (not= i from-idx) v))]
+                                 (let [insert-at (if (> from-idx to-idx) to-idx
+                                                     (- to-idx 1))]
+                                   (table.insert new-items
+                                                 (math.min insert-at
+                                                           (+ (length new-items)
+                                                              1))
+                                                 item)
+                                   (assoc db :items new-items)))))
+                           db))
+```
+
+Replace with:
+
+```fennel
+(reg-handler :event/drop (fn [db event]
+                           (let [ctx (. event 2)
+                                 from-idx ctx.from
+                                 to-idx ctx.to
+                                 items (get db :items [])]
+                             (when (and from-idx to-idx
+                                        (> from-idx 0) (<= from-idx (length items))
+                                        (> to-idx   0) (<= to-idx   (length items))
+                                        (not= from-idx to-idx))
+                               (let [item (. items from-idx)
+                                     new-items (icollect [i v (ipairs items)]
+                                                 (when (not= i from-idx) v))]
+                                 (table.insert new-items to-idx item)
+                                 (assoc db :items new-items))))
+                           db))
+```
+
+The conditional `insert-at` is gone — after `icollect` removes the source, `to-idx` already points at the correct insertion slot in both directions. The outer guard is identical to before. The outer `db` return at the very end is preserved (when the `when` doesn't fire, the handler still returns `db`).
+
+- [ ] **Step 3: Verify the fix**
+
+Launch the app, run the same probe from Step 1:
+
+```bash
+curl -sS -X POST -H "$H" -H "$HH" \
+     -d '["event/drop",{"from":1,"to":5}]' \
+     "http://localhost:$PORT/events"
+curl -sS -H "$H" -H "$HH" "http://localhost:$PORT/state/items" \
+  | python3 -c 'import json,sys; xs=json.load(sys.stdin); print([x["text"] for x in xs[:6]])'
+```
+
+Expected (fixed): `['Test 2', 'Test 3', 'Test 4', 'Test 5', 'Test 1', 'Test 6']` — `Test 1` now at slot 5.
+
+Also probe two more cases to cover both directions and an edge:
+
+```bash
+# Restart the app so item state is fresh
+curl -sS -X POST -H "$H" -H "$HH" "http://localhost:$PORT/shutdown" > /dev/null
+wait
+./build/redin examples/kitchen-sink.fnl > /tmp/redin-kitchen.log 2>&1 &
+for i in $(seq 1 20); do [ -f .redin-port ] && [ -f .redin-token ] && break; sleep 0.2; done
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token); H="Authorization: Bearer $TOKEN"; HH="Host: localhost:$PORT"
+
+# Drag upward: from=5 → to=1. Expect Test 5 first.
+curl -sS -X POST -H "$H" -H "$HH" -d '["event/drop",{"from":5,"to":1}]' "http://localhost:$PORT/events"
+curl -sS -H "$H" -H "$HH" "http://localhost:$PORT/state/items" \
+  | python3 -c 'import json,sys; xs=json.load(sys.stdin); print([x["text"] for x in xs[:6]])'
+# Expected: ['Test 5', 'Test 1', 'Test 2', 'Test 3', 'Test 4', 'Test 6']
+
+# Drag to the end: from=1 → to=24 (the current last slot).
+curl -sS -X POST -H "$H" -H "$HH" -d '["event/drop",{"from":1,"to":24}]' "http://localhost:$PORT/events"
+curl -sS -H "$H" -H "$HH" "http://localhost:$PORT/state/items" \
+  | python3 -c 'import json,sys; xs=json.load(sys.stdin); print([xs[-3]["text"], xs[-2]["text"], xs[-1]["text"]])' \
+  || true
+# Expected last three: Test 3, Test 4 (or similar), Test 5
+# The exact tail depends on the previous mutation; the key check is that
+# the item moved from slot 1 lands at slot 24 (the new tail), not slot 23.
+```
+
+Shutdown the app after the probe.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/kitchen-sink.fnl
+git commit -m "fix(kitchen-sink): drop handler off-by-one when dragging downward
+
+Removing the source from new-items already absorbs the index shift;
+the previous '(- to-idx 1)' conditional re-applied it, so dragging
+from=1 to=5 landed the row at slot 4. Insert at to-idx directly."
+```
+
+---
+
+## Task 2: Replace theme block with refreshed palette + new tokens
+
+**Files:**
+- Modify: `examples/kitchen-sink.fnl:62-98` (the `(theme-mod.set-theme …)` call)
+
+- [ ] **Step 1: Replace the theme map**
+
+Find the block beginning `(theme-mod.set-theme {:surface …` and ending with the closing `})` of `:button#active {:bg [59 66 82]}`. Replace it entirely with:
+
+```fennel
+(theme-mod.set-theme {;; --- Surfaces / text ---
+                      :surface       {:bg [46 52 64]
+                                      :padding [20 20 20 20]
+                                      :radius 8}
+                      :surface-elev  {:bg [59 66 82]
+                                      :padding [12 16 12 16]
+                                      :radius 6}
+                      :heading       {:font-size 22 :weight 1 :color [236 239 244]}
+                      :body          {:font-size 14 :color [216 222 233]}
+                      :muted         {:font-size 13 :color [129 138 155]}
+                      :count-badge   {:font-size 12 :color [129 138 155]}
+
+                      ;; --- Rows ---
+                      :row           {:padding [4 4 4 4] :radius 4}
+                      :row#hover     {:bg [59 66 82] :padding [4 4 4 4] :radius 4}
+                      :row-dragging  {:bg [94 129 172]
+                                      :color [30 34 46]
+                                      :padding [4 4 4 4]
+                                      :radius 4
+                                      :shadow [0 4 16 [0 0 0 120]]}
+                      :row-drop-hot  {:bg [59 66 82]
+                                      :border [136 192 208]
+                                      :border_width 2
+                                      :radius 4
+                                      :padding [4 4 4 4]}
+
+                      ;; --- Drag-over list zone ---
+                      :muted-armed   {:font-size 13
+                                      :color [129 138 155]
+                                      :bg [54 60 72]}
+
+                      ;; --- Input ---
+                      :input         {:bg [59 66 82]
+                                      :color [236 239 244]
+                                      :border [76 86 106]
+                                      :border-width 1
+                                      :radius 4
+                                      :padding [8 12 8 12]
+                                      :font-size 14}
+                      :input#focus   {:border [136 192 208]}
+
+                      ;; --- Buttons ---
+                      :button-primary       {:bg [136 192 208]
+                                             :color [30 34 46]
+                                             :radius 6
+                                             :padding [6 14 6 14]
+                                             :font-size 13
+                                             :weight 1}
+                      :button-primary#hover {:bg [143 188 187]}
+                      :button-primary#active{:bg [122 162 175]}
+                      :button-icon          {:bg [59 66 82]
+                                             :color [129 138 155]
+                                             :radius 6
+                                             :padding [4 4 4 4]
+                                             :font-size 16}
+                      :button-icon#hover    {:bg [59 66 82] :color [191 97 106]}
+                      :button-icon#active   {:bg [76 86 106]}}) 
+```
+
+Notes:
+- `:surface` opacity is removed (was `0.5`, made the card disappear). Default opacity = 1.0.
+- `:surface` gains `:radius 8` so the card edge is soft.
+- Shadow uses the documented vector form `[x y blur [r g b a]]` (theme.md:209).
+- The two button aspects (`:button-primary` and `:button-icon`) replace the single `:button` aspect; the view tree in Task 5 swaps callers over. The old `:button` aspect is gone — leaving it would invite future drift.
+- `:status-field` and `:drag-handle` aspects from the original theme are dropped: the status footer goes away in Task 5, and the drag handle is now a canvas (no chrome to theme).
+
+- [ ] **Step 2: Sanity-check that the app still loads**
+
+Launch:
+
+```bash
+./build/redin examples/kitchen-sink.fnl > /tmp/redin-kitchen.log 2>&1 &
+for i in $(seq 1 20); do [ -f .redin-port ] && [ -f .redin-token ] && break; sleep 0.2; done
+tail -n 20 /tmp/redin-kitchen.log
+```
+
+The app must come up. The view tree still references the old aspect names (`:button`, `:drag-handle`, `:status-field`) at this point — that is expected: the renderer treats unknown aspects as "no chrome", so the layout will look uglier than before but must not crash.
+
+Expected log: no `[fennel]` error traces, no panic. If there is an error, check the theme map for a syntax slip and fix before committing.
+
+Shutdown:
+
+```bash
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -sS -X POST -H "Authorization: Bearer $TOKEN" -H "Host: localhost:$PORT" "http://localhost:$PORT/shutdown" > /dev/null
+wait
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/kitchen-sink.fnl
+git commit -m "refactor(kitchen-sink): theme tokens for new palette
+
+Raise surface opacity to 1.0, add accent (frost-blue), danger (Nord
+red), surface-elev, button-primary / button-icon, row#hover, refreshed
+row-dragging without the magenta clash. View tree still uses the old
+aspect names — wiring follows in subsequent commits."
+```
+
+---
+
+## Task 3: Quiet the background canvas
+
+**Files:**
+- Modify: `examples/kitchen-sink.fnl:7-44` (the `:background` provider registration block)
+
+- [ ] **Step 1: Replace the provider body**
+
+Find `(canvas.register :background …` and the matching closing `))))))` that ends the second `for` loop (the "accent orbs" block). Replace the entire registration with:
+
+```fennel
+(canvas.register :background
+                 (fn [ctx]
+                   (let [t (redin.now)
+                         w ctx.width
+                         h ctx.height]
+                     ;; Polar night base
+                     (ctx.rect 0 0 w h {:fill [30 34 46]})
+                     ;; Three slow orbs — large radius, very low alpha, single hue.
+                     (for [i 1 3]
+                       (let [speed (* 0.08 (+ 1 (* i 0.4)))
+                             phase (* i 2.1)
+                             r     (+ 180 (* 40 i))
+                             x (+ (* w 0.5)
+                                  (* (* w 0.35) (math.sin (+ (* t speed) phase))))
+                             y (+ (* h 0.5)
+                                  (* (* h 0.3)
+                                     (math.cos (+ (* t speed 0.7) (* phase 1.3)))))
+                             alpha 14]
+                         (ctx.circle x y r {:fill [94 129 172 alpha]})))
+                     ;; Cheap vignette: nested rect strokes from the edges in,
+                     ;; alpha ramping up toward the outside.
+                     (for [i 1 12]
+                       (let [inset (* 6 (- 12 i))
+                             a (math.floor (* 2.5 i))]
+                         (ctx.rect inset inset
+                                   (- w (* inset 2)) (- h (* inset 2))
+                                   {:stroke [0 0 0 a] :width 1}))))))
+```
+
+The second loop builds a stack of progressively-inset 1-px rect strokes; outer strokes carry darker alpha than inner ones. This fakes a radial vignette using only `ctx.rect`. If the rendering reads as visible stepping or banding when tested in Task 6, delete the vignette loop — the three quiet orbs alone are enough.
+
+The `:pulse-dot` provider directly below the `:background` registration is **not** touched.
+
+- [ ] **Step 2: Sanity-check the canvas renders**
+
+```bash
+./build/redin examples/kitchen-sink.fnl > /tmp/redin-kitchen.log 2>&1 &
+for i in $(seq 1 20); do [ -f .redin-port ] && [ -f .redin-token ] && break; sleep 0.2; done
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -sS -H "Authorization: Bearer $TOKEN" -H "Host: localhost:$PORT" -o /tmp/redin-shots/kitchen-bg-only.png "http://localhost:$PORT/screenshot"
+ls -la /tmp/redin-shots/kitchen-bg-only.png
+curl -sS -X POST -H "Authorization: Bearer $TOKEN" -H "Host: localhost:$PORT" "http://localhost:$PORT/shutdown" > /dev/null
+wait
+```
+
+Open the PNG and confirm: dark background visible, 3 soft blue blobs visible, faint vignette at corners. Don't fret about exact orb positions (they drift). If the screen is solid black, the orbs are clipped — check `:fill` arity.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/kitchen-sink.fnl
+git commit -m "feat(kitchen-sink): quieter background canvas
+
+Three large slow orbs at low alpha plus a cheap rect-stroke vignette.
+Reads as ambient instead of as smudges, single hue ties into the
+drag-active color."
+```
+
+---
+
+## Task 4: Register the `:grip-dots` canvas provider
+
+**Files:**
+- Modify: `examples/kitchen-sink.fnl` — insert after the `:pulse-dot` provider registration (around line 58 in the pre-task file; line numbers will have shifted after Tasks 1–3).
+
+- [ ] **Step 1: Add the provider**
+
+Below the closing `)))))` of `(canvas.register :pulse-dot …)`, insert a blank line then:
+
+```fennel
+;; A six-dot grip pattern, drawn into a 24×42 canvas. Kept deliberately small
+;; and static — the row's own #hover variant carries the hover feedback.
+(canvas.register :grip-dots
+                 (fn [ctx]
+                   (let [cx (/ ctx.width 2)
+                         cy (/ ctx.height 2)
+                         gap 5
+                         r 1.5
+                         color [129 138 155]]
+                     (for [row -1 1]
+                       (for [col 0 1]
+                         (let [dx (* (- (* 2 col) 1) (* gap 0.5))
+                               dy (* row (+ gap (* 2 r)))]
+                           (ctx.circle (+ cx dx) (+ cy dy) r {:fill color})))))))
+```
+
+Two-column × three-row dot grid, ~10px wide × ~17px tall, centered.
+
+- [ ] **Step 2: Sanity-check by rendering once standalone**
+
+Until Task 5 wires it into the view, the provider is registered but unused. Confirm registration doesn't crash:
+
+```bash
+./build/redin examples/kitchen-sink.fnl > /tmp/redin-kitchen.log 2>&1 &
+for i in $(seq 1 20); do [ -f .redin-port ] && [ -f .redin-token ] && break; sleep 0.2; done
+grep -i "error\|panic\|traceback" /tmp/redin-kitchen.log && echo "BAD" || echo "ok"
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -sS -X POST -H "Authorization: Bearer $TOKEN" -H "Host: localhost:$PORT" "http://localhost:$PORT/shutdown" > /dev/null
+wait
+```
+
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/kitchen-sink.fnl
+git commit -m "feat(kitchen-sink): register :grip-dots canvas provider
+
+Six-dot grip pattern for the drag handle column. Registered now,
+used by the view tree in the next commit."
+```
+
+---
+
+## Task 5: Restructure the view tree
+
+This is the load-bearing task — it wires up Tasks 2–4 and removes the layout bugs.
+
+**Files:**
+- Modify: `examples/kitchen-sink.fnl` — the entire `(global main_view (fn [] …))` block at the bottom of the file (currently lines 187–254 of the pre-task file).
+
+- [ ] **Step 1: Replace `main_view` end-to-end**
+
+Replace the whole `(global main_view (fn [] …))` block with:
+
+```fennel
+(global main_view
+        (fn []
+          (let [items     (subscribe :items)
+                input-val (subscribe :input-value)
+                count     (length (or items []))]
+            [:stack
+             {:viewport [[:top_left 0 0 :full :full]
+                         [:top_center 0 32 480 :full]]}
+             [:canvas {:provider :background :width :full :height :full}]
+             [:vbox
+              {:aspect :surface}
+              ;; Header — title left, count right.
+              [:hbox
+               {:height 32 :layout :center}
+               [:text {:aspect :heading} "Todo List"]
+               [:vbox {:width :full}]                ; flexible spacer
+               [:text {:aspect :count-badge} (.. count " items")]]
+              ;; Input + Add side by side.
+              [:hbox
+               {:height 42}
+               [:input {:aspect :input
+                        :width :full
+                        :height 42
+                        :value input-val
+                        :change [:test/input]
+                        :key [:test/add]}]
+               [:vbox {:width 8}]                    ; gap
+               [:button {:aspect :button-primary
+                         :width 72
+                         :height 42
+                         :click [:test/add]
+                         :animate {:provider :pulse-dot
+                                   :rect [:top_right -8 -8 16 16]
+                                   :z :above}}
+                "Add"]]
+              [:vbox {:height 8}]                    ; gap before list
+              ;; Scrollable list.
+              [:vbox
+               {:overflow :scroll-y
+                :drag-over [:row-drag
+                            {:event :event/over
+                             :aspect :muted-armed}]}
+               (icollect [i item (ipairs (or items []))]
+                 [:hbox {:layout :center
+                         :aspect :row
+                         :height 42
+                         :draggable [:row-drag
+                                     {:mode :preview
+                                      :handle false
+                                      :event :event/drag
+                                      :aspect :row-dragging}
+                                     i]
+                         :dropable [:row-drag
+                                    {:event :event/drop
+                                     :aspect :row-drop-hot}
+                                    i]}
+                  ;; Grip handle — fixed 24px column, canvas-drawn dots.
+                  [:vbox {:width 24 :height 42 :drag-handle true}
+                   [:canvas {:provider :grip-dots
+                             :width 24 :height 42}]]
+                  ;; Item text — fills remaining width.
+                  [:text {:aspect :body :width :full} item.text]
+                  ;; Remove icon button.
+                  [:button {:aspect :button-icon
+                            :width 32 :height 32
+                            :click [:test/remove i]}
+                   "×"]])]]])))
+```
+
+Key changes vs. the original view:
+
+- **Layout root** is `:stack` with a 2-entry `:viewport` (background full-screen, card centered with 480 width and 32px top inset). The window-bottom status strip is gone.
+- **Heading row** combines the title and the live count badge (`:count-badge` aspect). The flexible spacer is an empty `:vbox` with `:width :full` — standard idiom in this codebase (cf. button-row patterns); if a more explicit `:layout :space-between` exists, prefer it during implementation. If it doesn't, the spacer is fine.
+- **Input + Add** sit in an hbox with the input filling and the button at fixed 72-px width, so neither stretches edge-to-edge.
+- **Rows** now have three children: grip (24×42 with `:drag-handle true` and a `:canvas` child rendering `:grip-dots`), text (fills), and a 32×32 `:button-icon` with `"×"` glyph. The grip vbox no longer carries `:aspect :drag-handle` — chrome lives at the row level.
+- **Drop visuals** are unchanged at the wiring level — the renamed/refreshed aspects `:row-dragging` and `:row-drop-hot` from Task 2 take effect automatically.
+- **`:animate :pulse-dot`** on the dragging row is dropped: the row is already very visible while dragging (shadow + frost-steel fill), and the pulse adds nothing. The Add button keeps its pulse decoration.
+
+- [ ] **Step 2: Launch and visually inspect**
+
+```bash
+./build/redin examples/kitchen-sink.fnl > /tmp/redin-kitchen.log 2>&1 &
+for i in $(seq 1 20); do [ -f .redin-port ] && [ -f .redin-token ] && break; sleep 0.2; done
+grep -i "error\|panic\|traceback" /tmp/redin-kitchen.log && echo "ERROR — DO NOT COMMIT YET"
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -sS -H "Authorization: Bearer $TOKEN" -H "Host: localhost:$PORT" -o /tmp/redin-shots/kitchen-task5.png "http://localhost:$PORT/screenshot"
+```
+
+Open `/tmp/redin-shots/kitchen-task5.png` and check:
+
+1. Card is centered, ~480px wide, with margin around it. Background is visible around the card.
+2. Header shows `Todo List` on the left and `24 items` on the right.
+3. Input and Add sit on one row; Add is a small accent-coloured button, not a window-wide stripe.
+4. Each row shows a faint dot grip on the far left, the item text in the middle, and a `×` button on the right.
+5. Dragging color (try a drag manually if you want — but the screenshot alone won't show this).
+
+If the spacer idiom (`[:vbox {:width :full}]` inside an `:hbox`) doesn't flex as expected, the count badge will be flush against the title. Fix by inspecting the relevant width-distribution behavior — `docs/reference/elements.md` § hbox is the source. Acceptable fallbacks if needed:
+- Give the title an explicit width (e.g. `:width 200`) and let the badge sit at far right via a different mechanism.
+- Use `:layout :space-between` on the hbox if supported.
+
+Don't commit until the screenshot looks right.
+
+Shutdown:
+
+```bash
+curl -sS -X POST -H "Authorization: Bearer $TOKEN" -H "Host: localhost:$PORT" "http://localhost:$PORT/shutdown" > /dev/null
+wait
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/kitchen-sink.fnl
+git commit -m "feat(kitchen-sink): centered card layout with grip rows
+
+480-px wide card centered over the background canvas, header with
+live item count, input + Add side by side, rows with canvas-drawn
+6-dot grip column and a 32-px × remove button. Old bottom-center
+status strip removed."
+```
+
+---
+
+## Task 6: Final visual + drag verification
+
+**Files:** None modified. Verification only.
+
+- [ ] **Step 1: Capture the after-screenshot**
+
+```bash
+./build/redin examples/kitchen-sink.fnl > /tmp/redin-kitchen.log 2>&1 &
+for i in $(seq 1 20); do [ -f .redin-port ] && [ -f .redin-token ] && break; sleep 0.2; done
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token); H="Authorization: Bearer $TOKEN"; HH="Host: localhost:$PORT"
+curl -sS -H "$H" -H "$HH" -o /tmp/redin-shots/kitchen-after.png "http://localhost:$PORT/screenshot"
+ls -la /tmp/redin-shots/kitchen-before.png /tmp/redin-shots/kitchen-after.png
+```
+
+Open both side by side. Confirm:
+- Card lift and centering visible.
+- Drag handle now reads as a grip (6 dots).
+- `Add` button is small and accent-coloured.
+- `×` buttons replace wide `remove` buttons.
+- Background reads ambient, not smudged.
+
+If the vignette stepping is obtrusive, delete the vignette `for` loop from the `:background` provider added in Task 3 and recapture. Amend Task 3's commit with `git commit --amend` only if no commits have followed it; otherwise add a new commit.
+
+- [ ] **Step 2: End-to-end drag via real input**
+
+Verify a real mouse drag still produces the corrected ordering:
+
+```bash
+# Find a row's rect from /frames
+ROW_RECT=$(curl -sS -H "$H" -H "$HH" "http://localhost:$PORT/frames" \
+  | python3 - <<'PY'
+import json, sys
+frame = json.load(sys.stdin)
+# Locate the first row's rect by walking the JSON; redin attaches "rect":[x,y,w,h]
+def walk(node):
+    if isinstance(node, dict):
+        for k, v in node.items(): yield from walk(v)
+        if "tag" in node and node.get("tag") == "hbox" and node.get("attrs", {}).get("aspect") == "row":
+            r = node["attrs"].get("rect")
+            if r: print(*r); return
+    elif isinstance(node, list):
+        for x in node: yield from walk(x)
+list(walk(frame))
+PY
+)
+echo "first row rect: $ROW_RECT"
+```
+
+(If the walker doesn't print, the JSON shape differs from the assumed `{"tag", "attrs"}` and the picker needs adjusting — `/frames` is the source of truth; tweak the walker until it prints the first row's `[x y w h]`.)
+
+Take over the mouse and drag row 1 onto row 5:
+
+```bash
+curl -sS -X POST -H "$H" -H "$HH" "http://localhost:$PORT/input/takeover" > /dev/null
+
+# Replace SX/SY/DX/DY with values from the rects of row-1 and row-5.
+# A sensible y is the row center; x is somewhere in the grip column (x + ~12).
+# Drag:
+curl -sS -X POST -H "$H" -H "$HH" -d '{"x":SX,"y":SY}' "http://localhost:$PORT/input/mouse/move"
+curl -sS -X POST -H "$H" -H "$HH" -d '{"button":"left"}' "http://localhost:$PORT/input/mouse/down"
+sleep 0.05
+curl -sS -X POST -H "$H" -H "$HH" -d '{"x":SX2,"y":SY}' "http://localhost:$PORT/input/mouse/move"  # cross 4px threshold
+sleep 0.1
+curl -sS -X POST -H "$H" -H "$HH" -d '{"x":DX,"y":DY}' "http://localhost:$PORT/input/mouse/move"
+sleep 0.1
+curl -sS -H "$H" -H "$HH" -o /tmp/redin-shots/kitchen-drag-preview.png "http://localhost:$PORT/screenshot"
+curl -sS -X POST -H "$H" -H "$HH" -d '{"button":"left"}' "http://localhost:$PORT/input/mouse/up"
+sleep 0.1
+curl -sS -X POST -H "$H" -H "$HH" "http://localhost:$PORT/input/release" > /dev/null
+
+# Confirm Test 1 landed at slot 5
+curl -sS -H "$H" -H "$HH" "http://localhost:$PORT/state/items" \
+  | python3 -c 'import json,sys; xs=json.load(sys.stdin); print([x["text"] for x in xs[:6]])'
+# Expected: ['Test 2', 'Test 3', 'Test 4', 'Test 5', 'Test 1', 'Test 6']
+```
+
+Inspect `kitchen-drag-preview.png` — the row being dragged should appear shadowed under the cursor, and the row 5 area should show a 2-px accent left border (drop-hot).
+
+If the drag preview does not appear shadowed: `shadow` may not be honored on `hbox` in the current renderer despite the theme.md table. Drop the `:shadow` key from `:row-dragging` in the theme (Task 2 block), recapture, and commit the fix as a new commit:
+
+```bash
+# Only if needed:
+git commit -am "fix(kitchen-sink): drop :shadow on :row-dragging (hbox shadow unsupported)"
+```
+
+- [ ] **Step 3: Existing test suite still green**
+
+The drag UI test is independent of `kitchen-sink.fnl` (it uses `test/ui/drag_app.fnl`), but run it to be safe:
+
+```bash
+./build/redin test/ui/drag_app.fnl > /tmp/redin-drag-app.log 2>&1 &
+for i in $(seq 1 20); do [ -f .redin-port ] && [ -f .redin-token ] && break; sleep 0.2; done
+bb test/ui/test_drag.bb
+EXIT=$?
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -sS -X POST -H "Authorization: Bearer $TOKEN" -H "Host: localhost:$PORT" "http://localhost:$PORT/shutdown" > /dev/null
+wait
+test "$EXIT" -eq 0 && echo "ok" || (echo "FAIL"; false)
+```
+
+Expected: `ok`.
+
+- [ ] **Step 4: Release build still compiles**
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:/tmp/redin-release-check
+echo "exit=$?"
+ls -la /tmp/redin-release-check
+rm -f /tmp/redin-release-check
+```
+
+Expected: exit 0 and a binary written to `/tmp/redin-release-check`. Sanity check that the release build still links — no kitchen-sink-related code paths are in the binary, but if a global `init.fnl` ever depends on examples for runtime tests, this catches regressions.
+
+- [ ] **Step 5: No commit**
+
+Verification only. If issues surfaced, address them in their own commits referencing this task.
+
+---
+
+## Self-review (against spec)
+
+| Spec requirement | Implementing task |
+|---|---|
+| Centered card max width 480, header / input+Add / list, no bottom strip | Task 5 |
+| Palette table (surface 1.0, accent, danger, drag-active, muted lift, surface-elev) | Task 2 |
+| Heading 22pt + count badge in header | Tasks 2 (token) + 5 (placement) |
+| Primary button only at `Add`; secondary `button-icon` for `×` | Tasks 2 + 5 |
+| `:grip-dots` canvas provider — 6 dots in 2×3 pattern | Tasks 4 (provider) + 5 (wiring) |
+| Row hover at row level (not grip canvas) — design pivot from spec | Task 2 (`:row#hover`) |
+| Drop-hot left-border indicator (accent, 2-px) | Task 2 |
+| Drag preview palette + shadow `[0 4 16 [0 0 0 120]]` | Task 2 |
+| Background: 3 orbs + vignette, accent orbs removed | Task 3 |
+| Drop-handler fix: insert at `to-idx`, drop conditional | Task 1 |
+| Visual diff against `kitchen-before.png` | Task 6 step 1 |
+| Manual drag sanity (events + real input) | Task 1 step 3 + Task 6 step 2 |
+| Release build still compiles | Task 6 step 4 |
+| Existing UI tests still green | Task 6 step 3 |
+
+The spec mentioned "grip hover via theme attr-to-ctx (option 1) or sibling provider (option 2)". This plan picks neither: row-level `:row#hover` covers the hover affordance without needing a per-canvas mechanism. This is a deliberate, documented deviation from the spec's two-option list; flagged in the table above.
+
+No placeholder text in the steps. Every step has either exact code or exact commands.

--- a/docs/superpowers/plans/2026-05-16-hover-active-rendering.md
+++ b/docs/superpowers/plans/2026-05-16-hover-active-rendering.md
@@ -1,0 +1,942 @@
+# Hover/Active rendering implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the half-built `aspect#hover` and `aspect#active` theme state variants end-to-end so the documented behaviour actually renders.
+
+**Architecture:** Track `hovered_indices: [dynamic]int` (set) and `active_idx: int` as package-level state in `src/redin/input`, populated by the existing event/listener flow. Introduce a single `resolve_themed_aspect(idx, aspect, theme)` helper in `src/redin/render.odin` that merges base + `#focus` + `#hover` + `#active` and is called from every aspect lookup site in the four draw procs. The drag-preview draw paths bypass state overlays by passing `idx = -1`.
+
+**Tech Stack:** Odin + Raylib (render, input), Fennel/Lua (test fixture), Babashka (UI integration test). Existing tooling: `./build-dev.sh`, `bb test/ui/run.bb`, dev-server `/input/*` endpoints for mouse takeover.
+
+**Spec:** `docs/superpowers/specs/2026-05-16-hover-active-rendering-design.md`
+
+---
+
+## File map
+
+| Path                                   | Action  | Responsibility                                                                              |
+|----------------------------------------|---------|---------------------------------------------------------------------------------------------|
+| `test/ui/hover_active_app.fnl`         | Create  | Single-button fixture app with distinct base/hover/active bg colours for pixel sampling.    |
+| `test/ui/test_hover_active.bb`         | Create  | Babashka integration test: mouse takeover, press/move/release, screenshot pixel asserts.    |
+| `test/ui/redin_test.bb`                | Modify  | Add `screenshot-pixel` helper (PNG → RGB at coordinate).                                    |
+| `src/redin/input/input.odin`           | Modify  | Add `hovered_indices` + `active_idx` package vars.                                          |
+| `src/redin/input/user_events.odin`     | Modify  | Populate `hovered_indices` in the existing hover-listener loop.                             |
+| `src/redin/input/apply.odin`           | Modify  | Set `active_idx` on press; clear via `is_mouse_button_down` poll; drop `ApplyActive` emit.  |
+| `src/redin/types/apply_events.odin`    | Modify  | Delete `ApplyActive` struct + union case.                                                   |
+| `src/redin/runtime.odin`               | Modify  | Drop empty `case types.ApplyActive:` line.                                                  |
+| `src/redin/render.odin`                | Modify  | Add `resolve_themed_aspect`; thread `idx` into `draw_button`/`draw_themed_rect`; route 4 draw procs through helper; drag-preview paths pass `idx = -1`. |
+
+---
+
+### Task 1: Failing UI integration test
+
+**Files:**
+- Create: `test/ui/hover_active_app.fnl`
+- Create: `test/ui/test_hover_active.bb`
+- Modify: `test/ui/redin_test.bb` (add `screenshot-pixel` helper)
+
+- [ ] **Step 1: Add `screenshot-pixel` helper to `test/ui/redin_test.bb`**
+
+Insert the following after the existing `screenshot-dims` function (after the closing `]` at the end of `screenshot-dims`, before `wait-ms`):
+
+```clojure
+(defn screenshot-pixel
+  "Read RGB at (x,y) from PNG bytes. Returns [r g b]. Uses javax.imageio
+   (Babashka built-in) so no external dependency. Coordinates are in
+   PNG pixels, matching raylib's framebuffer dimensions."
+  [^bytes png-bytes x y]
+  (let [bais (java.io.ByteArrayInputStream. png-bytes)
+        img  (javax.imageio.ImageIO/read bais)]
+    (when (nil? img)
+      (throw (ex-info "could not decode screenshot PNG" {})))
+    (let [argb (.getRGB img (int x) (int y))
+          r (bit-and (bit-shift-right argb 16) 0xff)
+          g (bit-and (bit-shift-right argb 8) 0xff)
+          b (bit-and argb 0xff)]
+      [r g b])))
+```
+
+- [ ] **Step 2: Create the fixture app `test/ui/hover_active_app.fnl`**
+
+```fennel
+;; Hover/active state-variant test fixture.
+;;
+;; One themed button at a fixed-size rect. Distinct, easy-to-recognise
+;; bg colours per state so the test can pixel-sample and compare exactly:
+;;   base   = [50 50 50]     (dark grey)
+;;   hover  = [100 100 100]  (mid grey)
+;;   active = [200 200 200]  (light grey)
+;;
+;; No corner radius, no shadow — solid rect makes pixel sampling stable.
+
+(local dataflow (require :dataflow))
+(local theme-mod (require :theme))
+
+(theme-mod.set-theme {:bg-fill {:bg [0 0 0]}
+                      :btn         {:bg [50 50 50]
+                                    :color [255 255 255]
+                                    :radius 0
+                                    :padding [0 0 0 0]
+                                    :font-size 14}
+                      :btn#hover   {:bg [100 100 100]}
+                      :btn#active  {:bg [200 200 200]}})
+
+(dataflow.init {:clicks 0})
+
+(reg-handler :test/click
+             (fn [db event]
+               (update db :clicks #(+  1))))
+
+(reg-sub :clicks (fn [db] (get db :clicks 0)))
+
+(global main_view
+        (fn []
+          [:stack
+           {:viewport [[:top_left 0 0 :full :full]]}
+           ;; Solid black background fill so anything outside the button
+           ;; is obviously not the button.
+           [:vbox {:aspect :bg-fill :width :full :height :full}
+            [:button {:aspect :btn
+                      :width 100
+                      :height 40
+                      :click [:test/click]}
+             ""]]]))
+```
+
+- [ ] **Step 3: Create the integration test `test/ui/test_hover_active.bb`**
+
+```clojure
+(require '[redin-test :refer :all])
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- btn-rect []
+  (rect-of (find-element {:tag :button :aspect :btn})))
+
+(defn- sample-bg
+  "Sample a pixel from the screenshot at a bg-only point inside the button
+   (4px in from the top-left corner — clear of any glyph footprint)."
+  []
+  (let [{:keys [x y]} (btn-rect)
+        png (screenshot)]
+    (screenshot-pixel png (+ x 4) (+ y 4))))
+
+(defn- center-of
+  "Return [cx cy] for the button rect's center."
+  []
+  (let [{:keys [x y w h]} (btn-rect)]
+    [(int (+ x (/ w 2))) (int (+ y (/ h 2)))]))
+
+;; ---------------------------------------------------------------------------
+;; Tests
+;; ---------------------------------------------------------------------------
+
+(deftest button-rect-exists
+  (assert (some? (btn-rect)) "Button rect should be present in /frames"))
+
+(deftest base-color-resting
+  ;; Cursor at default position (outside the button). Bg should be base.
+  (input-takeover)
+  (input-mouse-move 0 0)
+  (wait-ms 100)
+  (let [[r g b] (sample-bg)]
+    (assert (= [r g b] [50 50 50])
+            (str "Expected base color [50 50 50], got " [r g b])))
+  (input-release))
+
+(deftest hover-color-on-cursor-over
+  (input-takeover)
+  (let [[cx cy] (center-of)]
+    (input-mouse-move cx cy)
+    (wait-ms 100)
+    (let [[r g b] (sample-bg)]
+      (assert (= [r g b] [100 100 100])
+              (str "Expected hover color [100 100 100], got " [r g b]))))
+  (input-release))
+
+(deftest active-color-on-mouse-down
+  (input-takeover)
+  (let [[cx cy] (center-of)]
+    (input-mouse-move cx cy)
+    (wait-ms 100)
+    (input-mouse-down :left)
+    (wait-ms 100)
+    (let [[r g b] (sample-bg)]
+      (assert (= [r g b] [200 200 200])
+              (str "Expected active color [200 200 200], got " [r g b])))
+    (input-mouse-up :left))
+  (input-release))
+
+(deftest active-persists-when-cursor-drags-off
+  ;; CSS-like semantics: pressed button stays active until mouseup,
+  ;; even when the cursor leaves the rect while still held.
+  (input-takeover)
+  (let [[cx cy] (center-of)]
+    (input-mouse-move cx cy)
+    (wait-ms 100)
+    (input-mouse-down :left)
+    (wait-ms 100)
+    (input-mouse-move 0 0)
+    (wait-ms 100)
+    (let [[r g b] (sample-bg)]
+      (assert (= [r g b] [200 200 200])
+              (str "Active should persist while held; got " [r g b])))
+    (input-mouse-up :left))
+  (input-release))
+
+(deftest base-restored-after-mouseup-off-rect
+  (input-takeover)
+  (let [[cx cy] (center-of)]
+    (input-mouse-move cx cy)
+    (wait-ms 100)
+    (input-mouse-down :left)
+    (wait-ms 100)
+    (input-mouse-move 0 0)
+    (wait-ms 100)
+    (input-mouse-up :left)
+    (wait-ms 100)
+    (let [[r g b] (sample-bg)]
+      (assert (= [r g b] [50 50 50])
+              (str "After release with cursor off, base should return; got " [r g b]))))
+  (input-release))
+```
+
+- [ ] **Step 4: Build dev binary and start the fixture app**
+
+```bash
+./build-dev.sh
+./build/redin test/ui/hover_active_app.fnl &
+```
+
+Wait for the dev server to start (look for `redin-port` and `redin-token` files).
+
+- [ ] **Step 5: Run the test — confirm it FAILS**
+
+```bash
+bb test/ui/run.bb test/ui/test_hover_active.bb
+```
+
+Expected: `button-rect-exists` and `base-color-resting` PASS. `hover-color-on-cursor-over`, `active-color-on-mouse-down`, `active-persists-when-cursor-drags-off`, `base-restored-after-mouseup-off-rect` FAIL with "Expected hover/active color ..., got [50 50 50]" — proving the variants are not currently applied.
+
+Kill the app:
+
+```bash
+curl -X POST -H "Authorization: Bearer $(cat .redin-token)" \
+  "http://localhost:$(cat .redin-port)/shutdown" || true
+wait
+```
+
+- [ ] **Step 6: Commit the failing test**
+
+```bash
+git add test/ui/redin_test.bb test/ui/hover_active_app.fnl test/ui/test_hover_active.bb
+git commit -m "$(cat <<'EOF'
+test(ui): failing #hover / #active state-variant test
+
+Fixture renders one themed button with distinct base/hover/active bg
+colours; test pixel-samples the screenshot through resting / hover /
+press / drag-off-while-held / release. All but the resting case fail
+today because render.odin never applies the documented #hover and
+#active variants.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Track `hovered_indices` and `active_idx` in the input package
+
+**Files:**
+- Modify: `src/redin/input/input.odin` (add package vars)
+- Modify: `src/redin/input/user_events.odin` (populate `hovered_indices`)
+- Modify: `src/redin/input/apply.odin` (set/clear `active_idx`)
+
+- [ ] **Step 1: Add package-level state to `src/redin/input/input.odin`**
+
+Find the existing `focused_idx` declaration (it's a package-level `var`). Add the two new vars next to it. Search for `focused_idx :=` or `focused_idx:` to locate it:
+
+```bash
+grep -n "^focused_idx\|^@(private) focused_idx\|focused_idx :=" src/redin/input/input.odin
+```
+
+Add directly below the line that declares `focused_idx`:
+
+```odin
+// Set of node indices currently under the mouse that carry a HoverListener.
+// Multiple ancestors can be hovered simultaneously (matches the deepest-
+// listener-but-hover-multi-fires policy documented above). Rebuilt every
+// frame in get_user_events; never cleared elsewhere.
+hovered_indices: [dynamic]int
+
+// Index of the node currently in the #active visual state. Set on
+// mousedown when the press lands on a winner with a ClickListener.
+// Cleared in apply_listeners when the left mouse button is no longer
+// down (CSS-like "stays active until mouseup"). -1 means none.
+active_idx: int = -1
+```
+
+- [ ] **Step 2: Populate `hovered_indices` in `src/redin/input/user_events.odin`**
+
+Replace the existing hover-listener loop at lines 19-29 with:
+
+```odin
+	clear(&hovered_indices)
+	for listener in listeners {
+		if hl, ok := listener.(types.HoverListener); ok {
+			if hl.node_idx < len(node_rects) &&
+			   rl.CheckCollisionPointRec(mouse, node_rects[hl.node_idx]) {
+				append(&hovered_indices, hl.node_idx)
+				append(
+					&user_events,
+					types.UserEvent{event = .HOVER, node_idx = hl.node_idx},
+				)
+			}
+		}
+	}
+```
+
+- [ ] **Step 3: Set/clear `active_idx` in `src/redin/input/apply.odin`**
+
+Replace the entire body of `apply_listeners` (the whole proc) with:
+
+```odin
+apply_listeners :: proc(
+	listeners: [dynamic]types.Listener,
+	events: [dynamic]types.InputEvent,
+	node_rects: []rl.Rectangle,
+) -> [dynamic]types.ApplyEvents {
+	applied: [dynamic]types.ApplyEvents
+
+	if focused_idx >= len(node_rects) {
+		focused_idx = -1
+	}
+	if active_idx >= len(node_rects) {
+		active_idx = -1
+	}
+
+	press_this_frame := false
+
+	for event in events {
+		switch e in event {
+		case types.MouseEvent:
+			if e.button != .LEFT do continue
+			mouse := rl.Vector2{e.x, e.y}
+
+			// Deepest node wins (see get_user_events). Only listeners on
+			// the innermost listener-bearing node under the pointer fire.
+			winner := deepest_listener_idx(listeners[:], node_rects, mouse)
+			new_focus := -1
+			has_active := false
+			if winner >= 0 {
+				for listener in listeners {
+					switch l in listener {
+					case types.FocusListener:
+						if l.node_idx == winner do new_focus = winner
+					case types.ClickListener:
+						if l.node_idx == winner do has_active = true
+					case types.HoverListener, types.KeyListener, types.ChangeListener,
+					     types.DragListener, types.DropListener, types.Text_Select_Listener,
+					     types.DragOverListener:
+					}
+				}
+			}
+			focused_idx = new_focus
+			if new_focus >= 0 {
+				append(&applied, types.ApplyEvents(types.ApplyFocus{idx = new_focus}))
+			}
+			if has_active {
+				active_idx = winner
+				press_this_frame = true
+			}
+
+		case types.KeyEvent, types.CharEvent, types.ScrollEvent, types.ResizeEvent:
+		}
+	}
+
+	// Clear active_idx the frame the button comes up, but never on the
+	// same frame as the press (so a single-frame click still shows
+	// active for at least one rendered frame).
+	if !press_this_frame && !is_mouse_button_down(.LEFT) {
+		active_idx = -1
+	}
+
+	return applied
+}
+```
+
+- [ ] **Step 4: Build**
+
+```bash
+./build-dev.sh
+```
+
+Expected: clean compile, no new warnings. (`ApplyActive` is still emitted nowhere now — that's deliberate; we delete the type in the next task.)
+
+- [ ] **Step 5: Run existing UI tests to confirm no regression**
+
+```bash
+./build/redin test/ui/smoke_app.fnl &
+sleep 1
+bb test/ui/run.bb test/ui/test_smoke.bb
+curl -X POST -H "Authorization: Bearer $(cat .redin-token)" "http://localhost:$(cat .redin-port)/shutdown" || true
+wait
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/redin/input/input.odin src/redin/input/user_events.odin src/redin/input/apply.odin
+git commit -m "$(cat <<'EOF'
+feat(input): track hovered_indices and active_idx
+
+State lives in the input package alongside focused_idx. hovered_indices
+is rebuilt each frame from the existing HoverListener loop; active_idx
+is set on mousedown when the winner has a ClickListener and cleared
+when the left button is no longer down (one-frame minimum visibility
+to keep single-frame clicks observable).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Delete unused `ApplyActive` event
+
+**Files:**
+- Modify: `src/redin/types/apply_events.odin`
+- Modify: `src/redin/runtime.odin`
+
+- [ ] **Step 1: Remove `ApplyActive` from the apply-event union**
+
+Edit `src/redin/types/apply_events.odin` to delete the `ApplyActive` struct and its union variant. The file should end up with only `ApplyFocus`:
+
+```odin
+package types
+
+ApplyFocus :: struct {
+	idx: int,
+}
+
+ApplyEvents :: union {
+	ApplyFocus,
+}
+```
+
+- [ ] **Step 2: Drop the empty `ApplyActive` case in `src/redin/runtime.odin`**
+
+Around line 260, the runtime loop has:
+
+```odin
+		for ae in applied_events {
+			switch a in ae {
+			case types.ApplyFocus:
+				if a.idx < len(b.nodes) {
+					if n, ok := b.nodes[a.idx].(types.NodeInput); ok {
+						input.focus_enter(n.value)
+					} else {
+						input.focus_leave()
+					}
+				}
+			case types.ApplyActive:
+			}
+		}
+```
+
+Remove the trailing `case types.ApplyActive:` line. Result:
+
+```odin
+		for ae in applied_events {
+			switch a in ae {
+			case types.ApplyFocus:
+				if a.idx < len(b.nodes) {
+					if n, ok := b.nodes[a.idx].(types.NodeInput); ok {
+						input.focus_enter(n.value)
+					} else {
+						input.focus_leave()
+					}
+				}
+			}
+		}
+```
+
+- [ ] **Step 3: Build and run smoke test**
+
+```bash
+./build-dev.sh
+./build/redin test/ui/smoke_app.fnl &
+sleep 1
+bb test/ui/run.bb test/ui/test_smoke.bb
+curl -X POST -H "Authorization: Bearer $(cat .redin-token)" "http://localhost:$(cat .redin-port)/shutdown" || true
+wait
+```
+
+Expected: clean compile, smoke PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/redin/types/apply_events.odin src/redin/runtime.odin
+git commit -m "$(cat <<'EOF'
+refactor(input): drop unused ApplyActive event
+
+Active state lives directly in input.active_idx now; the ApplyActive
+event was an empty-case no-op in runtime.odin. One less indirection.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Add `resolve_themed_aspect` helper
+
+**Files:**
+- Modify: `src/redin/render.odin`
+
+- [ ] **Step 1: Add the helper near the top of `src/redin/render.odin`**
+
+Find the existing `resolve_vp` function (line 18). Insert the new helper directly above it so it's findable next to other small render helpers. Match the existing style (no doc-comment on small helpers is consistent with the file's tone, but this one merits a short note because the precedence order matters):
+
+```odin
+// Merge base aspect with #focus, #hover, #active state variants.
+// Later overrides earlier: base < #focus < #hover < #active. Matches
+// the order documented in docs/reference/theme.md.
+//
+// idx = -1 means "no state overlays" (used by the drag-preview draw
+// paths, where the source/clone aspect already encodes the dragging
+// visual and should not be further mutated).
+//
+// Returns a zero-value Theme if the base aspect is missing — every
+// caller already handles default values per-field with `t.<field> != {}`.
+resolve_themed_aspect :: proc(
+	idx: int,
+	aspect: string,
+	theme: map[string]types.Theme,
+) -> types.Theme {
+	result: types.Theme
+	if len(aspect) == 0 do return result
+	if base, ok := theme[aspect]; ok do result = base
+	if idx < 0 do return result
+
+	overlay :: proc(out: ^types.Theme, src: types.Theme) {
+		if src.bg != {}          do out.bg = src.bg
+		if src.color != {}       do out.color = src.color
+		if src.border != {}      do out.border = src.border
+		if src.border_width > 0  do out.border_width = src.border_width
+		if src.radius > 0        do out.radius = src.radius
+		if src.padding != {}     do out.padding = src.padding
+		if src.font_size > 0     do out.font_size = src.font_size
+		if len(src.font) > 0     do out.font = src.font
+		if src.weight > 0        do out.weight = src.weight
+		if src.line_height > 0   do out.line_height = src.line_height
+		if src.opacity > 0       do out.opacity = src.opacity
+		if src.shadow != {}      do out.shadow = src.shadow
+		if src.selection != {}   do out.selection = src.selection
+		if src.text_align != .Auto do out.text_align = src.text_align
+	}
+
+	if idx == input.focused_idx {
+		if t, ok := theme[strings.concatenate({aspect, "#focus"}, context.temp_allocator)]; ok do overlay(&result, t)
+	}
+	for hi in input.hovered_indices {
+		if hi == idx {
+			if t, ok := theme[strings.concatenate({aspect, "#hover"}, context.temp_allocator)]; ok do overlay(&result, t)
+			break
+		}
+	}
+	if idx == input.active_idx {
+		if t, ok := theme[strings.concatenate({aspect, "#active"}, context.temp_allocator)]; ok do overlay(&result, t)
+	}
+	return result
+}
+```
+
+- [ ] **Step 2: Verify the `Theme` struct fields match the overlay list**
+
+The overlay proc above lists every field it knows about. Confirm with:
+
+```bash
+grep -n "^Theme :: struct\|^\}" src/redin/types/theme.odin | head -10
+```
+
+Then open `src/redin/types/theme.odin` and confirm every field in `Theme` appears in the `overlay` proc. If any new field is present (e.g. `selection` exists per the canvas docs — already in the list), add it to the overlay. If a field is missing from the helper, **add it now** before continuing — the helper must overlay every Theme field or `#hover`/`#active` will silently drop properties.
+
+- [ ] **Step 3: Build**
+
+```bash
+./build-dev.sh
+```
+
+Expected: clean compile. (Helper is currently unused; Odin tolerates unused procs without warnings.)
+
+- [ ] **Step 4: No commit yet**
+
+This task ends without a commit; the helper is dead code until Task 5 wires it in. Task 5 will commit both the helper and its callers together.
+
+---
+
+### Task 5: Use the helper from the four draw procs
+
+**Files:**
+- Modify: `src/redin/render.odin`
+
+- [ ] **Step 1: Update `draw_box_chrome` (already has `idx`) to use the helper**
+
+Find `draw_box_chrome` (around line 696). Replace its body. The existing function looks like:
+
+```odin
+draw_box_chrome :: proc(
+	idx: int,
+	rect: rl.Rectangle,
+	aspect: string,
+	theme: map[string]types.Theme,
+) {
+	if len(aspect) == 0 do return
+
+	bg_color: rl.Color
+	has_bg := false
+	shadow: types.Shadow
+
+	if t, ok := theme[aspect]; ok {
+		if t.bg != {} {
+			alpha := u8(255)
+			if t.opacity > 0 && t.opacity < 1 do alpha = u8(t.opacity * 255)
+			bg_color = rl.Color{t.bg[0], t.bg[1], t.bg[2], alpha}
+			has_bg = true
+		}
+		shadow = t.shadow
+	}
+	draw_shadow(rect, shadow, 0)
+	if has_bg do rl.DrawRectangleRec(rect, bg_color)
+}
+```
+
+Replace with:
+
+```odin
+draw_box_chrome :: proc(
+	idx: int,
+	rect: rl.Rectangle,
+	aspect: string,
+	theme: map[string]types.Theme,
+) {
+	if len(aspect) == 0 do return
+
+	bg_color: rl.Color
+	has_bg := false
+
+	t := resolve_themed_aspect(idx, aspect, theme)
+	if t.bg != {} {
+		alpha := u8(255)
+		if t.opacity > 0 && t.opacity < 1 do alpha = u8(t.opacity * 255)
+		bg_color = rl.Color{t.bg[0], t.bg[1], t.bg[2], alpha}
+		has_bg = true
+	}
+
+	draw_shadow(rect, t.shadow, 0)
+	if has_bg do rl.DrawRectangleRec(rect, bg_color)
+}
+```
+
+- [ ] **Step 2: Update `draw_themed_rect` to take `idx`**
+
+Find `draw_themed_rect` at `src/redin/render.odin:1105`. The current body is exactly:
+
+```odin
+draw_themed_rect :: proc(rect: rl.Rectangle, aspect: string, theme: map[string]types.Theme) {
+	if len(aspect) > 0 {
+		if t, ok := theme[aspect]; ok && t.bg != {} {
+			bg := rl.Color{t.bg[0], t.bg[1], t.bg[2], 255}
+			rl.DrawRectangleRec(rect, bg)
+		}
+	}
+}
+```
+
+Replace with:
+
+```odin
+draw_themed_rect :: proc(idx: int, rect: rl.Rectangle, aspect: string, theme: map[string]types.Theme) {
+	if len(aspect) > 0 {
+		t := resolve_themed_aspect(idx, aspect, theme)
+		if t.bg != {} {
+			bg := rl.Color{t.bg[0], t.bg[1], t.bg[2], 255}
+			rl.DrawRectangleRec(rect, bg)
+		}
+	}
+}
+```
+
+- [ ] **Step 3: Update every `draw_themed_rect` call site**
+
+There are exactly three (`grep -n "draw_themed_rect(" src/redin/render.odin` to confirm):
+
+- `src/redin/render.odin:567` (case `NodeImage` in main render, inside the per-node loop). Change `draw_themed_rect(rect, n.aspect, theme)` → `draw_themed_rect(idx, rect, n.aspect, theme)`.
+- `src/redin/render.odin:573` (case `NodeModal` in main render). Change `draw_themed_rect(rect, n.aspect, theme)` → `draw_themed_rect(idx, rect, n.aspect, theme)`.
+- `src/redin/render.odin:668` (inside `draw_subtree_translated`, drag-preview path). Change `draw_themed_rect(rect, aspect, theme)` → `draw_themed_rect(-1, rect, aspect, theme)`.
+- `src/redin/render.odin:675` (drag-preview path, `NodeInput` clone). Change `draw_themed_rect(rect, n.aspect, theme)` → `draw_themed_rect(-1, rect, n.aspect, theme)`.
+
+- [ ] **Step 4: Update `draw_button` to take `idx`**
+
+Find `draw_button` (around line 1313). Replace its signature and the theme lookup. The existing function:
+
+```odin
+draw_button :: proc(rect: rl.Rectangle, n: types.NodeButton, theme: map[string]types.Theme) {
+	bg_color := rl.LIGHTGRAY
+	text_color := rl.BLACK
+	radius: f32 = 0
+	font_size: f32 = 18
+	font_name := "sans"
+	font_weight: u8 = 0
+	shadow: types.Shadow
+	radius_u8: u8 = 0
+
+	if len(n.aspect) > 0 {
+		if t, ok := theme[n.aspect]; ok {
+			if t.bg != {} do bg_color = rl.Color{t.bg[0], t.bg[1], t.bg[2], 255}
+			if t.color != {} do text_color = rl.Color{t.color[0], t.color[1], t.color[2], 255}
+			if t.radius > 0 do radius = f32(t.radius)
+			if t.font_size > 0 do font_size = f32(t.font_size)
+			if len(t.font) > 0 do font_name = t.font
+			font_weight = t.weight
+			shadow = t.shadow
+			radius_u8 = t.radius
+		}
+	}
+	...
+```
+
+Replace with:
+
+```odin
+draw_button :: proc(idx: int, rect: rl.Rectangle, n: types.NodeButton, theme: map[string]types.Theme) {
+	bg_color := rl.LIGHTGRAY
+	text_color := rl.BLACK
+	radius: f32 = 0
+	font_size: f32 = 18
+	font_name := "sans"
+	font_weight: u8 = 0
+	shadow: types.Shadow
+	radius_u8: u8 = 0
+
+	if len(n.aspect) > 0 {
+		t := resolve_themed_aspect(idx, n.aspect, theme)
+		if t.bg != {} do bg_color = rl.Color{t.bg[0], t.bg[1], t.bg[2], 255}
+		if t.color != {} do text_color = rl.Color{t.color[0], t.color[1], t.color[2], 255}
+		if t.radius > 0 do radius = f32(t.radius)
+		if t.font_size > 0 do font_size = f32(t.font_size)
+		if len(t.font) > 0 do font_name = t.font
+		font_weight = t.weight
+		shadow = t.shadow
+		radius_u8 = t.radius
+	}
+	...
+```
+
+(Keep everything after the theme block unchanged.)
+
+- [ ] **Step 5: Update every `draw_button` call site**
+
+There are exactly two (`grep -n "draw_button(" src/redin/render.odin` to confirm):
+
+- `src/redin/render.odin:563` (case `NodeButton` in main render, inside the per-node loop). Change `draw_button(rect, n, theme)` → `draw_button(idx, rect, n, theme)`.
+- `src/redin/render.odin:659` (drag-preview path). Change `draw_button(rect, b, theme)` → `draw_button(-1, rect, b, theme)`.
+
+- [ ] **Step 6: Update `draw_text` to use the helper**
+
+Find `draw_text` (around line 1356). It already takes `idx`. Replace the theme lookup block:
+
+```odin
+	if len(n.aspect) > 0 {
+		if t, ok := theme[n.aspect]; ok {
+			if t.font_size > 0 do font_size = f32(t.font_size)
+			if t.color != {} do text_color = rl.Color{t.color[0], t.color[1], t.color[2], 255}
+			if len(t.font) > 0 do font_name = t.font
+			font_weight = t.weight
+			lh_ratio = t.line_height
+			...
+```
+
+becomes:
+
+```odin
+	if len(n.aspect) > 0 {
+		t := resolve_themed_aspect(idx, n.aspect, theme)
+		if t.font_size > 0 do font_size = f32(t.font_size)
+		if t.color != {} do text_color = rl.Color{t.color[0], t.color[1], t.color[2], 255}
+		if len(t.font) > 0 do font_name = t.font
+		font_weight = t.weight
+		lh_ratio = t.line_height
+		...
+```
+
+(Preserve all field reads that follow; only replace the `if t, ok := theme[n.aspect]; ok {` outer shell. The closing brace of the inner block still exists; you're effectively dropping one layer of nesting.)
+
+- [ ] **Step 7: Update `draw_input` to use the helper**
+
+Find `draw_input` (around line 1141). It takes `idx`. There are two theme-related blocks:
+
+1. The leading selection-colour lookup (lines 1156-1165):
+
+```odin
+	if len(n.aspect) > 0 {
+		if aspect, ok := theme[n.aspect]; ok {
+			if aspect.selection != ([4]u8{}) {
+				selection_color = rl.Color{...}
+			}
+		}
+	}
+```
+
+This stays as-is — selection colour from the base aspect is fine; state overlay doesn't typically change it.
+
+2. The main theme lookup block (lines 1176-1197) plus the inline `#focus` overlay. Replace this entire block:
+
+```odin
+	if len(n.aspect) > 0 {
+		if t, ok := theme[n.aspect]; ok {
+			if t.border != {} do border_color = rl.Color{t.border[0], t.border[1], t.border[2], 255}
+			...
+		}
+		if is_focused {
+			focus_key := strings.concatenate({n.aspect, "#focus"}, context.temp_allocator)
+			if ft, ok := theme[focus_key]; ok {
+				if ft.border != {} do border_color = rl.Color{ft.border[0], ft.border[1], ft.border[2], 255}
+			}
+		}
+	}
+```
+
+with:
+
+```odin
+	if len(n.aspect) > 0 {
+		t := resolve_themed_aspect(idx, n.aspect, theme)
+		if t.border != {} do border_color = rl.Color{t.border[0], t.border[1], t.border[2], 255}
+		if t.bg != {} do bg_color = rl.Color{t.bg[0], t.bg[1], t.bg[2], 255}
+		if t.color != {} do text_color = rl.Color{t.color[0], t.color[1], t.color[2], 255}
+		if t.font_size > 0 do font_size = f32(t.font_size)
+		if t.border_width > 0 do border_width = f32(t.border_width)
+		if t.padding[3] > 0 do padding_l = f32(t.padding[3])
+		if t.padding[1] > 0 do padding_r = f32(t.padding[1])
+		if t.padding[0] > 0 do padding_t = f32(t.padding[0])
+		if len(t.font) > 0 do font_name = t.font
+		font_weight = t.weight
+		lh_ratio = t.line_height
+		text_align = t.text_align
+	}
+```
+
+Note `is_focused` is no longer consulted here — the helper handles `#focus` via `idx == input.focused_idx`. Confirm `is_focused` is still used elsewhere in `draw_input` (it is — for cursor / selection logic). Leave the local `is_focused := input.focused_idx == idx` definition in place; only the explicit `#focus` overlay block is gone.
+
+- [ ] **Step 8: Build**
+
+```bash
+./build-dev.sh
+```
+
+Expected: clean compile. If any `draw_button` / `draw_themed_rect` call site was missed, Odin will report "wrong number of arguments". Fix and re-build.
+
+- [ ] **Step 9: Run the failing UI test — confirm it now PASSES**
+
+```bash
+./build/redin test/ui/hover_active_app.fnl &
+sleep 1
+bb test/ui/run.bb test/ui/test_hover_active.bb
+curl -X POST -H "Authorization: Bearer $(cat .redin-token)" "http://localhost:$(cat .redin-port)/shutdown" || true
+wait
+```
+
+Expected: all 5 deftests PASS.
+
+- [ ] **Step 10: Run the existing UI suite to confirm no regression**
+
+```bash
+bash test/ui/run-all.sh
+```
+
+Expected: all tests pass. If anything fails, investigate before committing — `draw_button` / `draw_text` are on hot paths for the kitchen-sink, drag, button, modal, and popout tests.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/redin/render.odin
+git commit -m "$(cat <<'EOF'
+feat(render): apply #hover and #active theme state variants
+
+Adds resolve_themed_aspect helper that merges base + #focus + #hover +
+#active in the documented precedence order. draw_button, draw_text,
+draw_themed_rect, draw_box_chrome, and draw_input all route through
+it. Drag-preview paths pass idx=-1 to skip overlays (the source/clone
+aspect already encodes the drag visual). The inline #focus block in
+draw_input is replaced by the helper, so focused inputs now overlay
+all #focus fields, not just border.
+
+Closes the documented-but-never-built hover/active rendering gap.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Full verification
+
+**Files:** none
+
+- [ ] **Step 1: Full UI test suite**
+
+```bash
+bash test/ui/run-all.sh
+```
+
+Expected: all tests pass, including the new `test_hover_active`.
+
+- [ ] **Step 2: Fennel runtime unit tests**
+
+```bash
+luajit test/lua/runner.lua test/lua/test_*.fnl
+```
+
+Expected: all pass (unchanged by this work).
+
+- [ ] **Step 3: Release build check**
+
+```bash
+odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin-release
+```
+
+Expected: clean build. Confirms the change doesn't depend on REDIN_DEV-gated paths.
+
+- [ ] **Step 4: Manual smoke — kitchen-sink**
+
+```bash
+./build/redin examples/kitchen-sink.fnl &
+```
+
+Visually confirm:
+- Hovering the "Add" button shows the lighter `[143 188 187]` colour.
+- Hovering an "x" remove button turns the text red `[191 97 106]`.
+- Pressing either shows the darker active colour.
+- Pressing then dragging off the button keeps the active colour until release.
+
+Shutdown:
+
+```bash
+curl -X POST -H "Authorization: Bearer $(cat .redin-token)" "http://localhost:$(cat .redin-port)/shutdown" || true
+wait
+```
+
+- [ ] **Step 5: No commit needed**
+
+This is a verification-only task. If anything failed, fix and amend the previous commit (or commit a fix on top, per the repo's no-amend convention).

--- a/docs/superpowers/specs/2026-05-15-kitchen-sink-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-15-kitchen-sink-redesign-design.md
@@ -1,0 +1,270 @@
+# Kitchen-sink redesign
+
+Refresh the `examples/kitchen-sink.fnl` demo so it works as a showcase for the
+framework instead of looking like a maintenance scratchpad. Fix one drop-handler
+off-by-one along the way.
+
+Scope: a single file. No framework, theme schema, or canvas API changes.
+
+## Motivation
+
+The current kitchen-sink has three real problems:
+
+1. **Layout bugs read as "broken framework".** `:width 250` on the `Add`
+   button and `remove` buttons stretches edge-to-edge because the parent
+   `vbox` does not constrain — the literal width attribute looks ignored even
+   though it is not. Bad first impression in screenshots / demos.
+2. **Visual hierarchy is flat.** The surface card at `0.5` opacity dissolves
+   into the background; the bright magenta `[136 46 106]` dragging color
+   clashes with the Nord palette; the drag handle is a 24×42 dark-gray block
+   that reads as decoration rather than a grip.
+3. **Drop reorder is off-by-one in one direction.** Dragging a row downward
+   lands it one slot above the target.
+
+Fixing these makes the demo do its job (sell the framework) without expanding
+its scope.
+
+## Non-goals
+
+- No new framework features. Canvas API, theme schema, drag-and-drop event
+  shape — all untouched.
+- No new test file. `test/ui/test_drag.bb` exercises the drag mechanics on a
+  separate app (`drag_app.fnl`) and stays untouched.
+- No light theme. The dark Nord identity is part of redin's look; we refine,
+  not replace.
+- No new UI test for kitchen-sink (it is a demo, not a test surface).
+
+## Design
+
+### Layout
+
+A centered card with a fixed max width, surrounded by the background canvas.
+
+```
+┌─────────────── window ────────────────┐
+│           [background canvas]          │
+│                                        │
+│      ╭───────── 480px ──────────╮      │
+│      │  Todo List           24  │  ← header: title + count
+│      │  ────────────────────────│
+│      │  ┌────────────┐ ┌──────┐ │  ← input + Add side by side
+│      │  │ new todo…  │ │  Add │ │
+│      │  └────────────┘ └──────┘ │
+│      │                          │
+│      │  ⋮⋮  Test 1          ×  │  ← grip · text · remove
+│      │  ⋮⋮  Test 2          ×  │
+│      │  …  (scrolls)            │
+│      ╰──────────────────────────╯
+│                                        │
+└────────────────────────────────────────┘
+```
+
+- Card centered via `stack`'s `:viewport`. The stack now has two children
+  (background canvas + card), so `:viewport` is a 2-entry vector:
+  `[[:top_left 0 0 :full :full] [:center 0 32 480 :full-64]]` — full-size
+  background, card anchored center with 480 width and 32px top/bottom inset.
+  Exact anchor token (`:center` vs `:top_center` with explicit y) confirmed
+  during implementation against `docs/core-api.md § Viewport`.
+- Card padding: `[20 20 20 20]`.
+- Header → input gap: 16px. Input row → list gap: 12px.
+- Row height: 42px (unchanged).
+- Grip column: 24px fixed. Text fills. Remove becomes a 32×32 `button`
+  with `"×"` as its label (no icon system in redin) and a `:button#hover`
+  variant that swaps text color to `danger`.
+- The current bottom-center status strip is removed; the count moves into the
+  header.
+
+### Palette
+
+Token map (kept in the existing `set-theme` call):
+
+| Token | Value | Use |
+|---|---|---|
+| `bg` (window) | `[30 34 46]` | Polar night base (unchanged). |
+| `surface` | `[46 52 64]` opacity `1.0` | Card fill (was `0.5` — ghosting). |
+| `surface-elev` | `[59 66 82]` | Header strip, row hover, drop-hot bg. |
+| `text` | `[236 239 244]` | Heading. |
+| `body` | `[216 222 233]` | Item text. |
+| `muted` | `[129 138 155]` | Count badge, grip default, placeholder. |
+| `accent` | `[136 192 208]` | Add button bg, focused input border, drop-hot left border, grip hover. |
+| `danger` | `[191 97 106]` | Remove `×` on hover only. |
+| `drag-active` | `[94 129 172]` | Dragging row bg (replaces magenta). |
+
+Typography:
+
+- Heading 22pt, weight 1.
+- Count badge 12pt, `muted`, right-aligned in header row.
+- Body 14pt, `body`.
+- Button label 13pt; weight 1 on primary (`Add`), weight 0 on secondary.
+- Input value 14pt, 12px horizontal padding.
+
+Primary fill (`accent`) is used **only** on the `Add` button. Everywhere else
+the accent is a hairline (focused input border, drop-hot left border, grip
+hover). This keeps it special.
+
+### Drag-and-drop visuals
+
+**Grip handle.** New canvas provider `:grip-dots` draws six dots in a 2×3
+pattern centered in its rect:
+
+```fennel
+(canvas.register :grip-dots
+  (fn [ctx]
+    (let [cx (/ ctx.width 2)
+          cy (/ ctx.height 2)
+          gap 5
+          r  1.5
+          color (or ctx.color [129 138 155])]
+      (for [row -1 1]
+        (for [col 0 1]
+          (ctx.circle (+ cx (* (- (* 2 col) 1) (* gap 0.5)))
+                      (+ cy (* row (+ gap (* 2 r))))
+                      r {:fill color}))))))
+```
+
+The grip `vbox` keeps `:drag-handle true` and renders a `[:canvas {:provider
+:grip-dots}]` child filling its 24×42 box.
+
+Hover affordance: a `:drag-handle#hover` aspect lightens the visible fill.
+Two implementation routes exist; pick at implementation time:
+
+1. Pass `color` to the canvas via attrs and theme it.
+2. Register a sibling `:grip-dots-hot` provider and switch via `:aspect#hover`.
+
+Either is one or two lines. Option 1 is cleaner if the canvas API forwards
+attrs to `ctx` (verify against `docs/core-api.md § Animation`); option 2 is
+the unconditional fallback.
+
+**Drop-hot indicator.** Replace the bg flash with a 2-px accent left border:
+
+```fennel
+:row-drop-hot {:bg [59 66 82]
+               :border [136 192 208]
+               :border_width 2
+               :radius 4
+               :padding [4 4 4 4]}
+```
+
+Theme borders apply to all sides; on a 42-px row the side/bottom strokes are
+subtle and the eye still lands on the left edge. If it reads as too heavy
+during implementation, drop to `:border_width 1`.
+
+**Drag preview.** Already uses `:mode :preview`. Update its aspect to a
+palette-matching fill plus a drop shadow:
+
+```fennel
+:row-dragging {:bg [94 129 172]
+               :color [30 34 46]
+               :padding [4 4 4 4]
+               :radius 4
+               :shadow {:x 0 :y 4 :blur 16 :color [0 0 0 120]}}
+```
+
+`shadow` is documented in `docs/reference/theme.md` as a theme struct. Confirm
+during implementation that it applies to `hbox` rows (not only buttons); if
+hbox-shadow is unsupported, drop the `:shadow` key — the color change alone
+is enough to differentiate.
+
+### Background canvas
+
+Quiet the current 12-orb soup down to 3 large slow orbs plus a vignette:
+
+- 3 orbs (was 8 + 4). Radius 180–260 px, speed ~0.08 (current ~0.15–0.6),
+  alpha 14 (current 18 + 10). Fill `[94 129 172]` — same as `drag-active`,
+  ties the screen together.
+- Vignette: single overlay pass at the end of the canvas — concentric rect
+  strokes from the edges inward, alpha tapering from 0 to ~30 at the corners.
+  Crude radial darkening using only `ctx.rect`. Treat as cosmetic: if the
+  result looks blocky during implementation (visible stepping), drop the
+  vignette — 3 quiet orbs alone is acceptable.
+- Drop the second "accent orbs" loop entirely.
+
+Aurora-band alternative was considered and rejected: the canvas API has
+`rect` + `circle` only, no native gradient. Faked gradient is more code than
+3 orbs for the same end effect.
+
+### Drop-handler fix
+
+Current logic at `examples/kitchen-sink.fnl:170-176`:
+
+```fennel
+(let [insert-at (if (> from-idx to-idx) to-idx (- to-idx 1))]
+  (table.insert new-items
+                (math.min insert-at (+ (length new-items) 1))
+                item))
+```
+
+After `icollect` removes the source, the index shift is already absorbed.
+The conditional re-applies the shift, so dragging downward lands one slot
+short.
+
+Trace `[A,B,C,D,E,F,G]` with `from=1, to=5`:
+
+- `new-items` after removing A = `[B,C,D,E,F,G]` (length 6).
+- `from < to` → `insert-at = 4`.
+- result: `[B,C,D,A,E,F,G]` — A at slot 4, expected slot 5.
+
+Fix — drop the conditional, insert at `to-idx`:
+
+```fennel
+(let [item (. items from-idx)
+      new-items (icollect [i v (ipairs items)]
+                  (when (not= i from-idx) v))]
+  (table.insert new-items to-idx item)
+  (assoc db :items new-items))
+```
+
+Verified by tracing:
+
+| from | to | input | `new-items` | insert | result |
+|---|---|---|---|---|---|
+| 1 | 5 | `[A,B,C,D,E,F,G]` | `[B,C,D,E,F,G]` | A @ 5 | `[B,C,D,E,A,F,G]` |
+| 5 | 1 | `[A,B,C,D,E,F,G]` | `[A,B,C,D,F,G]` | E @ 1 | `[E,A,B,C,D,F,G]` |
+| 1 | 2 | `[A,B,C,D]` | `[B,C,D]` | A @ 2 | `[B,A,C,D]` |
+| 2 | 1 | `[A,B,C,D]` | `[A,C,D]` | B @ 1 | `[B,A,C,D]` |
+| 1 | 7 | `[A,B,C,D,E,F,G]` | `[B,C,D,E,F,G]` | A @ 7 | `[B,C,D,E,F,G,A]` |
+
+Guard against out-of-range `to-idx` (defensive — the framework only emits
+indices that exist, but the handler already does range validation):
+
+```fennel
+(when (and from-idx to-idx
+           (> from-idx 0) (<= from-idx (length items))
+           (> to-idx   0) (<= to-idx   (length items))
+           (not= from-idx to-idx))
+  …)
+```
+
+This existing guard is kept verbatim; the body inside it is what changes.
+
+## Affected files
+
+- `examples/kitchen-sink.fnl` — only file modified.
+
+## Verification plan
+
+- **Visual diff.** Existing `/tmp/redin-shots/kitchen-before.png` is the
+  baseline. After landing changes, capture `kitchen-after.png` via the dev
+  server `/screenshot` endpoint. Side-by-side eyeball check — no automated
+  pixel diff (would over-trigger).
+- **Manual drag sanity.** Two paths:
+  1. POST `/events` with `["event/drop" {:from N :to M}]` for a few
+     `(N, M)` pairs from the trace table; assert state via `/state/items`.
+  2. Real mouse via `/input/takeover` + `/input/mouse/{move,down,up}`:
+     drag row 1 onto row 5, confirm new ordering matches the table.
+- **Release build.** `odin build src/cmd/redin
+  -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin`
+  must succeed unchanged.
+- **Existing tests.** `bb test/ui/test_drag.bb` (and other UI tests) must
+  remain green. Kitchen-sink isn't part of `run-all.sh`, so no regression
+  vector there.
+
+## Implementation notes (carry into the plan)
+
+- All work is in one file; do not split.
+- The `canvas` provider for `:grip-dots` registers at top level alongside
+  `:background` and `:pulse-dot`.
+- The hover-color route for the grip is decided at implementation time after
+  a 30-second check of how `canvas` attrs flow to `ctx`.
+- The `shadow` aspect key on `:row-dragging` is conditional on hbox-shadow
+  support; remove if it errors at render.

--- a/docs/superpowers/specs/2026-05-16-hover-active-rendering-design.md
+++ b/docs/superpowers/specs/2026-05-16-hover-active-rendering-design.md
@@ -1,0 +1,243 @@
+# Theme state variant rendering — `#hover` and `#active`
+
+Make the documented `aspect#hover` and `aspect#active` theme variants actually
+affect rendering. Today the keys parse, the listeners register, and hover
+events fire — but no draw site overlays the variant onto the base aspect, so
+the visual feedback never appears.
+
+Scope: input package state + render-side aspect resolution + one UI test.
+No theme schema change, no API change, no doc rewrite.
+
+## Motivation
+
+`docs/reference/theme.md:151` and `docs/core-api.md:420` both document
+`#hover` and `#active` as supported theme state variants, and
+`docs/core-api.md:350` literally says *"Applies `aspect#hover` theme
+variant"*. The kitchen-sink theme uses them (`:button-primary#hover`,
+`:button-icon#hover`, etc.) but pressing or hovering a button produces no
+visual change. The same applies to any other aspect carrying these variants.
+
+The wiring is half-built:
+
+| Step                                                  | Status | Site                                    |
+|-------------------------------------------------------|--------|-----------------------------------------|
+| Theme parser accepts `:foo#hover` / `:foo#active`     | works  | `src/redin/parser/theme_parser.odin`    |
+| `HoverListener` registered when `<aspect>#hover` set  | works  | `src/redin/input/input.odin:184`        |
+| Per-frame HOVER user-events fire under the cursor     | works  | `src/redin/input/user_events.odin:20`   |
+| `ApplyActive{idx}` emitted on mouse-down              | works  | `src/redin/input/apply.odin:46`         |
+| Runtime consumes `ApplyActive`                        | **no-op** | `src/redin/runtime.odin:260-261` (empty case) |
+| `view.fnl` consumes `:hover` events                   | dropped intentionally | `src/runtime/view.fnl:36`     |
+| `render.odin` overlays `<aspect>#hover` / `#active`   | **missing** | `draw_button` (1313), `draw_themed_rect` (1105), `draw_text` (1356), `draw_box_chrome` (696) |
+| `#focus` overlay (already works)                      | works  | `src/redin/render.odin:1191`            |
+
+This fix completes the missing edges without touching the rest.
+
+## Non-goals
+
+- **Composed aspects.** `docs/reference/theme.md:165-171` describes
+  `{:aspect [:button :danger]}` merging — never built. `aspect: string` on
+  every node struct (`types/view_tree.odin:61,71,80,...`), parsed via a
+  single `lua_get_string_field` call, never used in any example or test.
+  Punt to a follow-up; doc-vs-impl gap is acknowledged but not closed here.
+- **Runtime-side hover state.** `view.fnl:36` keeps dropping `:hover` events.
+  Visual state is pure Odin — no Lua roundtrip per frame. Apps that *want* to
+  react to hover from Fennel can still wire a custom listener; the framework
+  doesn't push hover into the dataflow.
+- **Doc changes.** The docs already describe the correct behaviour. Code
+  catches up to docs, not the other way around.
+- **New event delivery to apps.** `#hover` / `#active` are purely visual —
+  no new dispatched events, no new public API.
+
+## Design
+
+### State in the `input` package
+
+Mirror the existing `focused_idx` package-level state with two new fields:
+
+```odin
+hovered_indices: [dynamic]int   // ordered set, no duplicates
+active_idx:      int = -1
+```
+
+`hovered_indices` is a set, not a single idx, because the current input
+contract (`input.odin:64`) explicitly preserves ancestor hover: a hover on
+a nested button does not "shadow" a hover on its row. CSS does the same.
+Render iterates by node idx anyway, so membership check is the right shape.
+
+Both are reset to empty / `-1` at the right lifecycle points:
+
+- `hovered_indices`: cleared and rebuilt every frame inside
+  `get_user_events`, right where the HOVER user-events are already emitted
+  (`user_events.odin:20-28`). Same iteration, just record the idx into the
+  set alongside the event append.
+- `active_idx`: set in `apply_listeners` (`apply.odin:46`) when a
+  `MouseEvent` with `pressed = true` lands on a winner that has a
+  `ClickListener` (so non-clickable bg-only nodes can't pin themselves
+  active). Cleared in `apply_listeners` when a `MouseEvent` with
+  `pressed = false` is observed — *unconditionally*, regardless of cursor
+  position. This implements the agreed CSS-like "stays active until
+  mouseup, even if you drag off" semantics.
+
+The existing `MouseEvent` already carries press/release state in the
+input poller — confirm in implementation; if not, extend the event.
+
+### `runtime.odin:260` no-op cleanup
+
+`runtime.odin:260-261` has an empty case body for `types.ApplyActive`.
+Either:
+
+- delete the case + remove `ApplyActive` from `apply_events.odin` if
+  nothing else consumes it (active state is set directly in
+  `apply_listeners` per the previous section), **or**
+- keep `ApplyActive` as the channel and have the runtime set
+  `input.active_idx = ev.idx` in the case body.
+
+Decision: **delete the `ApplyActive` event**. State lives in `input`, set
+directly by the package that owns it; one less indirection. The
+`types.ApplyActive` struct and union case go too. `ApplyFocus` stays as-is
+(it does have a non-empty consumer — `input.focus_enter` / `focus_leave`).
+
+### Render-side aspect resolution
+
+Introduce one helper in `render.odin`, used by every draw site that
+currently does `theme[n.aspect]`:
+
+```odin
+// Merge base aspect + state variants in the documented order.
+// Precedence (later overrides earlier): base < #focus < #hover < #active.
+// Returns the merged Theme struct; falls back to zero-value if base
+// aspect is missing.
+resolve_themed_aspect :: proc(
+    idx: int,
+    aspect: string,
+    theme: map[string]types.Theme,
+) -> types.Theme
+```
+
+Callers replace `if t, ok := theme[n.aspect]; ok { ... }` with
+`t := resolve_themed_aspect(idx, n.aspect, theme)` and stop hand-rolling
+the `#focus` overlay (it moves into the helper).
+
+State checks inside the helper:
+
+- `#focus` overlay: `idx == input.focused_idx`. Currently only
+  meaningful for `NodeInput` (which is where the existing overlay
+  lives) — extending it to all aspects is harmless because the existing
+  listener-registration in `input.odin:189-197` only attaches a
+  `FocusListener` when `<aspect>#focus` is present AND the node is not an
+  input. Inputs use their own focus path. Either way: applying `#focus`
+  to a focused node with no `<aspect>#focus` entry is a no-op (map miss).
+- `#hover` overlay: `slice.contains(input.hovered_indices[:], idx)`.
+- `#active` overlay: `idx == input.active_idx`.
+
+Active takes precedence over hover, which takes precedence over focus,
+which takes precedence over base — matches the merge order documented in
+`docs/reference/theme.md:170-171` (base → composed → state, with state
+ordered focus < hover < active).
+
+### Drag interaction
+
+Two cases:
+
+1. **Drag source / preview node.** When a node is rendered as the drag
+   source or in the drag-preview clone, the drag system has already
+   swapped its aspect to the draggable's `:aspect`
+   (`docs/core-api.md:270`). The swap aspect *is* the source-of-truth
+   "I am being dragged" visual; we don't want `#hover` / `#active` on
+   top of it. **Bypass mechanism**: the helper signature takes `idx`;
+   the drag-preview draw paths (`draw_subtree_translated` at
+   `render.odin:650,654,659,668`) pass `idx = -1`. A `-1` idx fails
+   every state check (`-1 == focused_idx == -1` is possible but
+   `focused_idx == -1` means no node is focused anyway; same for
+   `active_idx`; and `-1` is never appended to `hovered_indices`). The
+   helper short-circuits state overlays when `idx < 0`, making this
+   explicit.
+
+2. **Mouse-down that becomes a drag.** `active_idx` is set on mouse-down.
+   If the press triggers a drag, the drag preview takes over rendering.
+   `active_idx` would still be set on the underlying node until mouseup.
+   This is fine: the user doesn't see the underlying node in active state
+   (it's covered by the preview / scrolled away), and mouseup clears it
+   on drop. No special case needed.
+
+### Re-flatten / index invalidation
+
+The architecture note in CLAUDE.md says every per-node side table indexed
+by node idx must be invalidated when bridge re-flattens the frame. Both
+`hovered_indices` and `active_idx` qualify. Add invalidation in the same
+`clear_frame` site that already resets `focused_idx` / `node_rects`:
+
+- `hovered_indices` is rebuilt every frame anyway — no explicit clear
+  needed, but a `clear()` in `clear_frame` is cheap insurance against
+  cross-frame leakage if the input pump is skipped.
+- `active_idx`: if the active node's idx no longer exists in the new
+  frame, the next mouseup will still clear it. To be safe against
+  out-of-bounds idx reads, bounds-check before using (mirrors the
+  existing `if focused_idx >= len(node_rects)` guard at
+  `apply.odin:13`).
+
+## Test plan
+
+One new UI integration test, modelled on the existing
+`test/ui/test_input.bb` pattern (which uses `/input/takeover` +
+`/input/mouse/*` + assertions).
+
+### `test/ui/hover_active_app.fnl`
+
+A minimal app with two themed buttons sharing the same fixed-size rect
+geometry but distinct base / hover / active bg colors:
+
+```fennel
+(theme.set-theme
+  {:btn          {:bg [50 50 50]   :color [255 255 255] :radius 0}
+   :btn#hover    {:bg [100 100 100]}
+   :btn#active   {:bg [200 200 200]}})
+
+;; Single button at known coordinates so the test can sample bg pixel.
+[:stack {:viewport [[:top_left 0 0 :full :full]]}
+  [:button {:aspect :btn :width 100 :height 40 :click [:noop]}
+    "btn"]]
+```
+
+The flat colour rect (no rounding, no gradient) lets the test sample a
+single pixel inside the rect from `/screenshot` and compare against the
+known base / hover / active values exactly.
+
+### `test/ui/test_hover_active.bb`
+
+Steps:
+
+1. `GET /frames` to read the button's rect from `attrs.rect`.
+2. Sample the screenshot pixel at a fixed bg-only point — top-left
+   interior at `rect.x + 4, rect.y + 4` (clears the corner radius and
+   any glyph footprint). Assert `[50 50 50]` (base).
+3. `POST /input/takeover`, `POST /input/mouse/move` to the rect center,
+   wait one frame, `GET /screenshot`, sample same bg-only point →
+   assert `[100 100 100]` (hover).
+4. `POST /input/mouse/down {button:"left"}`, wait one frame,
+   `GET /screenshot` → assert `[200 200 200]` (active).
+5. `POST /input/mouse/move` to (0,0) **while still down**, wait one
+   frame, `GET /screenshot` → assert active colour persists at the
+   button's bg sample point (stays-active-until-mouseup semantics).
+6. `POST /input/mouse/up`, wait one frame, `GET /screenshot` →
+   assert base colour returns (cursor is at (0,0) now, no longer
+   hovered).
+7. `POST /input/release`.
+
+Screenshot pixel sampling: Babashka can decode PNG via
+`javax.imageio.ImageIO` or via a small Java interop block; pick whichever
+is consistent with how other UI tests handle byte responses (the input
+test framework already returns binary bodies for `/screenshot` — verify
+during implementation, factor a shared helper if it's not already there).
+
+## Out of scope, filed as follow-ups
+
+- **Composed aspects** (`{:aspect [:foo :bar]}`) — type / parser /
+  render-resolver work, see Non-goals above.
+- **Runtime-side hover state** — apps that want hover dispatch (e.g.
+  for tooltips) would need a separate opt-in attribute, not a
+  reverse-engineering of `:hover` events out of the listener pipeline.
+- **Hover cursor.** `input.set_hover_cursor` already swaps the system
+  cursor for hover-listener nodes. Unchanged by this work, mentioned for
+  context (a node with `#hover` automatically gets a pointing-hand
+  cursor today — that part already works).

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -48,6 +48,21 @@
                      (ctx.circle (/ ctx.width 2) (/ ctx.height 2) r
                                  {:fill [235 203 139 alpha]}))))
 
+;; A six-dot grip pattern, drawn into a 24×42 canvas. Kept deliberately small
+;; and static — the row's own #hover variant carries the hover feedback.
+(canvas.register :grip-dots
+                 (fn [ctx]
+                   (let [cx (/ ctx.width 2)
+                         cy (/ ctx.height 2)
+                         gap 5
+                         r 1.5
+                         color [129 138 155]]
+                     (for [row -1 1]
+                       (for [col 0 1]
+                         (let [dx (* (- (* 2 col) 1) (* gap 0.5))
+                               dy (* row (+ gap (* 2 r)))]
+                           (ctx.circle (+ cx dx) (+ cy dy) r {:fill color})))))))
+
 ;; ===== Theme =====
 
 (theme-mod.set-theme {;; --- Surfaces / text ---

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -63,12 +63,8 @@
                       :surface       {:bg [46 52 64]
                                       :padding [20 20 20 20]
                                       :radius 8}
-                      :surface-elev  {:bg [59 66 82]
-                                      :padding [12 16 12 16]
-                                      :radius 6}
                       :heading       {:font-size 22 :weight 1 :color [236 239 244]}
                       :body          {:font-size 14 :color [216 222 233]}
-                      :muted         {:font-size 13 :color [129 138 155]}
                       :count-badge   {:font-size 12 :color [129 138 155]}
 
                       ;; --- Rows ---
@@ -81,7 +77,7 @@
                                       :shadow [0 4 16 [0 0 0 120]]}
                       :row-drop-hot  {:bg [59 66 82]
                                       :border [136 192 208]
-                                      :border_width 2
+                                      :border-width 2
                                       :radius 4
                                       :padding [4 4 4 4]}
 
@@ -114,7 +110,7 @@
                                              :radius 6
                                              :padding [4 4 4 4]
                                              :font-size 16}
-                      :button-icon#hover    {:bg [59 66 82] :color [191 97 106]}
+                      :button-icon#hover    {:color [191 97 106]}
                       :button-icon#active   {:bg [76 86 106]}})
 
 ;; ===== State =====

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -202,71 +202,70 @@
 
 ;; ===== View =====
 
-(global main_view (fn []
-                    (let [items (subscribe :items)
-                          input-val (subscribe :input-value)]
-                      [:vbox
-                       {}
-                       [:stack
-                        {:viewport [[:top_left 0 0 :full :full]
-                                    [:top_left 0 0 :full :full]
-                                    [:bottom_center 0 0 :1_4 42]]}
-                        [:canvas
-                         {:provider :background :width :full :height :full}]
-                        [:vbox
-                         {:aspect :surface}
-                         [:text {:aspect :heading :layout :center} "Todo List"]
-                         [:input
-                          {:aspect :input
-                           :width 250
-                           :height 42
-                           :value input-val
-                           :change [:test/input]
-                           :key [:test/add]}]
-                         [:button
-                          {:width 250
-                           :height 42
-                           :aspect :button
-                           :click [:test/add]
-                           :animate {:provider :pulse-dot
-                                     :rect [:top_right -8 -8 16 16]
-                                     :z :above}}
-                          "Add"]
-                         [:vbox
-                          {:overflow :scroll-y
-                           :aspect :muted
-                           :drag-over [:row-drag
-                                       {:event :event/over
-                                        :aspect :muted-armed}]}
-                          (icollect [i item (ipairs (or items []))]
-                            [:hbox
-                             {:layout :center
-                              :aspect :row
-                              :height 42
-                              :draggable [:row-drag
-                                          {:mode :preview
-                                           :handle false
-                                           :event :event/drag
-                                           :aspect :row-dragging
-                                           :animate {:provider :pulse-dot
-                                                     :rect [:top_right -6 -6 12 12]
-                                                     :z :above}}
-                                          i]
-                              :dropable [:row-drag
-                                         {:event :event/drop
-                                          :aspect :row-drop-hot}
-                                         i]}
-                             [:vbox {:width 24
-                                     :aspect :drag-handle
-                                     :drag-handle true}]
-                             [:text {:aspect :body} item.text]
-                             [:button
-                              {:width 250
-                               :aspect :button
-                               :click [:test/remove i]}
-                              "remove"]])]]
-                        [:hbox
-                         {:height 42 :aspect :status-field :layout :center}
-                         [:text
-                          {:aspect :body :layout :center}
-                          (.. "Todos: " (length items))]]]])))
+(global main_view
+        (fn []
+          (let [items     (subscribe :items)
+                input-val (subscribe :input-value)
+                count     (length (or items []))]
+            [:stack
+             {:viewport [[:top_left 0 0 :full :full]
+                         [:top_center 0 32 480 :full]]}
+             [:canvas {:provider :background :width :full :height :full}]
+             [:vbox
+              {:aspect :surface}
+              ;; Header — title left, count right.
+              [:hbox
+               {:height 32 :layout :center}
+               [:text {:aspect :heading} "Todo List"]
+               [:vbox {:width :full}]
+               [:text {:aspect :count-badge} (.. count " items")]]
+              ;; Input + Add side by side.
+              [:hbox
+               {:height 42}
+               [:input {:aspect :input
+                        :width :full
+                        :height 42
+                        :value input-val
+                        :change [:test/input]
+                        :key [:test/add]}]
+               [:vbox {:width 8}]
+               [:button {:aspect :button-primary
+                         :width 72
+                         :height 42
+                         :click [:test/add]
+                         :animate {:provider :pulse-dot
+                                   :rect [:top_right -8 -8 16 16]
+                                   :z :above}}
+                "Add"]]
+              [:vbox {:height 8}]
+              ;; Scrollable list.
+              [:vbox
+               {:overflow :scroll-y
+                :drag-over [:row-drag
+                            {:event :event/over
+                             :aspect :muted-armed}]}
+               (icollect [i item (ipairs (or items []))]
+                 [:hbox {:layout :center
+                         :aspect :row
+                         :height 42
+                         :draggable [:row-drag
+                                     {:mode :preview
+                                      :handle false
+                                      :event :event/drag
+                                      :aspect :row-dragging}
+                                     i]
+                         :dropable [:row-drag
+                                    {:event :event/drop
+                                     :aspect :row-drop-hot}
+                                    i]}
+                  ;; Grip handle — fixed 24px column, canvas-drawn dots.
+                  [:vbox {:width 24 :height 42 :drag-handle true}
+                   [:canvas {:provider :grip-dots
+                             :width 24 :height 42}]]
+                  ;; Item text — fills remaining width.
+                  [:text {:aspect :body :width :full} item.text]
+                  ;; Remove icon button.
+                  [:button {:aspect :button-icon
+                            :width 32 :height 32
+                            :click [:test/remove i]}
+                   "×"]])]]])))

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -268,4 +268,4 @@
                   [:button {:aspect :button-icon
                             :width 32 :height 32
                             :click [:test/remove i]}
-                   "×"]])]]])))
+                   "x"]])]]])))

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -74,17 +74,13 @@
                       :count-badge   {:font-size 12 :color [129 138 155]}
 
                       ;; --- Rows ---
-                      :row           {:padding [4 4 4 4] :radius 4}
-                      :row#hover     {:bg [59 66 82] :padding [4 4 4 4] :radius 4}
+                      :row           {:padding [4 4 4 4]}
+                      :row#hover     {:bg [59 66 82] :padding [4 4 4 4]}
                       :row-dragging  {:bg [94 129 172]
                                       :color [30 34 46]
                                       :padding [4 4 4 4]
-                                      :radius 4
                                       :shadow [0 4 16 [0 0 0 120]]}
-                      :row-drop-hot  {:bg [59 66 82]
-                                      :border [136 192 208]
-                                      :border-width 2
-                                      :radius 4
+                      :row-drop-hot  {:bg [60 90 110]
                                       :padding [4 4 4 4]}
 
                       ;; --- Drag-over list zone ---
@@ -217,7 +213,7 @@
               [:hbox
                {:height 32 :layout :center}
                [:text {:aspect :heading} "Todo List"]
-               [:vbox {:width :full}]
+               [:vbox {:width :full}] ; flex spacer
                [:text {:aspect :count-badge} (.. count " items")]]
               ;; Input + Add side by side.
               [:hbox
@@ -228,7 +224,7 @@
                         :value input-val
                         :change [:test/input]
                         :key [:test/add]}]
-               [:vbox {:width 8}]
+               [:vbox {:width 8}] ; 8px gap
                [:button {:aspect :button-primary
                          :width 72
                          :height 42
@@ -237,7 +233,7 @@
                                    :rect [:top_right -8 -8 16 16]
                                    :z :above}}
                 "Add"]]
-              [:vbox {:height 8}]
+              [:vbox {:height 8}] ; 8px gap before list
               ;; Scrollable list.
               [:vbox
                {:overflow :scroll-y

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -80,7 +80,7 @@
                                       :color [30 34 46]
                                       :padding [4 4 4 4]
                                       :shadow [0 4 16 [0 0 0 120]]}
-                      :row-drop-hot  {:bg [60 90 110]
+                      :row-drop-hot  {:bg [75 110 135]
                                       :padding [4 4 4 4]}
 
                       ;; --- Drag-over list zone ---
@@ -215,6 +215,7 @@
                [:text {:aspect :heading} "Todo List"]
                [:vbox {:width :full}] ; flex spacer
                [:text {:aspect :count-badge} (.. count " items")]]
+              [:vbox {:height 16}]                                 ; 16px gap before input
               ;; Input + Add side by side.
               [:hbox
                {:height 42}
@@ -233,7 +234,7 @@
                                    :rect [:top_right -8 -8 16 16]
                                    :z :above}}
                 "Add"]]
-              [:vbox {:height 8}] ; 8px gap before list
+              [:vbox {:height 12}]                                  ; 12px gap before list
               ;; Scrollable list.
               [:vbox
                {:overflow :scroll-y

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -99,6 +99,8 @@
 
 ;; ===== State =====
 
+(global redin_get_state (. dataflow :_get-raw-db))
+
 (dataflow.init {:items [{:text "Test 1"}
                         {:text "Test 2"}
                         {:text "Test 3"}
@@ -160,21 +162,15 @@
                                  from-idx ctx.from
                                  to-idx ctx.to
                                  items (get db :items [])]
-                             (when (and from-idx to-idx (> from-idx 0)
-                                        (<= from-idx (length items))
-                                        (> to-idx 0) (<= to-idx (length items))
+                             (when (and from-idx to-idx
+                                        (> from-idx 0) (<= from-idx (length items))
+                                        (> to-idx   0) (<= to-idx   (length items))
                                         (not= from-idx to-idx))
                                (let [item (. items from-idx)
                                      new-items (icollect [i v (ipairs items)]
                                                  (when (not= i from-idx) v))]
-                                 (let [insert-at (if (> from-idx to-idx) to-idx
-                                                     (- to-idx 1))]
-                                   (table.insert new-items
-                                                 (math.min insert-at
-                                                           (+ (length new-items)
-                                                              1))
-                                                 item)
-                                   (assoc db :items new-items)))))
+                                 (table.insert new-items to-idx item)
+                                 (assoc db :items new-items))))
                            db))
 
 ;; ===== Subscriptions =====

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -32,7 +32,7 @@
                              a (math.floor (* 2.5 i))]
                          (ctx.rect inset inset
                                    (- w (* inset 2)) (- h (* inset 2))
-                                   {:stroke [0 0 0 a] :width 1}))))))
+                                   {:stroke [0 0 0 a] :stroke-width 1}))))))
 
 ;; ===== Micro-animation =====
 ;; A small pulsing dot used as an :animate decoration on the Add button —

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -59,43 +59,63 @@
 
 ;; ===== Theme =====
 
-(theme-mod.set-theme {:surface {:bg [46 52 64]
-                                :padding [24 24 24 24]
-                                :opacity 0.5}
-                      :heading {:font-size 24 :color [236 239 244] :weight 1}
-                      :body {:font-size 14 :color [216 222 233]}
-                      :status-field {:font-size 14
-                                     :bg [26 32 34]
-                                     :color [216 222 233]
-                                     :border [255 255 255]
-                                     :border_width 2
-                                     :radius 4}
-                      :row {:padding [4 4 4 4]}
-                      :row-dragging {:bg [136 46 106]
-                                     :padding [4 4 4 4]
-                                     :radius 4}
-                      :row-drop-hot {:bg [76 86 106]
-                                     :padding [4 4 4 4]}
-                      :muted {:font-size 13 :color [76 86 106]}
-                      :muted-armed {:font-size 13
-                                    :color [76 86 106]
-                                    :bg [54 60 72]}
-                      :drag-handle {:bg [66 66 86]}
-                      :input {:bg [59 66 82]
-                              :color [236 239 244]
-                              :border [76 86 106]
-                              :border-width 1
-                              :radius 4
-                              :padding [8 12 8 12]
-                              :font-size 14}
-                      :input#focus {:border [136 192 208]}
-                      :button {:bg [76 86 106]
-                               :color [236 239 244]
-                               :radius 6
-                               :padding [6 14 6 14]
-                               :font-size 13}
-                      :button#hover {:bg [94 105 126]}
-                      :button#active {:bg [59 66 82]}})
+(theme-mod.set-theme {;; --- Surfaces / text ---
+                      :surface       {:bg [46 52 64]
+                                      :padding [20 20 20 20]
+                                      :radius 8}
+                      :surface-elev  {:bg [59 66 82]
+                                      :padding [12 16 12 16]
+                                      :radius 6}
+                      :heading       {:font-size 22 :weight 1 :color [236 239 244]}
+                      :body          {:font-size 14 :color [216 222 233]}
+                      :muted         {:font-size 13 :color [129 138 155]}
+                      :count-badge   {:font-size 12 :color [129 138 155]}
+
+                      ;; --- Rows ---
+                      :row           {:padding [4 4 4 4] :radius 4}
+                      :row#hover     {:bg [59 66 82] :padding [4 4 4 4] :radius 4}
+                      :row-dragging  {:bg [94 129 172]
+                                      :color [30 34 46]
+                                      :padding [4 4 4 4]
+                                      :radius 4
+                                      :shadow [0 4 16 [0 0 0 120]]}
+                      :row-drop-hot  {:bg [59 66 82]
+                                      :border [136 192 208]
+                                      :border_width 2
+                                      :radius 4
+                                      :padding [4 4 4 4]}
+
+                      ;; --- Drag-over list zone ---
+                      :muted-armed   {:font-size 13
+                                      :color [129 138 155]
+                                      :bg [54 60 72]}
+
+                      ;; --- Input ---
+                      :input         {:bg [59 66 82]
+                                      :color [236 239 244]
+                                      :border [76 86 106]
+                                      :border-width 1
+                                      :radius 4
+                                      :padding [8 12 8 12]
+                                      :font-size 14}
+                      :input#focus   {:border [136 192 208]}
+
+                      ;; --- Buttons ---
+                      :button-primary       {:bg [136 192 208]
+                                             :color [30 34 46]
+                                             :radius 6
+                                             :padding [6 14 6 14]
+                                             :font-size 13
+                                             :weight 1}
+                      :button-primary#hover {:bg [143 188 187]}
+                      :button-primary#active {:bg [122 162 175]}
+                      :button-icon          {:bg [59 66 82]
+                                             :color [129 138 155]
+                                             :radius 6
+                                             :padding [4 4 4 4]
+                                             :font-size 16}
+                      :button-icon#hover    {:bg [59 66 82] :color [191 97 106]}
+                      :button-icon#active   {:bg [76 86 106]}})
 
 ;; ===== State =====
 

--- a/examples/kitchen-sink.fnl
+++ b/examples/kitchen-sink.fnl
@@ -11,37 +11,28 @@
                    (let [t (redin.now)
                          w ctx.width
                          h ctx.height]
-                     ;; Dark base
+                     ;; Polar night base
                      (ctx.rect 0 0 w h {:fill [30 34 46]})
-                     ;; Drifting orbs — slow sine/cosine motion, muted colors, low alpha
-                     (for [i 1 8]
-                       (let [speed (* 0.15 (+ 1 (* i 0.3)))
-                             phase (* i 1.7)
-                             r (+ 40 (* 30 i))
+                     ;; Three slow orbs — large radius, very low alpha, single hue.
+                     (for [i 1 3]
+                       (let [speed (* 0.08 (+ 1 (* i 0.4)))
+                             phase (* i 2.1)
+                             r     (+ 180 (* 40 i))
                              x (+ (* w 0.5)
-                                  (* (* w 0.4) (math.sin (+ (* t speed) phase))))
+                                  (* (* w 0.35) (math.sin (+ (* t speed) phase))))
                              y (+ (* h 0.5)
-                                  (* (* h 0.35)
+                                  (* (* h 0.3)
                                      (math.cos (+ (* t speed 0.7) (* phase 1.3)))))
-                             pulse (+ 0.7
-                                      (* 0.3 (math.sin (+ (* t 0.5) phase))))
-                             alpha (math.floor (* 18 pulse))]
-                         (ctx.circle x y r {:fill [67 76 94 alpha]})))
-                     ;; Subtle accent orbs — brighter, smaller
-                     (for [i 1 4]
-                       (let [speed (* 0.1 (+ 1 (* i 0.5)))
-                             phase (* i 2.3)
-                             r (+ 20 (* 15 i))
-                             x (+ (* w 0.3)
-                                  (* (* w 0.5) (math.cos (+ (* t speed) phase))))
-                             y (+ (* h 0.4)
-                                  (* (* h 0.4)
-                                     (math.sin (+ (* t speed 0.8) (* phase 0.9)))))
-                             alpha (math.floor (+ 10
-                                                  (* 8
-                                                     (math.sin (+ (* t 0.4)
-                                                                  phase)))))]
-                         (ctx.circle x y r {:fill [94 129 172 alpha]}))))))
+                             alpha 14]
+                         (ctx.circle x y r {:fill [94 129 172 alpha]})))
+                     ;; Cheap vignette: nested rect strokes from the edges in,
+                     ;; alpha ramping up toward the outside.
+                     (for [i 1 12]
+                       (let [inset (* 6 (- 12 i))
+                             a (math.floor (* 2.5 i))]
+                         (ctx.rect inset inset
+                                   (- w (* inset 2)) (- h (* inset 2))
+                                   {:stroke [0 0 0 a] :width 1}))))))
 
 ;; ===== Micro-animation =====
 ;; A small pulsing dot used as an :animate decoration on the Add button —

--- a/src/redin/input/apply.odin
+++ b/src/redin/input/apply.odin
@@ -13,6 +13,11 @@ apply_listeners :: proc(
 	if focused_idx >= len(node_rects) {
 		focused_idx = -1
 	}
+	if active_idx >= len(node_rects) {
+		active_idx = -1
+	}
+
+	press_this_frame := false
 
 	for event in events {
 		switch e in event {
@@ -43,11 +48,19 @@ apply_listeners :: proc(
 				append(&applied, types.ApplyEvents(types.ApplyFocus{idx = new_focus}))
 			}
 			if has_active {
-				append(&applied, types.ApplyEvents(types.ApplyActive{idx = winner}))
+				active_idx = winner
+				press_this_frame = true
 			}
 
 		case types.KeyEvent, types.CharEvent, types.ScrollEvent, types.ResizeEvent:
 		}
+	}
+
+	// Clear active_idx the frame the button comes up, but never on the
+	// same frame as the press (so a single-frame click still shows
+	// active for at least one rendered frame).
+	if !press_this_frame && !is_mouse_button_down(.LEFT) {
+		active_idx = -1
 	}
 
 	return applied

--- a/src/redin/input/input.odin
+++ b/src/redin/input/input.odin
@@ -58,6 +58,18 @@ collect_drag_handles_recur :: proc(
 // Currently focused node index, -1 means none.
 focused_idx: int = -1
 
+// Set of node indices currently under the mouse that carry a HoverListener.
+// Multiple ancestors can be hovered simultaneously (matches the deepest-
+// listener-but-hover-multi-fires policy documented above). Rebuilt every
+// frame in get_user_events; never cleared elsewhere.
+hovered_indices: [dynamic]int
+
+// Index of the node currently in the #active visual state. Set on
+// mousedown when the press lands on a winner with a ClickListener.
+// Cleared in apply_listeners when the left mouse button is no longer
+// down (CSS-like "stays active until mouseup"). -1 means none.
+active_idx: int = -1
+
 // Deepest event-listener-bearing node under `pt`, or -1 if none.
 // "Deepest" = highest node_idx among listener matches; nodes[] is
 // DFS-ordered, so a descendant always has a higher idx than its

--- a/src/redin/input/state.odin
+++ b/src/redin/input/state.odin
@@ -44,6 +44,8 @@ state_destroy :: proc() {
 	state.selection_path = {}
 	delete(gesture.anchor_path)
 	gesture.anchor_path = {}
+	delete(hovered_indices)
+	hovered_indices = {}
 }
 
 // Called when an input gains focus. Copies the node's value into the editing buffer.

--- a/src/redin/input/user_events.odin
+++ b/src/redin/input/user_events.odin
@@ -16,10 +16,12 @@ get_user_events :: proc(
 
 	mouse := mouse_pos()
 
+	clear(&hovered_indices)
 	for listener in listeners {
 		if hl, ok := listener.(types.HoverListener); ok {
 			if hl.node_idx < len(node_rects) &&
 			   rl.CheckCollisionPointRec(mouse, node_rects[hl.node_idx]) {
+				append(&hovered_indices, hl.node_idx)
 				append(
 					&user_events,
 					types.UserEvent{event = .HOVER, node_idx = hl.node_idx},

--- a/src/redin/render.odin
+++ b/src/redin/render.odin
@@ -699,11 +699,11 @@ draw_subtree_translated :: proc(
 		draw_subtree_children_translated(idx, delta, nodes, children_list, theme)
 	case types.NodeVbox:
 		aspect := is_root ? override_aspect_for_root : n.aspect
-		draw_box_chrome(idx, rect, aspect, theme)
+		draw_box_chrome(-1, rect, aspect, theme)
 		draw_subtree_children_translated(idx, delta, nodes, children_list, theme)
 	case types.NodeHbox:
 		aspect := is_root ? override_aspect_for_root : n.aspect
-		draw_box_chrome(idx, rect, aspect, theme)
+		draw_box_chrome(-1, rect, aspect, theme)
 		draw_subtree_children_translated(idx, delta, nodes, children_list, theme)
 	case types.NodeButton:
 		b := n

--- a/src/redin/render.odin
+++ b/src/redin/render.odin
@@ -14,6 +14,58 @@ import rl "vendor:raylib"
 // Snap to pixel grid for crisp text rendering
 px :: proc(v: f32) -> f32 { return math.round(v) }
 
+// Merge base aspect with #focus, #hover, #active state variants.
+// Later overrides earlier: base < #focus < #hover < #active. Matches
+// the order documented in docs/reference/theme.md.
+//
+// idx = -1 means "no state overlays" (used by the drag-preview draw
+// paths, where the source/clone aspect already encodes the dragging
+// visual and should not be further mutated).
+//
+// Returns a zero-value Theme if the base aspect is missing — every
+// caller already handles default values per-field with `t.<field> != {}`.
+resolve_themed_aspect :: proc(
+	idx: int,
+	aspect: string,
+	theme: map[string]types.Theme,
+) -> types.Theme {
+	result: types.Theme
+	if len(aspect) == 0 do return result
+	if base, ok := theme[aspect]; ok do result = base
+	if idx < 0 do return result
+
+	overlay :: proc(out: ^types.Theme, src: types.Theme) {
+		if src.bg != {}          do out.bg = src.bg
+		if src.color != {}       do out.color = src.color
+		if src.border != {}      do out.border = src.border
+		if src.border_width > 0  do out.border_width = src.border_width
+		if src.radius > 0        do out.radius = src.radius
+		if src.padding != {}     do out.padding = src.padding
+		if src.font_size > 0     do out.font_size = src.font_size
+		if len(src.font) > 0     do out.font = src.font
+		if src.weight > 0        do out.weight = src.weight
+		if src.line_height > 0   do out.line_height = src.line_height
+		if src.opacity > 0       do out.opacity = src.opacity
+		if src.shadow != {}      do out.shadow = src.shadow
+		if src.selection != {}   do out.selection = src.selection
+		if src.text_align != .Auto do out.text_align = src.text_align
+	}
+
+	if idx == input.focused_idx {
+		if t, ok := theme[strings.concatenate({aspect, "#focus"}, context.temp_allocator)]; ok do overlay(&result, t)
+	}
+	for hi in input.hovered_indices {
+		if hi == idx {
+			if t, ok := theme[strings.concatenate({aspect, "#hover"}, context.temp_allocator)]; ok do overlay(&result, t)
+			break
+		}
+	}
+	if idx == input.active_idx {
+		if t, ok := theme[strings.concatenate({aspect, "#active"}, context.temp_allocator)]; ok do overlay(&result, t)
+	}
+	return result
+}
+
 // Resolve a single ViewportValue to pixels given a window dimension.
 resolve_vp :: proc(v: types.ViewportValue, window_dim: f32) -> f32 {
 	switch val in v {
@@ -560,17 +612,17 @@ draw_node :: proc(
 	case types.NodeInput:
 		draw_input(idx, rect, n, theme)
 	case types.NodeButton:
-		draw_button(rect, n, theme)
+		draw_button(idx, rect, n, theme)
 	case types.NodeText:
 		draw_text(idx, rect, n, theme)
 	case types.NodeImage:
-		draw_themed_rect(rect, n.aspect, theme)
+		draw_themed_rect(idx, rect, n.aspect, theme)
 		rl.DrawRectangleLinesEx(rect, 1, rl.GRAY)
 		rl.DrawText("image", i32(rect.x) + 4, i32(rect.y) + 4, 14, rl.GRAY)
 	case types.NodePopout:
 		draw_children(idx, nodes, children_list, theme)
 	case types.NodeModal:
-		draw_themed_rect(rect, n.aspect, theme)
+		draw_themed_rect(idx, rect, n.aspect, theme)
 		draw_children(idx, nodes, children_list, theme)
 	}
 
@@ -656,7 +708,7 @@ draw_subtree_translated :: proc(
 	case types.NodeButton:
 		b := n
 		if is_root do b.aspect = override_aspect_for_root
-		draw_button(rect, b, theme)
+		draw_button(-1, rect, b, theme)
 	case types.NodeText:
 		// Pass idx = -1 — the proc treats negative idx as "no selection,
 		// no scroll-offset persistence" (see step 2 of this task).
@@ -665,14 +717,14 @@ draw_subtree_translated :: proc(
 		draw_text(-1, rect, t, theme)
 	case types.NodeImage:
 		aspect := is_root ? override_aspect_for_root : n.aspect
-		draw_themed_rect(rect, aspect, theme)
+		draw_themed_rect(-1, rect, aspect, theme)
 		rl.DrawRectangleLinesEx(rect, 1, rl.GRAY)
 	case types.NodeCanvas:
 		// Canvas providers paint into content_rect — translation is enough.
 		if len(n.provider) > 0 do canvas.process(n.provider, content_rect)
 	case types.NodeInput:
 		// Inputs in the preview clone aren't focusable; render as a styled rect.
-		draw_themed_rect(rect, n.aspect, theme)
+		draw_themed_rect(-1, rect, n.aspect, theme)
 	case types.NodePopout, types.NodeModal:
 		// Popouts/modals don't make sense inside a drag preview; skip.
 	}
@@ -703,18 +755,16 @@ draw_box_chrome :: proc(
 
 	bg_color: rl.Color
 	has_bg := false
-	shadow: types.Shadow
 
-	if t, ok := theme[aspect]; ok {
-		if t.bg != {} {
-			alpha := u8(255)
-			if t.opacity > 0 && t.opacity < 1 do alpha = u8(t.opacity * 255)
-			bg_color = rl.Color{t.bg[0], t.bg[1], t.bg[2], alpha}
-			has_bg = true
-		}
-		shadow = t.shadow
+	t := resolve_themed_aspect(idx, aspect, theme)
+	if t.bg != {} {
+		alpha := u8(255)
+		if t.opacity > 0 && t.opacity < 1 do alpha = u8(t.opacity * 255)
+		bg_color = rl.Color{t.bg[0], t.bg[1], t.bg[2], alpha}
+		has_bg = true
 	}
-	draw_shadow(rect, shadow, 0)
+
+	draw_shadow(rect, t.shadow, 0)
 	if has_bg do rl.DrawRectangleRec(rect, bg_color)
 }
 
@@ -1102,9 +1152,10 @@ draw_shadow :: proc(rect: rl.Rectangle, shadow: types.Shadow, radius: u8) {
 	}
 }
 
-draw_themed_rect :: proc(rect: rl.Rectangle, aspect: string, theme: map[string]types.Theme) {
+draw_themed_rect :: proc(idx: int, rect: rl.Rectangle, aspect: string, theme: map[string]types.Theme) {
 	if len(aspect) > 0 {
-		if t, ok := theme[aspect]; ok && t.bg != {} {
+		t := resolve_themed_aspect(idx, aspect, theme)
+		if t.bg != {} {
 			bg := rl.Color{t.bg[0], t.bg[1], t.bg[2], 255}
 			rl.DrawRectangleRec(rect, bg)
 		}
@@ -1174,26 +1225,19 @@ draw_input :: proc(
 	text_align := types.Text_Align.Auto
 
 	if len(n.aspect) > 0 {
-		if t, ok := theme[n.aspect]; ok {
-			if t.border != {} do border_color = rl.Color{t.border[0], t.border[1], t.border[2], 255}
-			if t.bg != {} do bg_color = rl.Color{t.bg[0], t.bg[1], t.bg[2], 255}
-			if t.color != {} do text_color = rl.Color{t.color[0], t.color[1], t.color[2], 255}
-			if t.font_size > 0 do font_size = f32(t.font_size)
-			if t.border_width > 0 do border_width = f32(t.border_width)
-			if t.padding[3] > 0 do padding_l = f32(t.padding[3])
-			if t.padding[1] > 0 do padding_r = f32(t.padding[1])
-			if t.padding[0] > 0 do padding_t = f32(t.padding[0])
-			if len(t.font) > 0 do font_name = t.font
-			font_weight = t.weight
-			lh_ratio = t.line_height
-			text_align = t.text_align
-		}
-		if is_focused {
-			focus_key := strings.concatenate({n.aspect, "#focus"}, context.temp_allocator)
-			if ft, ok := theme[focus_key]; ok {
-				if ft.border != {} do border_color = rl.Color{ft.border[0], ft.border[1], ft.border[2], 255}
-			}
-		}
+		t := resolve_themed_aspect(idx, n.aspect, theme)
+		if t.border != {} do border_color = rl.Color{t.border[0], t.border[1], t.border[2], 255}
+		if t.bg != {} do bg_color = rl.Color{t.bg[0], t.bg[1], t.bg[2], 255}
+		if t.color != {} do text_color = rl.Color{t.color[0], t.color[1], t.color[2], 255}
+		if t.font_size > 0 do font_size = f32(t.font_size)
+		if t.border_width > 0 do border_width = f32(t.border_width)
+		if t.padding[3] > 0 do padding_l = f32(t.padding[3])
+		if t.padding[1] > 0 do padding_r = f32(t.padding[1])
+		if t.padding[0] > 0 do padding_t = f32(t.padding[0])
+		if len(t.font) > 0 do font_name = t.font
+		font_weight = t.weight
+		lh_ratio = t.line_height
+		text_align = t.text_align
 	}
 
 	// Draw background and border
@@ -1310,7 +1354,7 @@ draw_input :: proc(
 	rl.EndScissorMode()
 }
 
-draw_button :: proc(rect: rl.Rectangle, n: types.NodeButton, theme: map[string]types.Theme) {
+draw_button :: proc(idx: int, rect: rl.Rectangle, n: types.NodeButton, theme: map[string]types.Theme) {
 	bg_color := rl.LIGHTGRAY
 	text_color := rl.BLACK
 	radius: f32 = 0
@@ -1321,16 +1365,15 @@ draw_button :: proc(rect: rl.Rectangle, n: types.NodeButton, theme: map[string]t
 	radius_u8: u8 = 0
 
 	if len(n.aspect) > 0 {
-		if t, ok := theme[n.aspect]; ok {
-			if t.bg != {} do bg_color = rl.Color{t.bg[0], t.bg[1], t.bg[2], 255}
-			if t.color != {} do text_color = rl.Color{t.color[0], t.color[1], t.color[2], 255}
-			if t.radius > 0 do radius = f32(t.radius)
-			if t.font_size > 0 do font_size = f32(t.font_size)
-			if len(t.font) > 0 do font_name = t.font
-			font_weight = t.weight
-			shadow = t.shadow
-			radius_u8 = t.radius
-		}
+		t := resolve_themed_aspect(idx, n.aspect, theme)
+		if t.bg != {} do bg_color = rl.Color{t.bg[0], t.bg[1], t.bg[2], 255}
+		if t.color != {} do text_color = rl.Color{t.color[0], t.color[1], t.color[2], 255}
+		if t.radius > 0 do radius = f32(t.radius)
+		if t.font_size > 0 do font_size = f32(t.font_size)
+		if len(t.font) > 0 do font_name = t.font
+		font_weight = t.weight
+		shadow = t.shadow
+		radius_u8 = t.radius
 	}
 
 	draw_shadow(rect, shadow, radius_u8)
@@ -1364,13 +1407,12 @@ draw_text :: proc(idx: int, rect: rl.Rectangle, n: types.NodeText, theme: map[st
 	lh_ratio: f32 = 0
 
 	if len(n.aspect) > 0 {
-		if t, ok := theme[n.aspect]; ok {
-			if t.font_size > 0 do font_size = f32(t.font_size)
-			if t.color != {} do text_color = rl.Color{t.color[0], t.color[1], t.color[2], 255}
-			if len(t.font) > 0 do font_name = t.font
-			font_weight = t.weight
-			lh_ratio = t.line_height
-		}
+		t := resolve_themed_aspect(idx, n.aspect, theme)
+		if t.font_size > 0 do font_size = f32(t.font_size)
+		if t.color != {} do text_color = rl.Color{t.color[0], t.color[1], t.color[2], 255}
+		if len(t.font) > 0 do font_name = t.font
+		font_weight = t.weight
+		lh_ratio = t.line_height
 	}
 
 	if len(n.inline_spans) > 0 {

--- a/src/redin/render.odin
+++ b/src/redin/render.odin
@@ -581,25 +581,24 @@ draw_node :: proc(
 		draw_box_children(idx, content_rect, n.overflow, false, nodes, children_list, theme)
 	case types.NodeCanvas:
 		if len(n.aspect) > 0 {
-			if t, ok := theme[n.aspect]; ok {
-				draw_shadow(rect, t.shadow, t.radius)
-				if t.bg != {} {
-					bg := rl.Color{t.bg[0], t.bg[1], t.bg[2], 255}
-					if t.radius > 0 {
-						roundness := f32(t.radius) / min(rect.width, rect.height) * 2
-						rl.DrawRectangleRounded(rect, roundness, 6, bg)
-					} else {
-						rl.DrawRectangleRec(rect, bg)
-					}
+			t := resolve_themed_aspect(idx, n.aspect, theme)
+			draw_shadow(rect, t.shadow, t.radius)
+			if t.bg != {} {
+				bg := rl.Color{t.bg[0], t.bg[1], t.bg[2], 255}
+				if t.radius > 0 {
+					roundness := f32(t.radius) / min(rect.width, rect.height) * 2
+					rl.DrawRectangleRounded(rect, roundness, 6, bg)
+				} else {
+					rl.DrawRectangleRec(rect, bg)
 				}
-				if t.border != {} && t.border_width > 0 {
-					border := rl.Color{t.border[0], t.border[1], t.border[2], 255}
-					if t.radius > 0 {
-						roundness := f32(t.radius) / min(rect.width, rect.height) * 2
-						rl.DrawRectangleRoundedLinesEx(rect, roundness, 6, f32(t.border_width), border)
-					} else {
-						rl.DrawRectangleLinesEx(rect, f32(t.border_width), border)
-					}
+			}
+			if t.border != {} && t.border_width > 0 {
+				border := rl.Color{t.border[0], t.border[1], t.border[2], 255}
+				if t.radius > 0 {
+					roundness := f32(t.radius) / min(rect.width, rect.height) * 2
+					rl.DrawRectangleRoundedLinesEx(rect, roundness, 6, f32(t.border_width), border)
+				} else {
+					rl.DrawRectangleLinesEx(rect, f32(t.border_width), border)
 				}
 			}
 		}
@@ -1204,16 +1203,6 @@ draw_input :: proc(
 	// Theme selection color; fall back to the legacy blue when the aspect
 	// does not set :selection (sentinel is all-zero).
 	selection_color := rl.Color{51, 153, 255, 100}
-	if len(n.aspect) > 0 {
-		if aspect, ok := theme[n.aspect]; ok {
-			if aspect.selection != ([4]u8{}) {
-				selection_color = rl.Color{
-					aspect.selection[0], aspect.selection[1],
-					aspect.selection[2], aspect.selection[3],
-				}
-			}
-		}
-	}
 	font_size: f32 = 14
 	padding_l: f32 = 4
 	padding_r: f32 = 4
@@ -1226,6 +1215,12 @@ draw_input :: proc(
 
 	if len(n.aspect) > 0 {
 		t := resolve_themed_aspect(idx, n.aspect, theme)
+		if t.selection != ([4]u8{}) {
+			selection_color = rl.Color{
+				t.selection[0], t.selection[1],
+				t.selection[2], t.selection[3],
+			}
+		}
 		if t.border != {} do border_color = rl.Color{t.border[0], t.border[1], t.border[2], 255}
 		if t.bg != {} do bg_color = rl.Color{t.bg[0], t.bg[1], t.bg[2], 255}
 		if t.color != {} do text_color = rl.Color{t.color[0], t.color[1], t.color[2], 255}

--- a/src/redin/runtime.odin
+++ b/src/redin/runtime.odin
@@ -257,7 +257,6 @@ run :: proc(cfg: Config) {
 						input.focus_leave()
 					}
 				}
-			case types.ApplyActive:
 			}
 		}
 		if input.state.active && input.focused_idx < 0 {

--- a/src/redin/types/apply_events.odin
+++ b/src/redin/types/apply_events.odin
@@ -4,11 +4,6 @@ ApplyFocus :: struct {
 	idx: int,
 }
 
-ApplyActive :: struct {
-	idx: int,
-}
-
 ApplyEvents :: union {
 	ApplyFocus,
-	ApplyActive,
 }

--- a/test/ui/hover_active_app.fnl
+++ b/test/ui/hover_active_app.fnl
@@ -11,7 +11,8 @@
 (local dataflow (require :dataflow))
 (local theme-mod (require :theme))
 
-(theme-mod.set-theme {:bg-fill {:bg [0 0 0]}
+(theme-mod.set-theme {:bg-fill {:bg [0 0 0]
+                               :padding [50 0 0 50]}
                       :btn         {:bg [50 50 50]
                                     :color [255 255 255]
                                     :radius 0

--- a/test/ui/hover_active_app.fnl
+++ b/test/ui/hover_active_app.fnl
@@ -1,0 +1,42 @@
+;; Hover/active state-variant test fixture.
+;;
+;; One themed button at a fixed-size rect. Distinct, easy-to-recognise
+;; bg colours per state so the test can pixel-sample and compare exactly:
+;;   base   = [50 50 50]     (dark grey)
+;;   hover  = [100 100 100]  (mid grey)
+;;   active = [200 200 200]  (light grey)
+;;
+;; No corner radius, no shadow — solid rect makes pixel sampling stable.
+
+(local dataflow (require :dataflow))
+(local theme-mod (require :theme))
+
+(theme-mod.set-theme {:bg-fill {:bg [0 0 0]}
+                      :btn         {:bg [50 50 50]
+                                    :color [255 255 255]
+                                    :radius 0
+                                    :padding [0 0 0 0]
+                                    :font-size 14}
+                      :btn#hover   {:bg [100 100 100]}
+                      :btn#active  {:bg [200 200 200]}})
+
+(dataflow.init {:clicks 0})
+
+(reg-handler :test/click
+             (fn [db event]
+               (update db :clicks #(+ $ 1))))
+
+(reg-sub :clicks (fn [db] (get db :clicks 0)))
+
+(global main_view
+        (fn []
+          [:stack
+           {:viewport [[:top_left 0 0 :full :full]]}
+           ;; Solid black background fill so anything outside the button
+           ;; is obviously not the button.
+           [:vbox {:aspect :bg-fill :width :full :height :full}
+            [:button {:aspect :btn
+                      :width 100
+                      :height 40
+                      :click [:test/click]}
+             ""]]]))

--- a/test/ui/redin_test.bb
+++ b/test/ui/redin_test.bb
@@ -443,13 +443,17 @@
           :else               c)))
 
 (defn screenshot-pixel
-  "Read RGB at (x,y) from PNG bytes. Returns [r g b].
-   Only decompresses and unfilters rows 0..y, so it is fast even for
-   large screenshots. Raylib encodes screenshots as RGBA PNGs. Uses
-   java.util.zip (Babashka built-in) — no external dependencies."
+  "Read RGB at (x,y) from a PNG byte array. Returns [r g b].
+   Lightweight, partial decoder (Babashka doesn't ship javax.imageio):
+   concatenates IDAT chunks, then short-circuits the inflate + unfilter
+   loop after row y. Supports PNG colour types 2 (RGB) and 6 (RGBA),
+   8-bit. Throws on out-of-bounds coordinates."
   [^bytes png-bytes x y]
   (let [width  (read-be-int png-bytes 16)
         height (read-be-int png-bytes 20)
+        _      (when (or (< x 0) (< y 0) (>= x width) (>= y height))
+                 (throw (ex-info "screenshot-pixel: coordinate out of bounds"
+                                 {:x x :y y :width width :height height})))
         bpp    4   ; Raylib screenshot PNGs are RGBA
         stride (+ 1 (* width bpp))
         idat   (png-collect-idat png-bytes)

--- a/test/ui/redin_test.bb
+++ b/test/ui/redin_test.bb
@@ -422,17 +422,11 @@
       (throw (ex-info "screenshot is not a PNG" {:byte-idx i}))))
   [(read-be-int bytes 16) (read-be-int bytes 20)])
 
-(defn- png-read-be-int [^bytes b offset]
-  (bit-or (bit-shift-left (bit-and (aget b offset) 0xff) 24)
-          (bit-shift-left (bit-and (aget b (+ offset 1)) 0xff) 16)
-          (bit-shift-left (bit-and (aget b (+ offset 2)) 0xff) 8)
-          (bit-and (aget b (+ offset 3)) 0xff)))
-
 (defn- png-collect-idat [^bytes b]
   (let [baos (java.io.ByteArrayOutputStream.)]
     (loop [pos 8]
       (when (< pos (alength b))
-        (let [chunk-len (png-read-be-int b pos)
+        (let [chunk-len (read-be-int b pos)
               chunk-type (subs (String. b (+ pos 4) 4 "ASCII") 0 4)]
           (when (= chunk-type "IDAT")
             (.write baos b (+ pos 8) chunk-len))
@@ -440,7 +434,7 @@
     (.toByteArray baos)))
 
 (defn- png-paeth [a b c]
-  (let [p  (+ (- a b) c)
+  (let [p  (- (+ a b) c)
         pa (Math/abs (- p a))
         pb (Math/abs (- p b))
         pc (Math/abs (- p c))]
@@ -454,8 +448,8 @@
    large screenshots. Raylib encodes screenshots as RGBA PNGs. Uses
    java.util.zip (Babashka built-in) — no external dependencies."
   [^bytes png-bytes x y]
-  (let [width  (png-read-be-int png-bytes 16)
-        height (png-read-be-int png-bytes 20)
+  (let [width  (read-be-int png-bytes 16)
+        height (read-be-int png-bytes 20)
         bpp    4   ; Raylib screenshot PNGs are RGBA
         stride (+ 1 (* width bpp))
         idat   (png-collect-idat png-bytes)

--- a/test/ui/redin_test.bb
+++ b/test/ui/redin_test.bb
@@ -372,7 +372,7 @@
          (fn)
          (println "PASS")
          (swap! results update :passed inc)
-         (catch Exception e
+         (catch Throwable e
            (println "FAIL")
            (println (str "    " (.getMessage e)))
            (swap! results update :failed inc)
@@ -421,6 +421,76 @@
     (when (not= (aget bytes i) (aget png-signature i))
       (throw (ex-info "screenshot is not a PNG" {:byte-idx i}))))
   [(read-be-int bytes 16) (read-be-int bytes 20)])
+
+(defn- png-read-be-int [^bytes b offset]
+  (bit-or (bit-shift-left (bit-and (aget b offset) 0xff) 24)
+          (bit-shift-left (bit-and (aget b (+ offset 1)) 0xff) 16)
+          (bit-shift-left (bit-and (aget b (+ offset 2)) 0xff) 8)
+          (bit-and (aget b (+ offset 3)) 0xff)))
+
+(defn- png-collect-idat [^bytes b]
+  (let [baos (java.io.ByteArrayOutputStream.)]
+    (loop [pos 8]
+      (when (< pos (alength b))
+        (let [chunk-len (png-read-be-int b pos)
+              chunk-type (subs (String. b (+ pos 4) 4 "ASCII") 0 4)]
+          (when (= chunk-type "IDAT")
+            (.write baos b (+ pos 8) chunk-len))
+          (recur (+ pos 4 4 chunk-len 4)))))
+    (.toByteArray baos)))
+
+(defn- png-paeth [a b c]
+  (let [p  (+ (- a b) c)
+        pa (Math/abs (- p a))
+        pb (Math/abs (- p b))
+        pc (Math/abs (- p c))]
+    (cond (<= pa (min pb pc)) a
+          (<= pb pc)          b
+          :else               c)))
+
+(defn screenshot-pixel
+  "Read RGB at (x,y) from PNG bytes. Returns [r g b].
+   Only decompresses and unfilters rows 0..y, so it is fast even for
+   large screenshots. Raylib encodes screenshots as RGBA PNGs. Uses
+   java.util.zip (Babashka built-in) — no external dependencies."
+  [^bytes png-bytes x y]
+  (let [width  (png-read-be-int png-bytes 16)
+        height (png-read-be-int png-bytes 20)
+        bpp    4   ; Raylib screenshot PNGs are RGBA
+        stride (+ 1 (* width bpp))
+        idat   (png-collect-idat png-bytes)
+        n-rows (inc (int y))
+        need   (* n-rows stride)
+        bais   (java.io.ByteArrayInputStream. idat)
+        iis    (java.util.zip.InflaterInputStream. bais)
+        raw    (byte-array need)
+        _      (.readNBytes iis raw 0 need)
+        out    (byte-array (* n-rows (* width bpp)))
+        ub     (fn [v] (bit-and v 0xff))]
+    (doseq [row (range n-rows)]
+      (let [row-start    (* row stride)
+            filter-type  (ub (aget raw row-start))
+            out-row-off  (* row (* width bpp))]
+        (doseq [i (range (* width bpp))]
+          (let [raw-idx (+ row-start 1 i)
+                out-idx (+ out-row-off i)
+                xv      (ub (aget raw raw-idx))
+                a       (if (>= i bpp)     (ub (aget out (- out-idx bpp))) 0)
+                b       (if (> row 0)      (ub (aget out (- out-idx (* width bpp)))) 0)
+                c       (if (and (>= i bpp) (> row 0))
+                          (ub (aget out (- out-idx (+ (* width bpp) bpp)))) 0)
+                val     (case filter-type
+                          0 xv
+                          1 (mod (+ xv a) 256)
+                          2 (mod (+ xv b) 256)
+                          3 (mod (+ xv (quot (+ a b) 2)) 256)
+                          4 (mod (+ xv (png-paeth a b c)) 256)
+                          xv)]
+            (aset out out-idx (unchecked-byte val))))))
+    (let [idx (* (+ (* (int y) width) (int x)) bpp)]
+      [(ub (aget out idx))
+       (ub (aget out (+ idx 1)))
+       (ub (aget out (+ idx 2)))])))
 
 (defn wait-ms
   "Sleep for n milliseconds. Prefer wait-for."

--- a/test/ui/test_hover_active.bb
+++ b/test/ui/test_hover_active.bb
@@ -31,65 +31,75 @@
 (deftest base-color-resting
   ;; Cursor at default position (outside the button). Bg should be base.
   (input-takeover)
-  (input-mouse-move 0 0)
-  (wait-ms 100)
-  (let [[r g b] (sample-bg)]
-    (assert (= [r g b] [50 50 50])
-            (str "Expected base color [50 50 50], got " [r g b])))
-  (input-release))
+  (try
+    (input-mouse-move 0 0)
+    (wait-ms 100)
+    (let [[r g b] (sample-bg)]
+      (assert (= [r g b] [50 50 50])
+              (str "Expected base color [50 50 50], got " [r g b])))
+    (finally
+      (input-release))))
 
 (deftest hover-color-on-cursor-over
   (input-takeover)
-  (let [[cx cy] (center-of)]
-    (input-mouse-move cx cy)
-    (wait-ms 100)
-    (let [[r g b] (sample-bg)]
-      (assert (= [r g b] [100 100 100])
-              (str "Expected hover color [100 100 100], got " [r g b]))))
-  (input-release))
+  (try
+    (let [[cx cy] (center-of)]
+      (input-mouse-move cx cy)
+      (wait-ms 100)
+      (let [[r g b] (sample-bg)]
+        (assert (= [r g b] [100 100 100])
+                (str "Expected hover color [100 100 100], got " [r g b]))))
+    (finally
+      (input-release))))
 
 (deftest active-color-on-mouse-down
   (input-takeover)
-  (let [[cx cy] (center-of)]
-    (input-mouse-move cx cy)
-    (wait-ms 100)
-    (input-mouse-down :left)
-    (wait-ms 100)
-    (let [[r g b] (sample-bg)]
-      (assert (= [r g b] [200 200 200])
-              (str "Expected active color [200 200 200], got " [r g b])))
-    (input-mouse-up :left))
-  (input-release))
+  (try
+    (let [[cx cy] (center-of)]
+      (input-mouse-move cx cy)
+      (wait-ms 100)
+      (input-mouse-down :left)
+      (wait-ms 100)
+      (let [[r g b] (sample-bg)]
+        (assert (= [r g b] [200 200 200])
+                (str "Expected active color [200 200 200], got " [r g b])))
+      (input-mouse-up :left))
+    (finally
+      (input-release))))
 
 (deftest active-persists-when-cursor-drags-off
   ;; CSS-like semantics: pressed button stays active until mouseup,
   ;; even when the cursor leaves the rect while still held.
   (input-takeover)
-  (let [[cx cy] (center-of)]
-    (input-mouse-move cx cy)
-    (wait-ms 100)
-    (input-mouse-down :left)
-    (wait-ms 100)
-    (input-mouse-move 0 0)
-    (wait-ms 100)
-    (let [[r g b] (sample-bg)]
-      (assert (= [r g b] [200 200 200])
-              (str "Active should persist while held; got " [r g b])))
-    (input-mouse-up :left))
-  (input-release))
+  (try
+    (let [[cx cy] (center-of)]
+      (input-mouse-move cx cy)
+      (wait-ms 100)
+      (input-mouse-down :left)
+      (wait-ms 100)
+      (input-mouse-move 0 0)
+      (wait-ms 100)
+      (let [[r g b] (sample-bg)]
+        (assert (= [r g b] [200 200 200])
+                (str "Active should persist while held; got " [r g b])))
+      (input-mouse-up :left))
+    (finally
+      (input-release))))
 
 (deftest base-restored-after-mouseup-off-rect
   (input-takeover)
-  (let [[cx cy] (center-of)]
-    (input-mouse-move cx cy)
-    (wait-ms 100)
-    (input-mouse-down :left)
-    (wait-ms 100)
-    (input-mouse-move 0 0)
-    (wait-ms 100)
-    (input-mouse-up :left)
-    (wait-ms 100)
-    (let [[r g b] (sample-bg)]
-      (assert (= [r g b] [50 50 50])
-              (str "After release with cursor off, base should return; got " [r g b]))))
-  (input-release))
+  (try
+    (let [[cx cy] (center-of)]
+      (input-mouse-move cx cy)
+      (wait-ms 100)
+      (input-mouse-down :left)
+      (wait-ms 100)
+      (input-mouse-move 0 0)
+      (wait-ms 100)
+      (input-mouse-up :left)
+      (wait-ms 100)
+      (let [[r g b] (sample-bg)]
+        (assert (= [r g b] [50 50 50])
+                (str "After release with cursor off, base should return; got " [r g b]))))
+    (finally
+      (input-release))))

--- a/test/ui/test_hover_active.bb
+++ b/test/ui/test_hover_active.bb
@@ -1,0 +1,95 @@
+(require '[redin-test :refer :all])
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- btn-rect []
+  (rect-of (find-element {:tag :button :aspect :btn})))
+
+(defn- sample-bg
+  "Sample a pixel from the screenshot at a bg-only point inside the button
+   (4px in from the top-left corner — clear of any glyph footprint)."
+  []
+  (let [{:keys [x y]} (btn-rect)
+        png (screenshot)]
+    (screenshot-pixel png (+ x 4) (+ y 4))))
+
+(defn- center-of
+  "Return [cx cy] for the button rect's center."
+  []
+  (let [{:keys [x y w h]} (btn-rect)]
+    [(int (+ x (/ w 2))) (int (+ y (/ h 2)))]))
+
+;; ---------------------------------------------------------------------------
+;; Tests
+;; ---------------------------------------------------------------------------
+
+(deftest button-rect-exists
+  (assert (some? (btn-rect)) "Button rect should be present in /frames"))
+
+(deftest base-color-resting
+  ;; Cursor at default position (outside the button). Bg should be base.
+  (input-takeover)
+  (input-mouse-move 0 0)
+  (wait-ms 100)
+  (let [[r g b] (sample-bg)]
+    (assert (= [r g b] [50 50 50])
+            (str "Expected base color [50 50 50], got " [r g b])))
+  (input-release))
+
+(deftest hover-color-on-cursor-over
+  (input-takeover)
+  (let [[cx cy] (center-of)]
+    (input-mouse-move cx cy)
+    (wait-ms 100)
+    (let [[r g b] (sample-bg)]
+      (assert (= [r g b] [100 100 100])
+              (str "Expected hover color [100 100 100], got " [r g b]))))
+  (input-release))
+
+(deftest active-color-on-mouse-down
+  (input-takeover)
+  (let [[cx cy] (center-of)]
+    (input-mouse-move cx cy)
+    (wait-ms 100)
+    (input-mouse-down :left)
+    (wait-ms 100)
+    (let [[r g b] (sample-bg)]
+      (assert (= [r g b] [200 200 200])
+              (str "Expected active color [200 200 200], got " [r g b])))
+    (input-mouse-up :left))
+  (input-release))
+
+(deftest active-persists-when-cursor-drags-off
+  ;; CSS-like semantics: pressed button stays active until mouseup,
+  ;; even when the cursor leaves the rect while still held.
+  (input-takeover)
+  (let [[cx cy] (center-of)]
+    (input-mouse-move cx cy)
+    (wait-ms 100)
+    (input-mouse-down :left)
+    (wait-ms 100)
+    (input-mouse-move 0 0)
+    (wait-ms 100)
+    (let [[r g b] (sample-bg)]
+      (assert (= [r g b] [200 200 200])
+              (str "Active should persist while held; got " [r g b])))
+    (input-mouse-up :left))
+  (input-release))
+
+(deftest base-restored-after-mouseup-off-rect
+  (input-takeover)
+  (let [[cx cy] (center-of)]
+    (input-mouse-move cx cy)
+    (wait-ms 100)
+    (input-mouse-down :left)
+    (wait-ms 100)
+    (input-mouse-move 0 0)
+    (wait-ms 100)
+    (input-mouse-up :left)
+    (wait-ms 100)
+    (let [[r g b] (sample-bg)]
+      (assert (= [r g b] [50 50 50])
+              (str "After release with cursor off, base should return; got " [r g b]))))
+  (input-release))


### PR DESCRIPTION
## Summary

- **Kitchen-sink demo refresh.** Centered card layout with drag-handle grip rows, quieter background canvas, Nord-aligned palette, visible drop-hot zone, and a fixed off-by-one in the drop handler when dragging downward. Spec + plan in `docs/superpowers/specs/2026-05-15-kitchen-sink-redesign-design.md` and `docs/superpowers/plans/2026-05-15-kitchen-sink-redesign.md`.
- **#hover / #active theme state variants now actually render.** `docs/reference/theme.md` has documented `aspect#hover` / `aspect#active` for some time, but the rendering pipeline only ever applied `#focus` on inputs. Tasks landed: `input.hovered_indices` + `input.active_idx` state, `resolve_themed_aspect` helper merging base → #focus → #hover → #active in CSS precedence, four draw procs (`draw_box_chrome`, `draw_themed_rect`, `draw_button`, `draw_text`) plus `draw_input` and `NodeCanvas` routed through it, drag-preview paths bypass overlays via `idx = -1`. The now-empty `ApplyActive` event is dropped. Spec + plan in `docs/superpowers/specs/2026-05-16-hover-active-rendering-design.md` and `docs/superpowers/plans/2026-05-16-hover-active-rendering.md`.
- **Surfaced one separate pre-existing bug** while verifying: canvas mouse-pressed exposure consumes the override-system's one-shot press flag, breaking `/input/mouse/down` for any app with canvases. Filed as **#139** with a frame-order trace and three fix options. Real raylib input and `/click` are unaffected; this only bites the test-takeover path.

Composed aspects (`{:aspect [:foo :bar]}` merging) are documented but still not implemented; left in scope as a follow-up so this PR stays focused.

## Test plan

- [x] `bash test/ui/run-all.sh` — 25 suites / 151 assertions pass, including new `test_hover_active`
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 133/133 pass
- [x] `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin-release` — clean, no warnings (release build, no REDIN_DEV-gated dependencies)
- [x] `test_hover_active` pixel-samples all five state transitions (base, hover, active, active-held-cursor-off, release) — 6/6 pass
- [x] `test_drag` (most exposed to drag-preview render changes) — 12/12 pass
- [x] Manual smoke: `./build/redin examples/kitchen-sink.fnl` — hover transitions and remove-button hover/active behave as themed under real input. Under takeover-path input, kitchen-sink Add button shows hover but not active — tracked in #139, not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)