### PR TITLE
fix(security): widen handler pool, tighten slowloris caps (#136 M4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ walks upward (8801, 8802, ...) if busy, and writes the bound port to
 `./.redin-token` (0600). Every non-`OPTIONS` request must carry
 `Authorization: Bearer <token>`, and the `Host` header must be
 `localhost:<port>` / `127.0.0.1:<port>`. Requests are served by an
-acceptor plus a 4-handler worker pool (up to 4 in flight at a time).
+acceptor plus a 16-handler worker pool (up to 16 in flight at a time).
 
 | Method | Path | Description |
 |--------|------|-------------|

--- a/docs/reference/dev-server.md
+++ b/docs/reference/dev-server.md
@@ -10,7 +10,7 @@ Starts when the binary was built with `-define:REDIN_DEV=true` (or `-define:REDI
 
 Read endpoints reflect the last state pushed to the host. Write endpoints queue events into the main input channel as if they came from real user input.
 
-The listener is an acceptor thread plus a fixed pool of 4 handler threads, so up to 4 requests can be in flight at once. Beyond that, new connections queue until a handler frees up.
+The listener is an acceptor thread plus a fixed pool of 16 handler threads, so up to 16 requests can be in flight at once. Beyond that, new connections queue until a handler frees up. Each connection is bounded by a 2-second per-recv timeout and a 10-second total request deadline — slowloris caps, not user-facing knobs.
 
 Implementation: `src/redin/bridge/devserver.odin`.
 

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -41,8 +41,14 @@ Sync_Queue :: struct {
 }
 
 // --- Handler pool queue (#129 H8) ---
-
-HANDLER_POOL_SIZE :: 4
+//
+// Pool size raised from 4 → 16 in response to #136 M4: four slow-header
+// connections could otherwise pin every worker for up to the request
+// deadline, blocking legitimate localhost callers. The bigger pool plus
+// the tightened CLIENT_RECV_TIMEOUT below means a slowloris-style
+// attacker would need 16 concurrent connections AND a per-recv that
+// beats a 2-second timer to keep the server fully wedged.
+HANDLER_POOL_SIZE :: 16
 
 Pending_Conn :: struct {
 	socket: net.TCP_Socket,
@@ -377,15 +383,21 @@ devserver_drain_events :: proc(ds: ^Dev_Server, events: ^[dynamic]types.InputEve
 // --- Simple blocking HTTP server thread ---
 
 // Per-recv deadline. Slowloris variant "connect and send nothing"
-// unblocks via SO_RCVTIMEO when recv returns after this. Value kept
-// generous enough to not trip up a sluggish local client.
-CLIENT_RECV_TIMEOUT :: 5 * time.Second
+// unblocks via SO_RCVTIMEO when recv returns after this. Tightened
+// from 5s → 2s for #136 M4 — the server is loopback-only, so any
+// legitimate client should produce request bytes within a single
+// scheduler quantum. A 2-second timeout still tolerates very sluggish
+// local tooling without giving a slowloris client free pinning.
+CLIENT_RECV_TIMEOUT :: 2 * time.Second
 
 // Total time any one request may take from accept to end-of-body,
 // regardless of per-recv progress. Defends against drip-feed
 // slowloris where a client sends one byte every CLIENT_RECV_TIMEOUT
-// just often enough to keep the per-recv timer from firing.
-CLIENT_REQUEST_DEADLINE :: 30 * time.Second
+// just often enough to keep the per-recv timer from firing. Tightened
+// from 30s → 10s for #136 M4: a real request finishes in milliseconds
+// over loopback, 10s is already extravagantly generous, and the lower
+// ceiling caps how long a hostile connection can monopolise a worker.
+CLIENT_REQUEST_DEADLINE :: 10 * time.Second
 
 acceptor_thread_proc :: proc(ds: ^Dev_Server) {
 	for ds.running {

--- a/src/redin/bridge/devserver_pool_test.odin
+++ b/src/redin/bridge/devserver_pool_test.odin
@@ -41,6 +41,7 @@ test_conn_queue_nil_sentinel :: proc(t: ^testing.T) {
 @(test)
 test_handler_pool_size_constant :: proc(t: ^testing.T) {
 	// Pool size is part of the contract — fix the value here so an
-	// accidental tweak in devserver.odin trips this test.
-	testing.expect_value(t, HANDLER_POOL_SIZE, 4)
+	// accidental tweak in devserver.odin trips this test. Raised from
+	// 4 → 16 in #136 M4 (slowloris mitigation).
+	testing.expect_value(t, HANDLER_POOL_SIZE, 16)
 }


### PR DESCRIPTION
## Summary

### M4 — handler-pool slowloris mitigation

Three constants in `src/redin/bridge/devserver.odin`:

| | before | after |
|---|---|---|
| `HANDLER_POOL_SIZE` | 4 | **16** |
| `CLIENT_RECV_TIMEOUT` | 5s | **2s** |
| `CLIENT_REQUEST_DEADLINE` | 30s | **10s** |

A slow-header attacker previously needed only 4 connections (one per worker) to pin the dev server for up to 30s at a time, blocking legitimate localhost callers. After this PR they need 16 concurrent connections AND each one is freed by 2s/10s caps instead of 5s/30s. Bridge test `test_handler_pool_size_constant` updated to assert 16. CLAUDE.md + `docs/reference/dev-server.md` mention the new caps.

### M3 — audit claim does not reproduce

The audit (#136 M3) claimed `LoadImageFromScreen` captures the whole monitor, exposing other apps in the PNG. Empirical test:

```
window: 1280×800 → /screenshot → PNG image data, 1280 x 800
window: 400×300  → /screenshot → PNG image data, 400 x 300
```

The captured size always matches the redin window's render size on Linux/X11 with raylib 5.5. No code change for M3 — documenting the audit response in the commit body so the trail is preserved. (If a future raylib upgrade or Wayland-specific path changes this, we can revisit.)

## Test plan

- [x] `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:/tmp/redin-rel` — clean.
- [x] `odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit` — 57 pass (pool-size constant test updated).
- [x] All other Odin suites pass.
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 134 pass.
- [x] Manual: screenshot at full window size and after `/resize 400 300` both return a PNG whose dimensions match the window's render size.

## Remaining audit items

After this: **L2** (release.yml version regex) and **L4** (signed tarballs). Both target the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
