### PR TITLE
fix(security): pin babashka, parser depth limit, signal cleanup (#136)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,8 +68,23 @@ jobs:
             libgl1-mesa-dev libx11-dev libxrandr-dev libxi-dev \
             libxcursor-dev libxinerama-dev
 
+      # Pinned download + sha256 verification — never pipe `master/install`
+      # into `sudo bash`. See issue #136 (H1). Bump BB_VERSION + BB_SHA256
+      # together; the sha is for the linux-amd64-static tarball published
+      # alongside the release.
       - name: Install Babashka
-        run: curl -sL https://raw.githubusercontent.com/babashka/babashka/master/install | sudo bash
+        env:
+          BB_VERSION: 1.12.218
+          BB_SHA256: 7bd028cc794732ffde3da31ce4379840893c8e54f1046f92a8dfc4f4b3cddaf8
+        run: |
+          set -euo pipefail
+          tmp=$(mktemp -d)
+          curl -fsSL -o "$tmp/bb.tar.gz" \
+            "https://github.com/babashka/babashka/releases/download/v${BB_VERSION}/babashka-${BB_VERSION}-linux-amd64-static.tar.gz"
+          echo "${BB_SHA256}  $tmp/bb.tar.gz" | sha256sum -c -
+          tar -xzf "$tmp/bb.tar.gz" -C "$tmp" bb
+          sudo install -m 0755 "$tmp/bb" /usr/local/bin/bb
+          bb --version
 
       - name: Install Odin
         uses: laytan/setup-odin@8536d8fa450ec6f1bd9ddc84bbaaf16296c0051d  # v2.12.2

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -92,6 +92,16 @@ TOKEN_FILE :: ".redin-token"
 PORT_BASE  :: 8800
 PORT_RANGE :: 100
 
+// Constant-pool cstring copies of the cleanup paths. We can't allocate
+// or build cstrings inside a signal handler (no Odin context, no malloc
+// — only async-signal-safe operations are legal), so the paths live
+// here as compile-time `cstring` constants. Keep them in sync with
+// PORT_FILE / TOKEN_FILE if those ever change.
+@(private = "file")
+SIGNAL_PORT_FILE_C: cstring : ".redin-port"
+@(private = "file")
+SIGNAL_TOKEN_FILE_C: cstring : ".redin-token"
+
 // Number of bytes of entropy for the auth token. 32 bytes (256 bits)
 // hex-encoded yields a 64-char token.
 AUTH_TOKEN_BYTES :: 32
@@ -112,6 +122,59 @@ sync_queue_drain :: proc(sq: ^Sync_Queue, out: ^[dynamic]^Pending_Request) {
 		}
 	}
 	sync.unlock(&sq.mu)
+}
+
+// --- Signal-driven cleanup ---
+//
+// Without this, a SIGSEGV / SIGKILL / Ctrl-C / kill -9 / OOM leaves
+// `.redin-port` and `.redin-token` on disk. The token files are 0600
+// so they don't leak to other users, but a stale bearer token sitting
+// in CWD is still wrong — it can be misread for a live server. Plus
+// the port file misleads any tooling that polls for "is redin up".
+//
+// Strategy: rt_sigaction with SA_RESETHAND. Our handler runs once,
+// the kernel restores the default disposition automatically, and we
+// re-raise via kill(getpid(), sig) so the original handler (core dump
+// for SIGSEGV, default termination for SIGTERM, etc.) still fires.
+// Inside the handler we only call async-signal-safe primitives:
+// linux.unlink, linux.getpid, linux.kill.
+//
+// Issue #136 (M2).
+
+@(private = "file")
+g_signal_cleanup_installed: bool = false
+
+@(private = "file")
+cleanup_on_signal :: proc "c" (sig: linux.Signal) {
+	linux.unlink(SIGNAL_PORT_FILE_C)
+	linux.unlink(SIGNAL_TOKEN_FILE_C)
+	// SA_RESETHAND already restored the default handler. Re-raise so
+	// the kernel runs that default disposition (e.g. core dump for
+	// SIGSEGV) on this same signal.
+	linux.kill(linux.getpid(), sig)
+}
+
+@(private = "file")
+install_signal_cleanup :: proc() {
+	if g_signal_cleanup_installed do return
+	g_signal_cleanup_installed = true
+
+	sa := linux.Sig_Action(rawptr) {
+		handler = cleanup_on_signal,
+		flags   = {.RESETHAND},
+	}
+	signals := []linux.Signal{
+		.SIGINT,
+		.SIGTERM,
+		.SIGQUIT,
+		.SIGHUP,
+		.SIGSEGV,
+		.SIGABRT,
+	}
+	for s in signals {
+		// nil oldact via casting; we don't care about the previous handler.
+		linux.rt_sigaction(s, &sa, (^linux.Sig_Action(rawptr))(nil))
+	}
 }
 
 // --- Init/Destroy ---
