### PR TITLE
fix(security): deny-by-default for http + shell, "*" to opt-out (#136)

### DIFF
--- a/docs/reference/effects.md
+++ b/docs/reference/effects.md
@@ -104,7 +104,7 @@ Make an async HTTP request. The response is routed back as an event.
 | `"http header contains invalid character"` | A header key or value contained `\r`, `\n`, or `\x00`. |
 | `"http timeout exceeded"` | Wall-clock timeout (per-call `:timeout`, default 30000 ms) elapsed. |
 | `"too many concurrent http requests (cap 64)"` | Submitted while 64 in-flight requests were already running. |
-| `"host <name> not in http whitelist"` | Whitelist is set (`bridge.set_http_whitelist`) and the URL host is not on it. See [native bridge](native-bridge.md). |
+| `"host <name> not in http whitelist"` | Whitelist denies this host. Deny-by-default since #136 H2 — set `bridge.set_http_whitelist([]string{"*"})` to allow any host. See [native bridge](native-bridge.md). |
 
 **Success handler** receives `[event-name response]`:
 
@@ -161,7 +161,7 @@ Spawn a child process. The result is routed back as an event.
 | `"shell timeout exceeded N ms"` | Wall-clock timeout (per-call `:timeout`, default 30000 ms) elapsed; child killed. |
 | `"shell output exceeded N MiB cap"` | Combined stdout + stderr exceeded the cap (per-call `:max-output`, default 16 MiB); child killed. |
 
-The shell-env allowlist (`bridge.set_shell_env_allowlist`, see [native bridge](native-bridge.md)) is applied at spawn time and does not produce a runtime failure — children just see a stripped environment when it is set.
+The shell-env allowlist (`bridge.set_shell_env_allowlist`, see [native bridge](native-bridge.md)) is applied at spawn time and does not produce a runtime failure. **Deny-by-default since #136 H3:** with no allowlist set the child gets an empty environment. Pass `[]string{"*"}` for full parent-env passthrough, or list specific KEYs (`{"PATH", "HOME", ...}`). Tools that resolve their executable via `$PATH` will fail with "command not found" unless you list `"PATH"` or pass absolute paths in `:cmd`.
 
 ---
 

--- a/docs/reference/native-bridge.md
+++ b/docs/reference/native-bridge.md
@@ -111,33 +111,57 @@ ok, err := bridge.dispatch_tos(L, "combat/push")
 
 ## Effect policy setters
 
-These setters install host-side policy for the built-in `redin.http` and `redin.shell` host functions. Both are global, take a slice of strings (cloned internally), and accept `nil` to clear back to the permissive default. Call before or after `redin.run`; changes apply to subsequent requests.
+These setters install host-side policy for the built-in `redin.http` and `redin.shell` host functions. Both are global, take a slice of strings (cloned internally), and accept `nil` to reset to the deny-by-default state. Call before or after `redin.run`; changes apply to subsequent requests.
 
-**Open-default warning.** When the setter has not been called, the first invocation of the corresponding host function prints a one-shot `[redin] WARNING:` block to stderr explaining that the surface is unrestricted and pointing at the setter. Logged once per process. This is an intentional nudge — call the setter explicitly to acknowledge the open default and silence the warning.
+**Deny-by-default (#136 H2, H3).** When the setter has not been called (or has been called with `nil` or an empty slice), the corresponding surface is closed:
+
+- `redin.http` → every outbound host is rejected with `host <name> not in http whitelist`.
+- `redin.shell` → spawned children get an empty environment.
+
+To re-enable the historical open-by-default behaviour, pass the wildcard sentinel `"*"`:
+
+```odin
+bridge.set_http_whitelist([]string{"*"})         // accept any host
+bridge.set_shell_env_allowlist([]string{"*"})    // full parent-env passthrough
+```
+
+`"*"` works with the rest of the list (e.g. `[]string{"*", "extra"}`), though there's no reason to mix it with real entries — the wildcard always matches first.
 
 ### `bridge.set_http_whitelist(allow: []string)`
 
-When set, `redin.http` accepts only URLs whose host matches an entry. Entries are either hostname literals (case-insensitive — e.g. `"api.example.com"`) or CIDR blocks (IPv4 or IPv6 — e.g. `"127.0.0.0/8"`, `"::1/128"`). CIDR entries are matched only against IP-literal hosts, not DNS names. `nil` (the default) accepts any host.
+Configures which hosts `redin.http` will dial. Entries are either hostname literals (case-insensitive — e.g. `"api.example.com"`) or CIDR blocks (IPv4 or IPv6 — e.g. `"127.0.0.0/8"`, `"::1/128"`). CIDR entries are matched only against IP-literal hosts, not DNS names. The sentinel entry `"*"` matches any host.
 
 Hostname comparison is ASCII-byte case-insensitive. IDN hostnames must be passed in their punycode (`xn--...`) form — `münchen.example` is not equivalent to `xn--mnchen-3ya.example`, and the URL parser punycodes the request host before matching.
 
 Rejection failure (delivered to the `:http` effect's `on-error`): `{status: 0, error: "host <name> not in http whitelist"}`.
 
 ```odin
+// Restrict to specific hosts:
 bridge.set_http_whitelist([]string{"api.example.com", "127.0.0.0/8"})
+
+// Open it up entirely (pre-#136 default):
+bridge.set_http_whitelist([]string{"*"})
+
 redin.run(cfg)
 ```
 
 ### `bridge.set_shell_env_allowlist(allow: []string)`
 
-When set, child processes spawned by `redin.shell` see only env vars whose keys match a list entry. Comparison is exact (case-sensitive on POSIX). `nil` (the default) is full passthrough — children inherit the parent process environment.
+Configures which environment variables `redin.shell` passes to spawned children. Entries are env-var KEY names; comparison is exact (case-sensitive on POSIX). The sentinel entry `"*"` requests full passthrough.
 
-The setter does not produce a runtime failure path. It only changes the env that reaches `execve(2)`.
+The setter does not produce a runtime failure path — it only changes the env that reaches `execve(2)`.
 
 ```odin
+// Specific keys:
 bridge.set_shell_env_allowlist([]string{"PATH", "HOME", "GITHUB_TOKEN"})
+
+// Full passthrough (pre-#136 default):
+bridge.set_shell_env_allowlist([]string{"*"})
+
 redin.run(cfg)
 ```
+
+Tools that resolve their command via `$PATH` (e.g. `bb`, `git`, `gh`) will fail with "command not found" when the allowlist is empty and the child has no `PATH`. Either pass absolute paths in `cmd`, or list `"PATH"` (and whatever else the command needs).
 
 ## Calling conventions and context
 

--- a/src/redin/bridge/api.odin
+++ b/src/redin/bridge/api.odin
@@ -460,36 +460,25 @@ set_http_whitelist :: proc(allow: []string) {
 	g_http_whitelist = cloned
 }
 
-// #129 H1: warn loudly once per process the first time redin.http is invoked
-// with no whitelist set. Fail-open is intentional (keeps the framework usable
-// as a scripting toolkit), but combined with the dev server's /events pivot
-// this grants any holder of .redin-token outbound HTTP. The warning surfaces
-// the choice so app authors can opt in to restriction.
-@(private) g_http_open_warned: bool
-
-@(private)
-http_warn_open_once :: proc() {
-	sync.lock(&g_http_whitelist_mutex)
-	defer sync.unlock(&g_http_whitelist_mutex)
-	if g_http_whitelist != nil do return
-	if g_http_open_warned do return
-	g_http_open_warned = true
-	fmt.eprintln("[redin] WARNING: redin.http called with no host whitelist (#129 H1).")
-	fmt.eprintln("[redin]   Outbound HTTP is unrestricted. Call bridge.set_http_whitelist([...])")
-	fmt.eprintln("[redin]   from app.odin to restrict. Logged once per process.")
-}
-
 // http_whitelist_check returns ("", true) if allowed, ("<rejected host>", false)
 // otherwise. host must already be the URL host (no port, no scheme).
+//
+// Defaults (#136 H2): an unset or empty whitelist denies every outbound
+// host. To re-enable the historical open-by-default behaviour, call
+// `bridge.set_http_whitelist([]string{"*"})` from app.odin — the `"*"`
+// entry is a sentinel wildcard that matches any host.
 @(private)
 http_whitelist_check :: proc(host: string) -> (rejected: string, ok: bool) {
 	sync.lock(&g_http_whitelist_mutex)
 	defer sync.unlock(&g_http_whitelist_mutex)
 
-	if g_http_whitelist == nil do return "", true
+	if len(g_http_whitelist) == 0 do return host, false
 
 	host_lower := strings.to_lower(host, context.temp_allocator)
 	for entry in g_http_whitelist {
+		// Sentinel wildcard — matches any host. Explicit opt-out of
+		// the deny-by-default policy.
+		if entry == "*" do return "", true
 		// CIDR entry?
 		if strings.contains(entry, "/") {
 			if cidr_match(host, entry) do return "", true
@@ -599,37 +588,50 @@ set_shell_env_allowlist :: proc(allow: []string) {
 	g_shell_env_allowlist = cloned
 }
 
-// #129 H1: warn loudly once per process the first time redin.shell is invoked
-// with no env allowlist set. Combined with the unrestricted argv surface and
-// the dev server's /events pivot, this is local code execution for any
-// holder of .redin-token.
-@(private) g_shell_open_warned: bool
-
-@(private)
-shell_warn_open_once :: proc() {
-	sync.lock(&g_shell_env_allowlist_mutex)
-	defer sync.unlock(&g_shell_env_allowlist_mutex)
-	if g_shell_env_allowlist != nil do return
-	if g_shell_open_warned do return
-	g_shell_open_warned = true
-	fmt.eprintln("[redin] WARNING: redin.shell called with no env allowlist (#129 H1).")
-	fmt.eprintln("[redin]   Child inherits the full parent env; argv is unrestricted by design.")
-	fmt.eprintln("[redin]   Call bridge.set_shell_env_allowlist([...]) from app.odin to restrict.")
-	fmt.eprintln("[redin]   Logged once per process.")
+// Shell_Env_Disposition tells the caller what to put in Process_Desc.env.
+// Returned by shell_env_filtered.
+Shell_Env_Disposition :: enum {
+	// Pass Process_Desc.env = nil — child inherits the full parent env.
+	// Only reached when the allowlist contains the sentinel "*" entry.
+	Inherit,
+	// Pass Process_Desc.env = <non-nil zero-length slice> — child gets
+	// an empty environment. Reached when the allowlist is nil or empty
+	// (the deny-by-default case from #136 H3).
+	Empty,
+	// Pass Process_Desc.env = filtered (returned slice). Child sees only
+	// the env vars whose KEYs match an allowlist entry.
+	Filtered,
 }
 
-// shell_env_filtered returns the filtered env, or nil if the allowlist is
-// unset (caller should leave Process_Desc.env = nil for full passthrough).
-// Returned slice is owned by the caller (free each entry + the slice
-// itself, both with the same allocator that the heap_allocator yields).
+// shell_env_filtered returns:
+//   - Inherit, nil          → caller sets env = nil (full passthrough)
+//   - Empty, nil            → caller substitutes a non-nil zero-length
+//                              slice (e.g. a stack-backed slice) so
+//                              Process_Desc.env != nil and the child
+//                              gets an empty environment
+//   - Filtered, owned-slice → caller assigns env directly. The slice's
+//                              entries + the slice itself are owned by
+//                              the caller and must be freed with the
+//                              heap allocator after process_start.
+//
+// Defaults (#136 H3): an unset or empty allowlist gives the child an
+// empty environment. To re-enable the historical full-passthrough
+// behaviour, call `bridge.set_shell_env_allowlist([]string{"*"})` from
+// app.odin — the `"*"` entry is a sentinel wildcard.
 @(private)
-shell_env_filtered :: proc() -> []string {
+shell_env_filtered :: proc() -> (env: []string, disposition: Shell_Env_Disposition) {
 	sync.lock(&g_shell_env_allowlist_mutex)
 	defer sync.unlock(&g_shell_env_allowlist_mutex)
 
-	if g_shell_env_allowlist == nil do return nil
-
 	heap := runtime.heap_allocator()
+
+	// Sentinel wildcard — explicit opt-out of the deny-by-default policy.
+	for entry in g_shell_env_allowlist {
+		if entry == "*" do return nil, .Inherit
+	}
+
+	// Unset or empty allowlist → empty env.
+	if len(g_shell_env_allowlist) == 0 do return nil, .Empty
 
 	// os.environ allocates a fresh []string + cloned KEY=VALUE entries
 	// using the supplied allocator. Free the unused entries below.
@@ -638,7 +640,7 @@ shell_env_filtered :: proc() -> []string {
 		// Fall back to an explicit "no env" rather than passthrough; if the
 		// caller set an allowlist they explicitly opted into restriction,
 		// so a fetch failure must not silently widen the surface.
-		return make([]string, 0, heap)
+		return nil, .Empty
 	}
 	defer delete(all_env, heap)
 
@@ -664,5 +666,5 @@ shell_env_filtered :: proc() -> []string {
 			delete(entry, heap)
 		}
 	}
-	return out[:]
+	return out[:], .Filtered
 }

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -483,8 +483,6 @@ redin_http :: proc "c" (L: ^Lua_State) -> i32 {
 	context = g_context
 	if g_bridge == nil do return 0
 
-	http_warn_open_once()
-
 	req: Http_Request
 	req.headers = make(map[string]string)
 
@@ -980,8 +978,6 @@ deliver_http_response :: proc(b: ^Bridge, resp: ^Http_Response) {
 redin_shell :: proc "c" (L: ^Lua_State) -> i32 {
 	context = g_context
 	if g_bridge == nil do return 0
-
-	shell_warn_open_once()
 
 	req: Shell_Request
 

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -28,6 +28,14 @@ import "core:time"
 @(private = "file")
 g_test_http_state_mutex: sync.Mutex
 
+// Deny-by-default whitelist (#136 H2) means tests that issue real HTTP
+// requests without specifically testing the whitelist must opt in to
+// passthrough. The sentinel "*" entry matches any host.
+@(private = "file")
+allow_open_http :: proc() {
+	set_http_whitelist([]string{"*"})
+}
+
 @(private = "file")
 Mock_Server :: struct {
 	sock:     net.TCP_Socket,
@@ -114,6 +122,8 @@ mock_stop :: proc(m: ^Mock_Server) {
 test_http_response_cap_rejects_oversized_content_length :: proc(t: ^testing.T) {
 	sync.lock(&g_test_http_state_mutex)
 	defer sync.unlock(&g_test_http_state_mutex)
+	allow_open_http()
+	defer set_http_whitelist(nil)
 
 	// Announce 32 MiB. With a HTTP_MAX_BODY cap of 16 MiB the underlying
 	// scanner returns Too_Long without reading the body.
@@ -164,6 +174,8 @@ test_http_response_cap_rejects_oversized_content_length :: proc(t: ^testing.T) {
 test_http_header_value_rejects_crlf :: proc(t: ^testing.T) {
 	sync.lock(&g_test_http_state_mutex)
 	defer sync.unlock(&g_test_http_state_mutex)
+	allow_open_http()
+	defer set_http_whitelist(nil)
 
 	headers := make(map[string]string)
 	headers[strings.clone("X-Smuggle")] = strings.clone("evil\r\nHost: attacker")
@@ -198,6 +210,8 @@ test_http_header_value_rejects_crlf :: proc(t: ^testing.T) {
 test_http_header_key_rejects_nul :: proc(t: ^testing.T) {
 	sync.lock(&g_test_http_state_mutex)
 	defer sync.unlock(&g_test_http_state_mutex)
+	allow_open_http()
+	defer set_http_whitelist(nil)
 
 	headers := make(map[string]string)
 	headers[strings.clone("X-Bad\x00key")] = strings.clone("ok")
@@ -232,6 +246,8 @@ test_http_header_key_rejects_nul :: proc(t: ^testing.T) {
 test_http_redirect_not_followed :: proc(t: ^testing.T) {
 	sync.lock(&g_test_http_state_mutex)
 	defer sync.unlock(&g_test_http_state_mutex)
+	allow_open_http()
+	defer set_http_whitelist(nil)
 
 	resp := "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:1/elsewhere\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
 	m := mock_start(resp)
@@ -306,6 +322,8 @@ test_http_rejects_file_scheme :: proc(t: ^testing.T) {
 test_http_accepts_uppercase_https :: proc(t: ^testing.T) {
 	sync.lock(&g_test_http_state_mutex)
 	defer sync.unlock(&g_test_http_state_mutex)
+	allow_open_http()
+	defer set_http_whitelist(nil)
 
 	// Just confirms scheme matching is case-insensitive — no real connect.
 	// We expect a connect error (status 0, error_msg contains "Request failed"
@@ -466,6 +484,8 @@ slow_mock_serve :: proc(m: ^Mock_Server) {
 test_http_timeout_fires :: proc(t: ^testing.T) {
 	sync.lock(&g_test_http_state_mutex)
 	defer sync.unlock(&g_test_http_state_mutex)
+	allow_open_http()
+	defer set_http_whitelist(nil)
 
 	m := mock_start_slow()
 	if m == nil { testing.fail_now(t, "could not bind a loopback mock server") }
@@ -512,6 +532,8 @@ test_http_timeout_fires :: proc(t: ^testing.T) {
 test_http_inflight_cap_rejects :: proc(t: ^testing.T) {
 	sync.lock(&g_test_http_state_mutex)
 	defer sync.unlock(&g_test_http_state_mutex)
+	allow_open_http()
+	defer set_http_whitelist(nil)
 
 	hc: Http_Client
 	http_client_init(&hc)
@@ -563,6 +585,8 @@ test_http_inflight_cap_rejects :: proc(t: ^testing.T) {
 test_http_destroy_drains_or_times_out :: proc(t: ^testing.T) {
 	sync.lock(&g_test_http_state_mutex)
 	defer sync.unlock(&g_test_http_state_mutex)
+	allow_open_http()
+	defer set_http_whitelist(nil)
 
 	hc := new(Http_Client)
 	http_client_init(hc)

--- a/src/redin/bridge/shell.odin
+++ b/src/redin/bridge/shell.odin
@@ -154,20 +154,35 @@ execute_shell :: proc(req: Shell_Request) -> Shell_Response {
 		stdin_w = w
 	}
 
-	// Apply the env allowlist (issue #99 M3). When the allowlist is unset,
-	// shell_env_filtered returns nil — and Process_Desc.env = nil is the
-	// documented "inherit current process' environment" sentinel (see
-	// core/os/process.odin's Process_Desc docstring), preserving the
-	// historical full-passthrough behaviour.
-	//
-	// When set, shell_env_filtered allocates each entry + the slice via
-	// runtime.heap_allocator(); we free both after process_start, since
-	// process_start (Linux execve) copies the env into the child image.
-	filtered_env := shell_env_filtered()
-	defer if filtered_env != nil {
+	// Apply the env allowlist (#136 H3). Deny-by-default:
+	//   - Allowlist unset/empty → child gets an empty env. We pass a
+	//     non-nil zero-length slice (backed by `empty_env_backing` on
+	//     the stack) because Process_Desc treats env == nil as "inherit
+	//     parent" (core/os/process.odin); a freshly-make()d empty slice
+	//     is data-nil and compares equal to nil, so it wouldn't work.
+	//   - Allowlist contains "*" → full passthrough via env = nil.
+	//   - Otherwise → filtered slice from shell_env_filtered.
+	// When the disposition is Filtered, shell_env_filtered allocates
+	// each entry + the slice via runtime.heap_allocator(); we free both
+	// after process_start (Linux execve copies env into the child image).
+	filtered_env, env_disposition := shell_env_filtered()
+	defer if env_disposition == .Filtered && filtered_env != nil {
 		heap := runtime.heap_allocator()
 		for s in filtered_env do delete(s, heap)
 		delete(filtered_env, heap)
+	}
+
+	empty_env_backing: [1]string
+	child_env: []string
+	switch env_disposition {
+	case .Inherit:
+		child_env = nil
+	case .Empty:
+		// Non-nil zero-length slice; data points at `empty_env_backing`
+		// so the slice doesn't compare equal to nil.
+		child_env = empty_env_backing[:0]
+	case .Filtered:
+		child_env = filtered_env
 	}
 
 	// Start process
@@ -176,7 +191,7 @@ execute_shell :: proc(req: Shell_Request) -> Shell_Response {
 		stdout  = stdout_w,
 		stderr  = stderr_w,
 		stdin   = stdin_r,
-		env     = filtered_env, // nil = inherit parent env (default)
+		env     = child_env,
 	}
 
 	process, start_err := os.process_start(desc)

--- a/src/redin/bridge/shell_test.odin
+++ b/src/redin/bridge/shell_test.odin
@@ -1,13 +1,13 @@
 package bridge
 
-// Regression tests for issue #99 M3: opt-in shell env allowlist.
+// Regression tests for the shell env allowlist.
 //
 // When set_shell_env_allowlist is set to a non-nil slice, child processes
 // spawned by execute_shell see only the env vars whose KEYs match an
 // entry in the allowlist (exact match, case-sensitive). When unset
-// (default, nil), children inherit the full parent env — preserving
-// the historical behaviour for apps that shell out to credential-aware
-// tools like `gh`, `aws`, or `git`.
+// (default, nil) the child gets an empty environment — secure-by-default
+// per #136 H3. The sentinel "*" entry restores full parent-env passthrough
+// (the pre-#136 default) for apps that explicitly opt in.
 
 import "core:fmt"
 import "core:strings"
@@ -19,9 +19,17 @@ import "core:testing"
 // default, so a test that sets the allowlist can race against another
 // test that calls execute_shell and depends on the allowlist being unset.
 // Acquire this mutex in any test that either calls set_shell_env_allowlist
-// or relies on the default-passthrough behaviour.
+// or relies on the default-empty-env behaviour.
 @(private = "file")
 g_test_shell_state_mutex: sync.Mutex
+
+// Deny-by-default env (#136 H3) means tests that spawn children needing
+// $PATH to find their cmd (yes, sleep, etc.) must opt in to passthrough.
+// The sentinel "*" entry restores full parent-env inheritance.
+@(private = "file")
+allow_open_shell_env :: proc() {
+	set_shell_env_allowlist([]string{"*"})
+}
 
 @(test)
 test_shell_env_allowlist_filters :: proc(t: ^testing.T) {
@@ -56,17 +64,48 @@ test_shell_env_allowlist_filters :: proc(t: ^testing.T) {
 }
 
 @(test)
-test_shell_env_allowlist_unset_full_passthrough :: proc(t: ^testing.T) {
+test_shell_env_allowlist_unset_is_empty :: proc(t: ^testing.T) {
 	sync.lock(&g_test_shell_state_mutex)
 	defer sync.unlock(&g_test_shell_state_mutex)
 
+	// Default (nil allowlist) must mean empty env after #136 H3.
 	set_shell_env_allowlist(nil)
 
 	cmd := make([]string, 1)
 	cmd[0] = strings.clone("/usr/bin/env")
 	defer { for s in cmd do delete(s); delete(cmd) }
 	req := Shell_Request{
-		id    = strings.clone("env-2"),
+		id    = strings.clone("env-empty"),
+		cmd   = cmd,
+		stdin = strings.clone(""),
+	}
+	defer { delete(req.id); delete(req.stdin) }
+
+	got := execute_shell(req)
+	defer {
+		delete(got.id); delete(got.stdout); delete(got.stderr); delete(got.error_msg)
+	}
+	// /usr/bin/env should print nothing — no PATH, no HOME, no anything.
+	testing.expect(t, !strings.contains(got.stdout, "PATH="),
+		fmt.tprintf("expected empty env (deny-by-default), got %q", got.stdout))
+	testing.expect(t, !strings.contains(got.stdout, "HOME="),
+		fmt.tprintf("expected empty env (deny-by-default), got %q", got.stdout))
+}
+
+@(test)
+test_shell_env_allowlist_wildcard_is_full_passthrough :: proc(t: ^testing.T) {
+	sync.lock(&g_test_shell_state_mutex)
+	defer sync.unlock(&g_test_shell_state_mutex)
+
+	// The sentinel "*" entry is the explicit opt-out of deny-by-default.
+	set_shell_env_allowlist([]string{"*"})
+	defer set_shell_env_allowlist(nil)
+
+	cmd := make([]string, 1)
+	cmd[0] = strings.clone("/usr/bin/env")
+	defer { for s in cmd do delete(s); delete(cmd) }
+	req := Shell_Request{
+		id    = strings.clone("env-star"),
 		cmd   = cmd,
 		stdin = strings.clone(""),
 	}
@@ -78,13 +117,15 @@ test_shell_env_allowlist_unset_full_passthrough :: proc(t: ^testing.T) {
 	}
 	// PATH is reliably present in the test runner's env.
 	testing.expect(t, strings.contains(got.stdout, "PATH="),
-		"expected PATH= in default-passthrough env output")
+		"expected PATH= in wildcard-passthrough env output")
 }
 
 @(test)
 test_shell_output_cap_kills_child :: proc(t: ^testing.T) {
 	sync.lock(&g_test_shell_state_mutex)
 	defer sync.unlock(&g_test_shell_state_mutex)
+	allow_open_shell_env()
+	defer set_shell_env_allowlist(nil)
 
 	// `yes` runs forever; with a 1 MiB cap it should be killed quickly.
 	cmd := make([]string, 1)
@@ -115,6 +156,8 @@ test_shell_output_cap_kills_child :: proc(t: ^testing.T) {
 test_shell_timeout_kills_child :: proc(t: ^testing.T) {
 	sync.lock(&g_test_shell_state_mutex)
 	defer sync.unlock(&g_test_shell_state_mutex)
+	allow_open_shell_env()
+	defer set_shell_env_allowlist(nil)
 
 	// `sleep 60` should be killed by a 200 ms timeout.
 	cmd := make([]string, 2)


### PR DESCRIPTION
## Summary

Addresses **H2** and **H3** from #136. Flips both effect-policy setters from open-by-default to **deny-by-default**, with a `"*"` sentinel entry that explicitly restores the old passthrough behaviour.

### H2 — `redin.http` host whitelist

`src/redin/bridge/api.odin` (`http_whitelist_check`)

| Allowlist | Old behaviour | New behaviour |
|---|---|---|
| `nil` (default) | accept any host | **reject every host** |
| `[]` (empty) | reject every host | reject every host |
| `["api.example.com"]` | only that host | only that host |
| `["*"]` | not recognised | **accept any host** |

Rejection delivered to `:http` `on-error` as `{:status 0 :error "host <name> not in http whitelist"}`, same shape as before.

### H3 — `redin.shell` env allowlist

`src/redin/bridge/api.odin` (`shell_env_filtered`) + `src/redin/bridge/shell.odin`

| Allowlist | Old behaviour | New behaviour |
|---|---|---|
| `nil` (default) | full parent-env passthrough | **child gets empty env** |
| `[]` (empty) | parent-env passthrough | empty env |
| `["PATH", "HOME"]` | filtered subset | filtered subset |
| `["*"]` | matches KEY literally "*" | **full passthrough** |

`shell_env_filtered` now returns `(env, disposition: Shell_Env_Disposition)`. The caller in `shell.odin` interprets the disposition (`Inherit` / `Empty` / `Filtered`) and constructs `Process_Desc.env` accordingly. Odin's slice nil-check treats `make([]string, 0)` as equal to nil (`raw_data() == nil`), so the Empty case substitutes a stack-backed `[0:0]` slice that's distinct from a true nil.

### Documentation

- **`docs/reference/native-bridge.md`** — rewrote the "Effect policy setters" section. Deny-by-default is now front-and-center, `"*"` is the documented escape hatch, and there's a callout about the "command not found" gotcha when shelling out via `$PATH` lookup with no `PATH` in the child env.
- **`docs/reference/effects.md`** — updated the HTTP error table and the shell allowlist paragraph to match.

### Test changes

- New `test_shell_env_allowlist_unset_is_empty` confirms the deny default by spawning `/usr/bin/env` with nil allowlist and asserting the child sees no `PATH=`/`HOME=`.
- New `test_shell_env_allowlist_wildcard_is_full_passthrough` confirms `["*"]` restores inheritance.
- 8 HTTP tests and 2 shell tests that issue real requests / spawn `$PATH`-resolved commands now opt in via `allow_open_http()` / `allow_open_shell_env()` helpers — they don't care about the policy, only about the request/child working.

Bridge suite: **57 tests pass** (was 56 — net +1 new shell test). Other suites: 134 Fennel, 27 parser, 27 markdown, 25 input, 4 profile — all green.

## Test plan

- [x] `odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit` — 57/57 pass.
- [x] `odin test src/redin/{parser,markdown,profile,input}` (+ flags) — all pass.
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 134/134 pass.
- [x] `odin build src/cmd/redin …` — clean.
- [x] Manual: `bridge.set_http_whitelist([]string{"*"})` re-enables outbound HTTP; `bridge.set_shell_env_allowlist([]string{"*"})` re-enables full parent-env passthrough.

## Remaining audit items

Not in this PR (happy to follow up): M3 (screenshot scope), M4 (worker pool slowloris), M5 (padding clamps), M6 (theme u8 wrap), L1–L4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
