### PR TITLE
docs(http): reference #156 for bounded shutdown leak

### DIFF
--- a/docs/reference/effects.md
+++ b/docs/reference/effects.md
@@ -106,6 +106,8 @@ Make an async HTTP request. The response is routed back as an event.
 | `"too many concurrent http requests (cap 64)"` | Submitted while 64 in-flight requests were already running. |
 | `"host <name> not in http whitelist"` | Whitelist denies this host. Deny-by-default since #136 H2 — set `bridge.set_http_whitelist([]string{"*"})` to allow any host. See [native bridge](native-bridge.md). |
 
+**Shutdown behavior.** `http_client_destroy` waits up to 3 s for in-flight workers to drain. Workers parked inside the underlying socket read can't be cancelled (odin-http has no cancellation knob), so on timeout the bridge logs `"redin: warning: N HTTP worker(s) still in flight at shutdown"` and leaks each stuck worker's ~4 KiB response-scanner buffer. The leak is bounded (cap 64 workers × 4 KiB = 256 KiB) and shutdown-only. Tracked in #156.
+
 **Success handler** receives `[event-name response]`:
 
 ```fennel

--- a/src/redin/bridge/http_client.odin
+++ b/src/redin/bridge/http_client.odin
@@ -147,10 +147,11 @@ http_client_destroy :: proc(hc: ^Http_Client) {
 
 	// Final cleanup. Anything still alive is a worker we couldn't drain
 	// — log and leak (better than UAF when the worker eventually
-	// returns).
+	// returns). Each stuck worker leaks ~4 KiB (its scanner buffer in
+	// odin-http's parse_response); bounded by MAX_INFLIGHT_HTTP. See #156.
 	leaked := sync.atomic_load(&hc.workers_alive)
 	if leaked > 0 {
-		fmt.eprintfln("redin: warning: %d HTTP worker(s) still in flight at shutdown; leaking their state", leaked)
+		fmt.eprintfln("redin: warning: %d HTTP worker(s) still in flight at shutdown; leaking their state (~4 KiB each, see #156)", leaked)
 	}
 
 	sync.lock(&hc.results_mutex)

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -522,13 +522,14 @@ test_http_timeout_fires :: proc(t: ^testing.T) {
 }
 
 @(test)
-// Known leak: the 64 in-flight workers are blocked in odin-http's
-// http_client.request, which has no cancellation knob. http_client_destroy
-// waits 3 s for them to drain via the timeout sweep, then logs and gives up.
-// The tracking allocator reports each worker's scanner buffer (~4 KiB) as
-// leaked. Eliminating this requires either modifying odin-http (vendored,
-// out of scope) or tracking + closing pending sockets from destroy
-// (substantial change). The leak is bounded and shutdown-only.
+// Known leak (tracked in #156): the 64 in-flight workers are blocked in
+// odin-http's http_client.request, which has no cancellation knob.
+// http_client_destroy waits 3 s for them to drain via the timeout sweep,
+// then logs and gives up. The tracking allocator reports each worker's
+// scanner buffer (~4 KiB, allocated in lib/odin-http/client/
+// communication.odin:141) as leaked. Bounded at MAX_INFLIGHT_HTTP × ~4 KiB
+// = 256 KiB; shutdown-only. Eliminating it requires either an upstream
+// cancellation API or tracking + closing pending sockets from destroy.
 test_http_inflight_cap_rejects :: proc(t: ^testing.T) {
 	sync.lock(&g_test_http_state_mutex)
 	defer sync.unlock(&g_test_http_state_mutex)


### PR DESCRIPTION
## Summary

Wires the existing "Known leak" trail to the newly filed #156, so future readers tracing 4 KiB scanner allocations in the tracking-allocator output land on the issue with full technical detail and proposed fixes.

- `src/redin/bridge/http_client.odin` — extended the shutdown warning message with the per-worker leak size (~4 KiB) and an issue reference.
- `src/redin/bridge/http_client_test.odin` — comment on `test_http_inflight_cap_rejects` now points at #156, includes the exact upstream allocation site (`lib/odin-http/client/communication.odin:141`), and notes the 256 KiB bound.
- `docs/reference/effects.md` — new "Shutdown behavior" paragraph in the `:http` effect reference documenting the bounded leak and linking to #156.

No behavior change. The fix itself (issue #156) is substantial — either an upstream cancellation API in odin-http or socket-tracking + force-close from `http_client_destroy` — and stays out of scope for this PR.

## Test plan

- [x] `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:/tmp/redin-rel` — clean release build.
- [x] `odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit` — 57/57 pass; the documented leak still reproduces exactly as the comment now says (4 KiB blocks from `scanner.odin:204`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)