### PR TITLE
fix(security): clamp padding+theme, widen path length, pin submodule (#136)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "lib/odin-http"]
 	path = lib/odin-http
 	url = https://github.com/laytan/odin-http.git
+	branch = main

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -1229,7 +1229,7 @@ flatten_subtree :: proc(b: ^Bridge, tree: markdown.LoweredTree, parent_flat_idx:
 		append(&b.node_animations, nil)
 		path_copy := make([]u8, len(cur^))
 		copy(path_copy, cur^[:])
-		append(&b.paths, types.Path{value = path_copy, length = u8(len(path_copy))})
+		append(&b.paths, types.Path{value = path_copy, length = u16(len(path_copy))})
 		// Reserve slots — Pass 2 fills parent_indices and children_list.
 		append(&b.parent_indices, 0)
 		append(&b.children_list, types.Children{})
@@ -1320,7 +1320,7 @@ lua_flatten_node :: proc(L: ^Lua_State, index: i32, cur: ^[dynamic]u8, b: ^Bridg
 	my_idx := len(b.nodes)
 	p := make([]u8, len(cur))
 	copy(p, cur[:])
-	append(&b.paths, types.Path{value = p, length = u8(len(p))})
+	append(&b.paths, types.Path{value = p, length = u16(len(p))})
 	append(&b.parent_indices, parent_idx)
 	append(&b.children_list, types.Children{})
 

--- a/src/redin/parser/theme_parser.odin
+++ b/src/redin/parser/theme_parser.odin
@@ -75,9 +75,9 @@ _parse_theme_props :: proc(p: ^_Parser) -> types.Theme {
 			case "border":
 				t.border = _parse_rgb(p)
 			case "border-width":
-				t.border_width = u8(_read_number(p))
+				t.border_width = _to_u8(_read_number(p))
 			case "radius":
-				t.radius = u8(_read_number(p))
+				t.radius = _to_u8(_read_number(p))
 			case "font-size":
 				t.font_size = f16(_read_number(p))
 			case "font":
@@ -94,7 +94,7 @@ _parse_theme_props :: proc(p: ^_Parser) -> types.Theme {
 					if w == "bold" do t.weight = 1
 					else if w == "italic" do t.weight = 2
 				} else if c2 >= '0' && c2 <= '9' {
-					t.weight = u8(_read_number(p))
+					t.weight = _to_u8(_read_number(p))
 				}
 			case "opacity":
 				t.opacity = _read_number(p)
@@ -119,16 +119,29 @@ _parse_theme_props :: proc(p: ^_Parser) -> types.Theme {
 	return t
 }
 
+// _to_u8 clamps a parsed f32 to [0,255] before truncating to u8.
+// Without this, negative or out-of-range numbers wrap mod 256:
+// `:border-width -1` would silently become 255, `:radius 256.5`
+// would become 0. Combined with the negative-rect path that #136
+// M5 also closed, theme inputs from `PUT /aspects` could drive the
+// renderer into weird states. #136 M6.
+@(private = "file")
+_to_u8 :: proc(n: f32) -> u8 {
+	if n <= 0 do return 0
+	if n >= 255 do return 255
+	return u8(n)
+}
+
 _parse_rgb :: proc(p: ^_Parser) -> [3]u8 {
 	_skip_ws(p)
 	if p.pos < len(p.text) && p.text[p.pos] == '[' {
 		p.pos += 1
 		_skip_ws(p)
-		r := u8(_read_number(p))
+		r := _to_u8(_read_number(p))
 		_skip_ws(p)
-		g := u8(_read_number(p))
+		g := _to_u8(_read_number(p))
 		_skip_ws(p)
-		b := u8(_read_number(p))
+		b := _to_u8(_read_number(p))
 		_skip_ws(p)
 		if p.pos < len(p.text) && p.text[p.pos] == ']' do p.pos += 1
 		return {r, g, b}
@@ -141,13 +154,13 @@ _parse_rgba :: proc(p: ^_Parser) -> [4]u8 {
 	if p.pos < len(p.text) && p.text[p.pos] == '[' {
 		p.pos += 1
 		_skip_ws(p)
-		r := u8(_read_number(p))
+		r := _to_u8(_read_number(p))
 		_skip_ws(p)
-		g := u8(_read_number(p))
+		g := _to_u8(_read_number(p))
 		_skip_ws(p)
-		b := u8(_read_number(p))
+		b := _to_u8(_read_number(p))
 		_skip_ws(p)
-		a := u8(_read_number(p))
+		a := _to_u8(_read_number(p))
 		_skip_ws(p)
 		if p.pos < len(p.text) && p.text[p.pos] == ']' do p.pos += 1
 		return {r, g, b, a}
@@ -160,13 +173,13 @@ _parse_padding :: proc(p: ^_Parser) -> [4]u8 {
 	if p.pos < len(p.text) && p.text[p.pos] == '[' {
 		p.pos += 1
 		_skip_ws(p)
-		top := u8(_read_number(p))
+		top := _to_u8(_read_number(p))
 		_skip_ws(p)
-		right := u8(_read_number(p))
+		right := _to_u8(_read_number(p))
 		_skip_ws(p)
-		bottom := u8(_read_number(p))
+		bottom := _to_u8(_read_number(p))
 		_skip_ws(p)
-		left := u8(_read_number(p))
+		left := _to_u8(_read_number(p))
 		_skip_ws(p)
 		if p.pos < len(p.text) && p.text[p.pos] == ']' do p.pos += 1
 		return {top, right, bottom, left}

--- a/src/redin/parser/theme_parser_test.odin
+++ b/src/redin/parser/theme_parser_test.odin
@@ -135,6 +135,29 @@ test_parse_theme_selection :: proc(t: ^testing.T) {
 	testing.expect_value(t, body.selection, [4]u8{255, 220, 0, 120})
 }
 
+// Regression test for issue #136 M6: the theme parser used to truncate
+// f32 values straight to u8, which wrapped on out-of-range numbers
+// (`:border-width -1` → 255, `:radius 256` → 0). Clamping to [0,255]
+// stops a malicious or sloppy `PUT /aspects` body from driving the
+// renderer into states where the wrapped value diverges from what the
+// app wrote.
+@(test)
+test_parse_theme_clamps_u8_fields :: proc(t: ^testing.T) {
+	input := `{:a {:bg [-5 300 128] :padding [-1 256 0 1024] :radius 999 :border-width -2 :weight 5}}`
+	theme, ok := _parse_theme_string(input)
+	defer {
+		for k in theme do delete(k)
+		delete(theme)
+	}
+	testing.expect(t, ok, "parse should succeed")
+	a := theme["a"]
+	testing.expect_value(t, a.bg, [3]u8{0, 255, 128})
+	testing.expect_value(t, a.padding, [4]u8{0, 255, 0, 255})
+	testing.expect_value(t, a.radius, u8(255))
+	testing.expect_value(t, a.border_width, u8(0))
+	testing.expect_value(t, a.weight, u8(5))
+}
+
 @(test)
 test_parse_theme_text_align :: proc(t: ^testing.T) {
 	input := `{:a {:text-align :top}

--- a/src/redin/parser/view_tree_parser.odin
+++ b/src/redin/parser/view_tree_parser.odin
@@ -458,7 +458,7 @@ _flatten :: proc(
 
 	p := make([]u8, len(cur))
 	copy(p, cur[:])
-	append(paths, types.Path{value = p, length = u8(len(p))})
+	append(paths, types.Path{value = p, length = u16(len(p))})
 	append(nodes, n.data)
 	append(parent_indices, parent_idx)
 	append(children_list, types.Children{}) // placeholder

--- a/src/redin/render.odin
+++ b/src/redin/render.odin
@@ -233,11 +233,15 @@ layout_node :: proc(
 		if len(n.aspect) > 0 {
 			if t, ok := theme[n.aspect]; ok {
 				if t.padding != {} {
+					// Clamp width/height to 0 — a theme with padding
+					// wider than its host would otherwise produce a
+					// negative rect that Raylib's scissor and rect-
+					// outline routines mishandle. #136 M5.
 					content_rect = rl.Rectangle{
 						rect.x + f32(t.padding[3]),
 						rect.y + f32(t.padding[0]),
-						rect.width - f32(t.padding[1]) - f32(t.padding[3]),
-						rect.height - f32(t.padding[0]) - f32(t.padding[2]),
+						max(0, rect.width - f32(t.padding[1]) - f32(t.padding[3])),
+						max(0, rect.height - f32(t.padding[0]) - f32(t.padding[2])),
 					}
 				}
 			}
@@ -355,11 +359,12 @@ layout_box :: proc(
 		effective_aspect := effective_aspect_for_drag(idx, aspect, nodes[idx])
 		if t, ok := theme[effective_aspect]; ok do pad = t.padding
 		if pad != {} {
+			// Clamp width/height to 0 — see #136 M5.
 			content_rect = rl.Rectangle{
 				rect.x + f32(pad[3]),
 				rect.y + f32(pad[0]),
-				rect.width - f32(pad[1]) - f32(pad[3]),
-				rect.height - f32(pad[0]) - f32(pad[2]),
+				max(0, rect.width - f32(pad[1]) - f32(pad[3])),
+				max(0, rect.height - f32(pad[0]) - f32(pad[2])),
 			}
 		}
 	}

--- a/src/redin/types/view_tree.odin
+++ b/src/redin/types/view_tree.odin
@@ -82,8 +82,12 @@ Drag_Over_Attrs :: struct {
 }
 
 Path :: struct {
-	value:  []u8,
-	length: u8,
+	value: []u8,
+	// `length` mirrors `len(value)` (paths are written by parser/_flatten
+	// where each step is one child index). A u8 silently truncated past
+	// depth 255; widened to u16 so the field stays consistent up to the
+	// parser's MAX_NESTING (256) and well beyond. #136 L1.
+	length: u16,
 }
 
 Children :: struct {


### PR DESCRIPTION
## Summary

Four small fixes from #136 in one bundle:

- **M5** (`src/redin/render.odin`) — `max(0, …)` on the two spots that compute `content_rect` width/height after padding. Negative-extent Rectangles into Raylib's scissor were a latent foot-gun.
- **M6** (`src/redin/parser/theme_parser.odin`) — every `f32 → u8` conversion now goes through `_to_u8` that clamps to `[0,255]`. Stops `PUT /aspects` with negative or out-of-range numbers from wrapping mod 256 (e.g. `:border-width -1` → 255, `:radius 256.5` → 0). Regression test added.
- **L1** (`src/redin/types/view_tree.odin`) — `Path.length` widened `u8 → u16`. Combined with M1's `MAX_NESTING = 256` cap, u16 is comfortably wider than anything the parser will produce. Three write sites updated to match.
- **L3** (`.gitmodules`) — added `branch = main` to the `lib/odin-http` submodule entry. Doesn't change the pinned commit, just makes `git submodule update --remote`'s intent explicit so it tracks the maintainer-intended branch.

## Test plan

- [x] `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:/tmp/redin-rel` — clean release.
- [x] `odin test src/redin/parser -define:ODIN_TEST_THREADS=1` — 28 pass (was 27, +1 new clamp test).
- [x] `odin test src/redin/{bridge,markdown,input,profile}` (with flags) — 57+27+25+4 all pass.
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 134 pass.

## Remaining

After this PR, the audit's open list is: **M3** (screenshot scope), **M4** (worker pool slowloris), **L2** (release-version regex), **L4** (signed tarballs). Ready to tackle individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