@@ -200,6 +263,11 @@ devserver_init :: proc(ds: ^Dev_Server, b: ^Bridge) {
 		net.close(ds.tcp_sock)
 		return
 	}
+
+	// Now that the port + token files exist on disk, register the
+	// async-signal-safe cleanup so they're removed on crash/Ctrl-C —
+	// not just on clean shutdown. See the block comment above.
+	install_signal_cleanup()
 
 	ds.acceptor_thread = thread.create_and_start_with_poly_data(ds, acceptor_thread_proc, context)
 	for i in 0 ..< HANDLER_POOL_SIZE {

--- a/src/redin/parser/view_tree_parser.odin
+++ b/src/redin/parser/view_tree_parser.odin
@@ -73,9 +73,15 @@ _tree_node_destroy_after_flatten :: proc(n: ^_Tree_Node) {
 
 // -- Parser for [:tag {props}? "text"? children...] format --
 
+// Maximum element-nesting depth accepted by the parser. A `.fnl` file
+// nested deeper than this is refused outright (ok=false) rather than
+// allowed to recurse into a stack overflow. Issue #136 (M1).
+MAX_NESTING :: 256
+
 _Parser :: struct {
-	text: string,
-	pos:  int,
+	text:  string,
+	pos:   int,
+	depth: int,
 }
 
 _skip_ws :: proc(p: ^_Parser) {
@@ -248,6 +254,16 @@ _parse_size_f32 :: proc(v: _Prop) -> union {types.SizeValue, f32} {
 }
 
 _parse_element :: proc(p: ^_Parser) -> (_Tree_Node, bool) {
+	if p.depth >= MAX_NESTING {
+		fmt.eprintfln(
+			"view-tree parser: refusing input nested deeper than MAX_NESTING (%d)",
+			MAX_NESTING,
+		)
+		return {}, false
+	}
+	p.depth += 1
+	defer p.depth -= 1
+
 	if _peek(p) != '[' do return {}, false
 	p.pos += 1
 
@@ -266,9 +282,25 @@ _parse_element :: proc(p: ^_Parser) -> (_Tree_Node, bool) {
 	}
 
 	children: [dynamic]_Tree_Node
+	// Bail out of the child loop on parse failure rather than silently
+	// retrying — without this, a depth-limit refusal (MAX_NESTING) on
+	// the next `[` would never consume the character and the parent
+	// would loop forever. Propagate the failure to our caller so the
+	// top-level parse reports ok=false. Issue #136 (M1).
+	child_parse_failed := false
 	for _peek(p) == '[' {
 		child, ok := _parse_element(p)
-		if ok do append(&children, child)
+		if !ok {
+			child_parse_failed = true
+			break
+		}
+		append(&children, child)
+	}
+
+	if child_parse_failed {
+		for &c in children do _tree_node_destroy(&c)
+		delete(children)
+		return {}, false
 	}
 
 	if _peek(p) == ']' do p.pos += 1

--- a/src/redin/parser/view_tree_parser_test.odin
+++ b/src/redin/parser/view_tree_parser_test.odin
@@ -1,5 +1,6 @@
 package parser
 
+import "core:strings"
 import "core:testing"
 import "../types"
 
@@ -198,4 +199,27 @@ test_vector_prop_value :: proc(t: ^testing.T) {
 	prop := _read_prop_value(&p)
 	testing.expect_value(t, prop.kind, _Prop_Kind.Keyword)
 	testing.expect_value(t, prop.str_val, "test/add")
+}
+
+// Regression test for the parser recursion depth limit (issue #136, M1).
+// Before the MAX_NESTING guard, a deeply-nested `[:stack [:stack ...]]`
+// input would either stack-overflow the host process or succeed silently.
+// After the guard, the parser refuses inputs deeper than MAX_NESTING and
+// reports ok=false instead of recursing further.
+@(test)
+test_parse_rejects_excessive_nesting :: proc(t: ^testing.T) {
+	// Build [:stack [:stack ... [:stack]]] nested 1000 deep — well past
+	// any reasonable MAX_NESTING, and below the depth that would blow
+	// the test runner's stack pre-fix.
+	depth :: 1000
+	sb: strings.Builder
+	strings.builder_init(&sb)
+	defer strings.builder_destroy(&sb)
+	for _ in 0 ..< depth do strings.write_string(&sb, "[:stack ")
+	for _ in 0 ..< depth do strings.write_string(&sb, "]")
+
+	p := _Parser{text = strings.to_string(sb), pos = 0}
+	tree, ok := _parse_element(&p)
+	if ok do _tree_node_destroy(&tree)
+	testing.expect(t, !ok, "1000-deep nesting must be rejected by MAX_NESTING guard")
 }


### PR DESCRIPTION
## Summary

Addresses **H1, M1, M2** from #136 — the three cheap wins at the top of the audit's suggested fix order.

### H1 — Pin babashka in CI

`.github/workflows/test.yml:71-89`

Replace `curl … master/install | sudo bash` with a pinned-version download verified against its sha256:

```yaml
env:
  BB_VERSION: 1.12.218
  BB_SHA256:  7bd028cc794732ffde3da31ce4379840893c8e54f1046f92a8dfc4f4b3cddaf8
```

The pipeline can no longer be backdoored by a babashka maintainer-account compromise or a moving HEAD on the install script.

### M1 — Parser depth limit

`src/redin/parser/view_tree_parser.odin`

Add `MAX_NESTING = 256`. Each recursive `_parse_element` call increments a depth counter on the `_Parser`; past the limit the parser refuses the input (ok=false) and prints a single diagnostic to stderr. A second guard breaks the child loop and propagates the failure outward — without it, the unconsumed `[` at the depth-limit boundary would loop the parent forever rather than fall through to the missing-`]` branch.

Regression test (`view_tree_parser_test.odin`): a 1000-deep `[:stack [:stack ...]]` input must report `ok=false` and not stack-overflow.

### M2 — Signal cleanup of `.redin-port` / `.redin-token`

`src/redin/bridge/devserver.odin`

Register `rt_sigaction` handlers for SIGINT/SIGTERM/SIGQUIT/SIGHUP/SIGSEGV/SIGABRT with `SA_RESETHAND`. The handler unlinks both files and re-raises so the default disposition still fires (core dump etc.). Uses async-signal-safe primitives only (`linux.unlink`, `linux.kill`, `linux.getpid`).

The token was already freshly generated per `devserver_init` via `crypto.rand_bytes`, so the audit's "rotate on init" half is already satisfied — this completes the fix by guaranteeing the on-disk artifact disappears on crash, not just on clean shutdown.

SIGKILL remains uncatchable (kernel-level); the audit's other listed scenarios (segfault, Ctrl-C, kill, panic) are all covered.

## Test plan

- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 134 pass.
- [x] `odin test src/redin/parser -define:ODIN_TEST_THREADS=1` — 27 pass (incl. new depth-limit test).
- [x] `odin test src/redin/{profile,markdown,input,bridge}` — 4 + 27 + 25 + 56 all pass.
- [x] `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:/tmp/redin-rel` — clean release build.
- [x] Smoke: launch `./build/redin /tmp/probe.fnl`, send `SIGINT` → `.redin-port` + `.redin-token` removed. Repeat with `SIGTERM` → same.

## Out of scope

Audit findings **H2** (http SSRF default-open), **H3** (shell env inheritance), **M3** (screenshot scope), **M4** (worker pool slowloris), **M5** (padding clamps), **M6** (theme u8 wrap), **L1–L4** are not in this PR — happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
