### PR TITLE
fix(runtime): dispatch-later uses wall clock (#146)

### DIFF
--- a/src/runtime/effect.fnl
+++ b/src/runtime/effect.fnl
@@ -84,7 +84,12 @@
           (dispatch-fn event)))))
   (M.reg-fx :dispatch-later
     (fn [params]
-      (let [now (* (os.clock) 1000)]
+      ;; Wall-clock ms when the bridge is present, falling back to
+      ;; CPU time for pure-Lua tests. The host polls with wall-clock,
+      ;; so the two clocks must agree in production. See issue #146.
+      (let [now (if (and _G.redin _G.redin.now)
+                  (* (_G.redin.now) 1000)
+                  (* (os.clock) 1000))]
         (if (and (= (type params) "table") (. params :ms))
           (table.insert timer-queue {:at (+ now params.ms) :event params.dispatch})
           (each [_ timer-spec (ipairs params)]

--- a/test/lua/test_effect.fnl
+++ b/test/lua/test_effect.fnl
@@ -104,6 +104,39 @@
   (effect.clear-timers)
   (assert (= (effect.pending-timers) 0) "timers cleared"))
 
+;; Regression test for issue #146.
+;;
+;; In production the host calls poll-timers with wall-clock ms
+;; (`time.to_unix_nanoseconds(time.now()) / 1e6`, which is on the order
+;; of 1.78e12). The scheduler must record `:at` on the same scale,
+;; otherwise every timer fires instantly the next frame and any
+;; self-rearming dispatch-later loop hangs the app.
+;;
+;; The scheduler reads wall-clock ms from `_G.redin.now` (the bridge's
+;; cfunc, units of seconds). When `_G.redin` is not present (pure-Lua
+;; tests above), it falls back to `os.clock` so legacy tests keep
+;; working.
+(fn t.test-dispatch-later-uses-wall-clock-when-bridge-present []
+  (setup)
+  (dataflow.init {:counter 0})
+  (dataflow.register-globals)
+  (dataflow.reg-handler :event/tick
+    (fn [db event]
+      (dataflow.update db :counter #(+ $1 1))))
+  ;; Simulate the bridge: redin.now returns wall-clock seconds.
+  (set _G.redin {:now (fn [] 1000000)})
+  (effect.execute {:db nil :dispatch-later {:ms 100 :dispatch [:event/tick]}})
+  ;; The host polls with wall-clock ms. Before the timer's :at, no fire.
+  (effect.poll-timers (+ (* 1000000 1000) 50))
+  (assert (= (rawget (dataflow._get-raw-db) :counter) 0)
+          "timer not fired before scheduled :at")
+  ;; After :at, fires exactly once.
+  (effect.poll-timers (+ (* 1000000 1000) 150))
+  (assert (= (rawget (dataflow._get-raw-db) :counter) 1)
+          "timer fired after scheduled :at")
+  ;; Restore so later tests are not polluted.
+  (set _G.redin nil))
+
 (fn t.test-globals-registered []
   (setup)
   (effect.register-globals)


### PR DESCRIPTION
## Summary

Fixes #146.

`dispatch-later` was scheduling timers with `(os.clock)` (CPU seconds since process start, small numbers) while the host polled them with wall-clock ms (~1.78e12). The mismatch meant every scheduled timer's `:at` was less than the first poll's `now-ms`, so timers fired instantly. Any self-rearming `dispatch-later` loop hung the app at startup.

The scheduler now reads wall-clock ms from the bridge's `redin.now` (multiplied by 1000) to match the host's polling units. When the bridge isn't loaded — the pure-Lua test runner — it falls back to `os.clock` so existing tests keep working without modification.

## Test plan

- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 134 pass (was 133), 0 fail. New `test-dispatch-later-uses-wall-clock-when-bridge-present` stubs `_G.redin = {:now ...}` and verifies the timer fires only after wall-clock has advanced past the scheduled `:at`.
- [x] `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:/tmp/redin-rel` — clean.
- [x] End-to-end: a probe app with `(reg-handler :tick (fn [db e] {:db (...) :dispatch-later {:ms 500 :dispatch [:tick]}}))` plus a bootstrap `(dispatch [:tick])` now ticks steadily (n = 1, 3, 6 at 0.3s, 1.3s, 2.5s). Without this fix, the same app hangs at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)