### PR TITLE
fix(render): scissor stack for nested scroll/canvas/input clipping (#142)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ acceptor plus a 4-handler worker pool (up to 4 in flight at a time).
 | `POST` | `/input/mouse/down` | Press a button (`{button:"left\|right\|middle"}`). Requires takeover. |
 | `POST` | `/input/mouse/up` | Release a button (`{button:...}`). Requires takeover. |
 | `POST` | `/input/key` | Synthesise one KeyEvent (`{key, mods?}`). Does not require takeover. |
+| `POST` | `/input/scroll` | Synthesise one ScrollEvent (`{x,y,delta_x,delta_y}`). Drives `scroll-y` / `scroll-x` containers; does not require takeover. |
 | `GET`  | `/agent/nodes` | List `:agent`-tagged nodes (REDIN_AGENT only). |
 | `GET`  | `/agent/content/<id>` | Read content (REDIN_AGENT only). |
 | `PUT`  | `/agent/content/<id>` | Write content; node must be `:agent :edit` (REDIN_AGENT only). |

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -686,8 +686,8 @@ lua_canvas_draw :: proc(b: ^Bridge, name: string, rect: rl.Rectangle) {
 }
 
 execute_canvas_commands :: proc(L: ^Lua_State, buf_idx: i32, rect: rl.Rectangle) {
-	rl.BeginScissorMode(i32(rect.x), i32(rect.y), i32(rect.width), i32(rect.height))
-	defer rl.EndScissorMode()
+	push_scissor(rect)
+	defer pop_scissor()
 
 	n := i32(lua_objlen(L, buf_idx))
 	for i: i32 = 1; i <= n; i += 1 {

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -755,6 +755,8 @@ process_request :: proc(ds: ^Dev_Server, req: ^Pending_Request) {
 			handle_post_input_mouse_down(ds, ch, req.body)
 		} else if req.path == "/input/mouse/up" {
 			handle_post_input_mouse_up(ds, ch, req.body)
+		} else if req.path == "/input/scroll" {
+			handle_post_input_scroll(ds, ch, req.body)
 		} else if req.path == "/input/key" {
 			handle_post_input_key(ds, ch, req.body)
 		} else if req.path == "/shutdown" {
@@ -1924,6 +1926,37 @@ handle_post_input_key :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: stri
 	m := input.mouse_pos()
 	append(&ds.event_queue, types.InputEvent(types.KeyEvent{
 		x = m.x, y = m.y, key = key, mods = mods,
+	}))
+	respond_json_ok(ch)
+}
+
+handle_post_input_scroll :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
+	if !ds.bridge.dev_mode {
+		respond_text(ch, 404, "Not found")
+		return
+	}
+	L := ds.bridge.L
+	pos := 0
+	if !json_decode_value(L, body, &pos) {
+		respond_json_error(ch, 400, `{"error":"invalid JSON"}`)
+		return
+	}
+	defer lua_pop(L, 1)
+	if !lua_istable(L, -1) {
+		respond_json_error(ch, 400, `{"error":"body must be an object"}`)
+		return
+	}
+	get_num :: proc(L: ^Lua_State, key: cstring) -> f32 {
+		lua_getfield(L, -1, key)
+		defer lua_pop(L, 1)
+		return f32(lua_tonumber(L, -1))
+	}
+	x := get_num(L, "x")
+	y := get_num(L, "y")
+	dx := get_num(L, "delta_x")
+	dy := get_num(L, "delta_y")
+	append(&ds.event_queue, types.InputEvent(types.ScrollEvent{
+		x = x, y = y, delta_x = dx, delta_y = dy,
 	}))
 	respond_json_ok(ch)
 }

--- a/src/redin/bridge/scissor.odin
+++ b/src/redin/bridge/scissor.odin
@@ -1,0 +1,67 @@
+package bridge
+
+import rl "vendor:raylib"
+
+// Scissor stack — raylib's BeginScissorMode / EndScissorMode operate on
+// a single global scissor state (no stack), so nested Begin/End pairs in
+// independent render paths tear each other down. The renderer uses four
+// such pairs (scrollable container, draw_input, draw_text-with-clip,
+// execute_canvas_commands), and at least one nests inside the others in
+// every non-trivial layout. The stack here lets push/pop callers compose
+// safely: each push intersects with the current top, each pop re-applies
+// the new top (or disables scissor when the stack empties).
+//
+// Lives in package bridge because both render.odin (package redin) and
+// bridge.odin (the canvas command executor) need to call it, and bridge
+// is below redin in the import graph — putting it here avoids a cycle.
+
+@(private="package")
+scissor_stack: [dynamic]rl.Rectangle
+
+push_scissor :: proc(rect: rl.Rectangle) {
+	effective := rect
+	if len(scissor_stack) > 0 {
+		effective = scissor_intersect(effective, scissor_stack[len(scissor_stack) - 1])
+	}
+	append(&scissor_stack, effective)
+	rl.BeginScissorMode(
+		i32(effective.x), i32(effective.y),
+		i32(effective.width), i32(effective.height),
+	)
+}
+
+pop_scissor :: proc() {
+	if len(scissor_stack) == 0 do return
+	pop(&scissor_stack)
+	if len(scissor_stack) > 0 {
+		r := scissor_stack[len(scissor_stack) - 1]
+		rl.BeginScissorMode(i32(r.x), i32(r.y), i32(r.width), i32(r.height))
+	} else {
+		rl.EndScissorMode()
+	}
+}
+
+// Safety net for frame-start: callers that forgot to pop don't leak
+// their scissor into the next frame's draws. Render runtime calls this
+// once at the top of each frame, before any push.
+reset_scissor :: proc() {
+	if len(scissor_stack) > 0 {
+		clear(&scissor_stack)
+		rl.EndScissorMode()
+	}
+}
+
+destroy_scissor :: proc() {
+	delete(scissor_stack)
+	scissor_stack = nil
+}
+
+scissor_intersect :: proc(a, b: rl.Rectangle) -> rl.Rectangle {
+	x := max(a.x, b.x)
+	y := max(a.y, b.y)
+	r := min(a.x + a.width, b.x + b.width)
+	bo := min(a.y + a.height, b.y + b.height)
+	w := max(0, r - x)
+	h := max(0, bo - y)
+	return rl.Rectangle{x, y, w, h}
+}

--- a/src/redin/render.odin
+++ b/src/redin/render.odin
@@ -860,10 +860,7 @@ draw_box_children :: proc(
 	scrollable := scrollable_y || scrollable_x
 
 	if scrollable {
-		rl.BeginScissorMode(
-			i32(content_rect.x), i32(content_rect.y),
-			i32(content_rect.width), i32(content_rect.height),
-		)
+		bridge.push_scissor(content_rect)
 	}
 
 	// Visibility culling for scrollable containers: skip children whose
@@ -885,7 +882,7 @@ draw_box_children :: proc(
 	}
 
 	if scrollable {
-		rl.EndScissorMode()
+		bridge.pop_scissor()
 
 		info := node_scroll_info[idx]
 		fixed_total := info.total
@@ -1283,7 +1280,7 @@ draw_input :: proc(
 	}
 
 	// Scissor clip to content area
-	rl.BeginScissorMode(i32(content_x), i32(content_y), i32(content_w), i32(content_h))
+	bridge.push_scissor(rl.Rectangle{content_x, content_y, content_w, content_h})
 
 	// Vertical alignment, resolved from the theme's :text-align.
 	// Auto centres single-line content and top-aligns multi-line
@@ -1346,7 +1343,7 @@ draw_input :: proc(
 		}
 	}
 
-	rl.EndScissorMode()
+	bridge.pop_scissor()
 }
 
 draw_button :: proc(idx: int, rect: rl.Rectangle, n: types.NodeButton, theme: map[string]types.Theme) {
@@ -1485,7 +1482,7 @@ draw_text :: proc(idx: int, rect: rl.Rectangle, n: types.NodeText, theme: map[st
 	// Clip when content may overflow the rect
 	needs_clip := scrollable_y || scrollable_x || (len(lines) > 1 && f32(len(lines)) * lh > rect.height)
 	if needs_clip {
-		rl.BeginScissorMode(i32(rect.x), i32(rect.y), i32(rect.width), i32(rect.height))
+		bridge.push_scissor(rect)
 	}
 
 	// Vertical alignment
@@ -1557,6 +1554,6 @@ draw_text :: proc(idx: int, rect: rl.Rectangle, n: types.NodeText, theme: map[st
 	}
 
 	if needs_clip {
-		rl.EndScissorMode()
+		bridge.pop_scissor()
 	}
 }

--- a/src/redin/runtime.odin
+++ b/src/redin/runtime.odin
@@ -162,6 +162,7 @@ run :: proc(cfg: Config) {
 	// lifetime, but still tracked allocations).
 	defer render_destroy()
 	defer text.destroy_intrinsic_cache()
+	defer bridge.destroy_scissor()
 
 	bridge.load_app(&b, cfg.app)
 
@@ -193,6 +194,7 @@ run :: proc(cfg: Config) {
 		profile.begin_frame()
 
 		free_all(context.temp_allocator)
+		bridge.reset_scissor()
 		bridge.check_hotreload(&b)
 
 		if b.frame_changed {

--- a/test/ui/redin_test.bb
+++ b/test/ui/redin_test.bb
@@ -262,6 +262,14 @@
   ([k]      (post-json "/input/key" {:key (name k)}))
   ([k mods] (post-json "/input/key" {:key (name k) :mods mods})))
 
+(defn input-scroll
+  "Synthesise a ScrollEvent at (x, y) with the given wheel deltas.
+   Positive delta-y scrolls content up (mimics raylib's GetMouseWheelMoveV).
+   Does not require takeover."
+  ([x y delta-y]       (input-scroll x y 0 delta-y))
+  ([x y delta-x delta-y]
+   (post-json "/input/scroll" {:x x :y y :delta_x delta-x :delta_y delta-y})))
+
 (defn rect-of
   "Read the :rect attr from a frame node and return {:x :y :w :h}.
    Returns nil if the node has no :rect (e.g. layout not yet computed)."

--- a/test/ui/scroll_clip_app.fnl
+++ b/test/ui/scroll_clip_app.fnl
@@ -1,0 +1,49 @@
+;; Regression fixture for #142: scroll-y clipping must hold when a
+;; scrollable container has a canvas (or input, or multi-line text)
+;; descendant. Each of those calls Begin/End scissor for its own clip,
+;; and without a scissor stack, EndScissor inside the descendant tears
+;; down the outer container's scissor — letting subsequent rows render
+;; over siblings positioned above the list.
+;;
+;; Layout:
+;;   [0..50, sibling]      solid RED background
+;;   [50..*, scroll-y vbox] rows of 30px each, each row a green canvas
+;;
+;; After one scroll tick (SCROLL_SPEED=30 → 30px), the first row's
+;; logical y becomes 20 — straddling the boundary. With the bug, the
+;; row's green canvas pixels render at y=20..49, covering the sibling.
+;; With the fix, scissor clips to y >= 50 and the red sibling stays
+;; visible.
+
+(local dataflow (require :dataflow))
+(local theme-mod (require :theme))
+(local canvas (require :canvas))
+
+(canvas.register :green-row
+                 (fn [ctx]
+                   (ctx.rect 0 0 ctx.width ctx.height {:fill [0 200 0]})))
+
+(theme-mod.set-theme {:sibling {:bg [220 0 0] :padding [0 0 0 0]}
+                      :list    {:bg [40 40 40] :padding [0 0 0 0]}
+                      :row     {:padding [0 0 0 0]}})
+
+(dataflow.init {})
+
+(global main_view
+        (fn []
+          [:stack {:viewport [[:top_left 0 0 :full :full]]}
+           [:vbox {:width :full :height :full}
+            ;; Sibling above the list — solid red.
+            [:vbox {:aspect :sibling :width :full :height 50}]
+            ;; Scrollable list with a tight 100px viewport but enough
+            ;; rows (each 30px) to force overflow. Each row contains a
+            ;; canvas: without a scissor stack, each row's canvas
+            ;; end-scissor wipes the list's own scissor, so a row
+            ;; scrolled above the list renders over the red sibling.
+            [:vbox {:aspect :list :width :full :height 100
+                    :overflow :scroll-y}
+             (icollect [i v (ipairs [1 2 3 4 5 6 7 8 9 10
+                                     11 12 13 14 15 16 17 18 19 20
+                                     21 22 23 24])]
+               [:vbox {:aspect :row :width :full :height 30}
+                [:canvas {:provider :green-row :width :full :height 30}]])]]]))

--- a/test/ui/test_scroll_clip.bb
+++ b/test/ui/test_scroll_clip.bb
@@ -1,0 +1,52 @@
+(require '[redin-test :refer :all])
+
+;; Regression test for #142. The scroll-y container holds rows that each
+;; contain a canvas. Each canvas's execute_canvas_commands runs its own
+;; BeginScissor/EndScissor pair — and raylib's scissor isn't a stack, so
+;; EndScissor disables clipping entirely. After the first canvas draws,
+;; the list's outer scissor is gone and subsequent row pixels render
+;; outside the list bounds.
+;;
+;; The test scrolls one wheel tick (30px under SCROLL_SPEED=30) and
+;; samples a pixel inside the sibling-above-the-list region. The
+;; sibling is red; the scrolled-up row is green. If clipping works the
+;; pixel stays red. If it doesn't (the bug), the row's green pixels
+;; have leaked above the list and the pixel reads green.
+
+(defn- list-rect [] (rect-of (find-element {:tag :vbox :aspect :list})))
+(defn- sibling-rect [] (rect-of (find-element {:tag :vbox :aspect :sibling})))
+
+(deftest sibling-and-list-laid-out
+  (let [s (sibling-rect)
+        l (list-rect)]
+    (assert (some? s) "sibling rect should be present")
+    (assert (some? l) "list rect should be present")
+    (assert (= (:y l) (+ (:y s) (:h s)))
+            (str "list should sit directly below sibling; got sibling="
+                 s " list=" l))))
+
+(deftest scrolled-row-does-not-overflow-into-sibling
+  (let [s (sibling-rect)
+        l (list-rect)
+        ;; Sample 8px inside the sibling, well above the list boundary.
+        sx (int (+ (:x s) (/ (:w s) 2)))
+        sy (int (+ (:y s) (/ (:h s) 2)))]
+    ;; Baseline: with no scroll, the sample point is unambiguously red.
+    (let [[r g b] (screenshot-pixel (screenshot) sx sy)]
+      (assert (= [r g b] [220 0 0])
+              (str "baseline (no scroll) sibling pixel should be red; got "
+                   [r g b])))
+
+    ;; Drive one wheel tick down. SCROLL_SPEED=30 → first row's logical
+    ;; y becomes (list.y - 30). The row's canvas would render at that
+    ;; y absent scissor clipping.
+    (input-scroll (int (+ (:x l) (/ (:w l) 2)))
+                  (int (+ (:y l) (/ (:h l) 2)))
+                  -1)
+    (wait-ms 100)
+
+    (let [[r g b] (screenshot-pixel (screenshot) sx sy)]
+      (assert (= [r g b] [220 0 0])
+              (str "after scrolling, sibling pixel should still be red "
+                   "(scissor must clip the scrolled-up row); got "
+                   [r g b])))))


### PR DESCRIPTION
## Summary

- **Closes #142.** raylib's `BeginScissorMode` / `EndScissorMode` is a single global state, not a stack — so the four Begin/End pairs in the render pipeline (`draw_box_children` for scrollable containers, `draw_input`, `draw_text` when content overflows, `execute_canvas_commands` for every canvas tick) were tearing each other's clips down whenever they nested. The visible symptom in `examples/kitchen-sink.fnl`: scroll the todo list one wheel tick down → the first row's content paints over the Add button and input field.
- **Adds `push_scissor` / `pop_scissor`** in `src/redin/bridge/scissor.odin`. Each push intersects with the current top (inner clips never expand outward); each pop re-applies the new top, or disables scissor when the stack empties. Lives in package `bridge` because that's the lowest common ancestor in the import graph for the four callers (`package redin`'s render.odin can import bridge; bridge.odin's canvas executor is already there).
- **Routes all four scissor sites through the helpers.** Adds `reset_scissor()` at frame start as a safety net for unbalanced pop pairs, and `destroy_scissor()` on shutdown.
- **Regression test** (`test_scroll_clip.bb` + `scroll_clip_app.fnl`): red sibling above a 100px scroll-y vbox of canvas-bearing rows; after one wheel tick, pixel-sample inside the sibling area must stay red.
- **Test infrastructure side-effect:** the regression test required a way to drive scroll programmatically from the dev server. Adds `POST /input/scroll {x, y, delta_x, delta_y}` that synthesizes a `ScrollEvent` into the input queue. Mirrors `/input/key`'s pattern; doesn't require takeover.

## Frame-order trace

Before the fix, in the kitchen-sink with a list scrolled down by one wheel tick:

```
draw_box_children(list)
  rl.BeginScissorMode(list_rect y=154..812)         ← outer clip
  for each visible row:
    draw_node(row)
      draw_box_chrome(row)
      for each child in row:
        draw_node(grip vbox)
          draw_node(canvas)
            execute_canvas_commands
              rl.BeginScissorMode(canvas_rect)      ← REPLACES outer
              ...draw dots...
              rl.EndScissorMode()                   ← DISABLES scissor
        draw_node(text)
        draw_node(x-button)                          ← drawn unclipped
```

Every row beyond the first drew with scissor entirely off — pixels at y < 154 (over input/button) rendered freely. The "jumps at a certain point" the issue described is the visibility-cull threshold at `render.odin:881`: once a row's bottom crosses above the list's top, it's culled outright (a binary skip), so the visible glitch snaps in/out at integer multiples of `row_height / SCROLL_SPEED`.

After the fix, `push_scissor` intersects each inner rect with the parent, so the canvas's effective clip is `intersect(canvas_rect, list_rect)` and `pop_scissor` re-applies the list_rect rather than disabling scissor.

## Test plan

- [x] `test_scroll_clip` — failing on `main`, passes after fix
- [x] `bash test/ui/run-all.sh` — full UI suite green
- [x] `./build-dev.sh` — clean build, no warnings
- [x] Manual smoke: kitchen-sink Add button and input area stay clean while scrolling the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)