### PR TITLE
fix(security): validate release version, publish sha256 sidecar (#136)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,26 @@ jobs:
         with:
           submodules: recursive
 
+      # Validate the workflow input before using it anywhere. Without this,
+      # a maintainer typo like `v1.0.0; rm -rf /` flows verbatim into the
+      # release name and tag (#136 L2). The trigger is workflow_dispatch
+      # (maintainer-only) so this isn't a code-injection vector, but a
+      # fail-fast regex keeps malformed inputs from reaching GitHub's
+      # release API at all.
       - name: Determine version
         id: version
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
+          set -euo pipefail
           if [ -n "$INPUT_VERSION" ]; then
+            # Strict semver-ish: optional leading `v`, MAJOR.MINOR.PATCH,
+            # optional `-pre.release.tag`. No spaces, no shell metas.
+            if ! printf '%s' "$INPUT_VERSION" \
+                 | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'; then
+              echo "::error::version input '$INPUT_VERSION' does not match ^v?[0-9]+\\.[0-9]+\\.[0-9]+(-[A-Za-z0-9.]+)?\$" >&2
+              exit 2
+            fi
             echo "tag=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
           else
             echo "tag=dev-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
@@ -77,6 +91,13 @@ jobs:
           cp .claude/skills/redin-dev/SKILL.md dist/skills/redin-dev/
           [ -f LICENSE ] && cp LICENSE dist/ || true
           tar czf "redin-${VERSION}-linux-amd64.tar.gz" -C dist .
+          # SHA-256 checksum published alongside the tarball so downstream
+          # tooling (redin-cli, manual `sha256sum -c`) can detect transport
+          # corruption or a swap during transit. #136 L4. Full signing
+          # (cosign keyless) is a follow-up; this is the minimum-friction
+          # integrity check.
+          sha256sum "redin-${VERSION}-linux-amd64.tar.gz" \
+            > "redin-${VERSION}-linux-amd64.tar.gz.sha256"
 
       - name: Smoke check (native build from tarball)
         # Simulates redin-cli's upgrade-to-native against the freshly built
@@ -90,7 +111,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: redin-${{ steps.version.outputs.tag }}-linux-amd64
-          path: redin-${{ steps.version.outputs.tag }}-linux-amd64.tar.gz
+          path: |
+            redin-${{ steps.version.outputs.tag }}-linux-amd64.tar.gz
+            redin-${{ steps.version.outputs.tag }}-linux-amd64.tar.gz.sha256
 
       - name: Build agent binary
         run: |
@@ -115,12 +138,17 @@ jobs:
           cp -r dist/skills dist-agent/
           [ -f dist/LICENSE ] && cp dist/LICENSE dist-agent/ || true
           tar czf "redin-${VERSION}-agent-linux-amd64.tar.gz" -C dist-agent .
+          # SHA-256 checksum, same rationale as the default tarball (#136 L4).
+          sha256sum "redin-${VERSION}-agent-linux-amd64.tar.gz" \
+            > "redin-${VERSION}-agent-linux-amd64.tar.gz.sha256"
 
       - name: Upload agent artifact
         uses: actions/upload-artifact@v7
         with:
           name: redin-${{ steps.version.outputs.tag }}-agent-linux-amd64
-          path: redin-${{ steps.version.outputs.tag }}-agent-linux-amd64.tar.gz
+          path: |
+            redin-${{ steps.version.outputs.tag }}-agent-linux-amd64.tar.gz
+            redin-${{ steps.version.outputs.tag }}-agent-linux-amd64.tar.gz.sha256
 
   release:
     needs: build
@@ -144,7 +172,9 @@ jobs:
           name: redin ${{ inputs.version }}
           draft: false
           prerelease: ${{ !startsWith(inputs.version, 'v') }}
-          files: artifacts/**/*.tar.gz
+          files: |
+            artifacts/**/*.tar.gz
+            artifacts/**/*.tar.gz.sha256
           body: |
             ## What's included
             - `redin` binary (Linux x86_64, LuaJIT statically linked,
@@ -153,6 +183,15 @@ jobs:
             - Fennel compiler (for hot reload)
             - Developer documentation (guides + reference)
             - Claude Code skill for redin development
+
+            ## Verifying the download
+
+            Each `.tar.gz` ships with a matching `.tar.gz.sha256` file
+            containing the SHA-256 of the tarball. After download:
+
+            ```bash
+            sha256sum -c redin-VERSION-linux-amd64.tar.gz.sha256
+            ```
 
             ## Quick start
             ```


### PR DESCRIPTION
## Summary

Closes **L2** and the high-friction half of **L4** from #136. Both touch only `.github/workflows/release.yml`.

### L2 — validate `workflow_dispatch` version input

```yaml
- name: Determine version
  ...
  run: |
    set -euo pipefail
    if [ -n "$INPUT_VERSION" ]; then
      if ! printf '%s' "$INPUT_VERSION" \
           | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'; then
        echo "::error::version input ... does not match …" >&2
        exit 2
      fi
      ...
```

A maintainer typo like `v1.0.0; rm -rf /` no longer flows verbatim into the release name/tag. Trigger is maintainer-only so this isn't a code-injection vector — but failing fast keeps malformed inputs from reaching the GitHub API at all.

Local sanity check on the regex:

| input | result |
|---|---|
| `v0.1.0`, `v1.0.0-rc.1`, `0.4.3`, `v0.4.3-pre.1.alpha` | accept |
| `v0.1`, `1.0.0; rm -rf /`, `v1.0.0 && oops`, empty, `../../etc`, `v1.2.3-foo bar` | reject |

### L4 (lite) — publish SHA-256 sidecar per tarball

Each `.tar.gz` now gets a matching `.tar.gz.sha256` file produced by `sha256sum` right after the tarball is created. Both upload-artifact entries glob the .sha256 alongside the .tar.gz, and the `softprops/action-gh-release` `files:` list publishes both.

Release notes gain a "Verifying the download" block:

```bash
sha256sum -c redin-VERSION-linux-amd64.tar.gz.sha256
```

This catches transport corruption or in-flight swaps; it does **not** prevent a maintainer-account or release-pipeline compromise. Full cosign keyless signing (the other half of L4) is a separate follow-up.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — parses.
- [x] Manual regex test against accept/reject corpora (above).
- [ ] CI verification awaits a real release dispatch.

## Remaining audit items

After this: **L4-full** (cosign keyless signing). Everything else from #136 (H1, M1, M2, H2, H3, M3, M4, M5, M6, L1, L2, L3, L4-lite) is now closed across PRs #151, #152, #153, #154, and this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
