### PR TITLE
fix(http): eliminate scanner-buffer leak at shutdown (#156)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "lib/odin-http"]
 	path = lib/odin-http
-	url = https://github.com/laytan/odin-http.git
-	branch = main
+	url = https://github.com/sstoehrm/odin-http.git
+	branch = fix/parse-response-leak-socket-hook

--- a/docs/reference/effects.md
+++ b/docs/reference/effects.md
@@ -106,7 +106,7 @@ Make an async HTTP request. The response is routed back as an event.
 | `"too many concurrent http requests (cap 64)"` | Submitted while 64 in-flight requests were already running. |
 | `"host <name> not in http whitelist"` | Whitelist denies this host. Deny-by-default since #136 H2 — set `bridge.set_http_whitelist([]string{"*"})` to allow any host. See [native bridge](native-bridge.md). |
 
-**Shutdown behavior.** `http_client_destroy` waits up to 3 s for in-flight workers to drain. Workers parked inside the underlying socket read can't be cancelled (odin-http has no cancellation knob), so on timeout the bridge logs `"redin: warning: N HTTP worker(s) still in flight at shutdown"` and leaks each stuck worker's ~4 KiB response-scanner buffer. The leak is bounded (cap 64 workers × 4 KiB = 256 KiB) and shutdown-only. Tracked in #156.
+**Shutdown behavior.** `http_client_destroy` waits up to 3 s for in-flight workers to drain naturally, then force-closes the TCP sockets of any still parked inside `parse_response`'s blocking read, then waits up to 1 s more for them to unwind. Closing the socket surfaces as `Connection_Closed` inside `recv_tcp`, which lets the parser return through its error path with the scanner buffer freed (#156). The "N HTTP worker(s) still in flight at shutdown" warning only fires if a worker survives both phases, which should be rare in practice.
 
 **Success handler** receives `[event-name response]`:
 

--- a/src/redin/bridge/http_client.odin
+++ b/src/redin/bridge/http_client.odin
@@ -3,6 +3,7 @@ package bridge
 import "core:bytes"
 import "core:fmt"
 import "core:log"
+import "core:net"
 import "core:strings"
 import "core:sync"
 import "core:thread"
@@ -103,7 +104,8 @@ Http_Client :: struct {
 	pending_mutex: sync.Mutex,
 	// Set by http_client_destroy to signal in-flight workers to bail
 	// without touching `results` or freeing state we'll free below.
-	// Read/written under `pending_mutex`. Issue #99 M1 B.
+	// Atomic so the socket hook can observe shutdown without taking
+	// pending_mutex. Issue #99 M1 B, #156.
 	destroying:    bool,
 	// Atomic counter of workers that have begun execute_http_request and
 	// not yet completed their cleanup. Drain waits for this to reach 0
@@ -111,6 +113,46 @@ Http_Client :: struct {
 	// `len(pending)` because the timeout sweep removes pending entries
 	// while the worker is still running. Issue #99 M1 B.
 	workers_alive: i32,
+	// Socket fds of in-flight requests, keyed by request id. Populated
+	// from inside odin-http's `request()` via the socket_hook callback
+	// right after dial, and force-closed by `http_client_destroy` on
+	// shutdown to unblock workers parked in `parse_response`'s blocking
+	// `net.recv_tcp`. The fork's `defer` in `parse_response` frees the
+	// scanner buffer once recv returns Connection_Closed. Issue #156.
+	sockets:       map[string]net.TCP_Socket,
+	sockets_mutex: sync.Mutex,
+}
+
+@(private = "file")
+Socket_Registration :: struct {
+	client: ^Http_Client,
+	id:     string,
+}
+
+// Hook passed to odin-http's `http_client.request()`. Invoked once with
+// the freshly-dialed TCP socket. Registers the socket in the client's
+// `sockets` map so `http_client_destroy` can force-close it during
+// shutdown. If destroy already started, closes the socket immediately
+// — the subsequent send/recv inside `request()` fails and the worker
+// returns through normal error cleanup.
+@(private = "file")
+register_socket :: proc(sock: net.TCP_Socket, user: rawptr) {
+	reg := cast(^Socket_Registration)user
+	sync.lock(&reg.client.sockets_mutex)
+	if sync.atomic_load(&reg.client.destroying) {
+		sync.unlock(&reg.client.sockets_mutex)
+		net.close(sock)
+		return
+	}
+	reg.client.sockets[reg.id] = sock
+	sync.unlock(&reg.client.sockets_mutex)
+}
+
+@(private = "file")
+unregister_socket :: proc(hc: ^Http_Client, id: string) {
+	sync.lock(&hc.sockets_mutex)
+	delete_key(&hc.sockets, id)
+	sync.unlock(&hc.sockets_mutex)
 }
 
 http_client_init :: proc(hc: ^Http_Client) {
@@ -118,40 +160,57 @@ http_client_init :: proc(hc: ^Http_Client) {
 
 http_client_destroy :: proc(hc: ^Http_Client) {
 	// Signal workers to bail on completion. They re-check `destroying`
-	// under `pending_mutex` after `execute_http_request` returns and
-	// decrement `workers_alive` LAST, so a worker count of 0 means no
-	// worker holds a pointer into `hc`.
-	sync.lock(&hc.pending_mutex)
-	hc.destroying = true
-	sync.unlock(&hc.pending_mutex)
+	// after `execute_http_request` returns and decrement `workers_alive`
+	// LAST, so a worker count of 0 means no worker holds a pointer into
+	// `hc`. Atomic store so the socket hook can observe shutdown
+	// without locking `pending_mutex`.
+	sync.atomic_store(&hc.destroying, true)
 
-	// Wait for all in-flight workers to complete their cleanup. We watch
-	// `workers_alive` (atomic) rather than `len(pending)` because the
-	// timeout sweep removes pending entries while the worker thread is
-	// still running its HTTP I/O. Cap the wait so a stuck remote doesn't
-	// hang shutdown forever.
+	// Phase 1: wait up to 3 s for workers to drain naturally. The
+	// timeout sweep also runs here to mark long-running requests as
+	// timed out; workers that complete normally during this window
+	// remove themselves from `pending` and `sockets`.
 	deadline := time.time_add(time.now(), 3 * time.Second)
 	for {
 		if sync.atomic_load(&hc.workers_alive) == 0 do break
 		if time.diff(time.now(), deadline) <= 0 do break
 		time.sleep(10 * time.Millisecond)
 
-		// Sweep timed-out entries while we wait, so workers blocked
-		// reading the response notice (their HTTP call may eventually
-		// fail naturally; the sweep at least keeps the registry tidy).
 		dummy: [dynamic]Http_Response
 		http_client_poll(hc, &dummy)
 		for &r in dummy do http_response_destroy(&r)
 		delete(dummy)
 	}
 
-	// Final cleanup. Anything still alive is a worker we couldn't drain
-	// — log and leak (better than UAF when the worker eventually
-	// returns). Each stuck worker leaks ~4 KiB (its scanner buffer in
-	// odin-http's parse_response); bounded by MAX_INFLIGHT_HTTP. See #156.
+	// Phase 2: force-close any sockets still registered. Workers parked
+	// inside odin-http's `parse_response → net.recv_tcp` only return
+	// when the socket dies, so close them ourselves. The upstream defer
+	// (commits on the fork branch) frees the scanner buffer along the
+	// way, eliminating the 4 KiB-per-stuck-worker leak from #156.
+	sync.lock(&hc.sockets_mutex)
+	for _, sock in hc.sockets {
+		net.close(sock)
+	}
+	sync.unlock(&hc.sockets_mutex)
+
+	// Phase 3: wait up to 1 s more for workers to unwind through the
+	// now-unblocked recv. Continue sweeping timeouts so newly-failed
+	// requests get cleaned up too.
+	deadline2 := time.time_add(time.now(), 1 * time.Second)
+	for {
+		if sync.atomic_load(&hc.workers_alive) == 0 do break
+		if time.diff(time.now(), deadline2) <= 0 do break
+		time.sleep(10 * time.Millisecond)
+
+		dummy: [dynamic]Http_Response
+		http_client_poll(hc, &dummy)
+		for &r in dummy do http_response_destroy(&r)
+		delete(dummy)
+	}
+
 	leaked := sync.atomic_load(&hc.workers_alive)
 	if leaked > 0 {
-		fmt.eprintfln("redin: warning: %d HTTP worker(s) still in flight at shutdown; leaking their state (~4 KiB each, see #156)", leaked)
+		fmt.eprintfln("redin: warning: %d HTTP worker(s) still in flight at shutdown", leaked)
 	}
 
 	sync.lock(&hc.results_mutex)
@@ -161,16 +220,21 @@ http_client_destroy :: proc(hc: ^Http_Client) {
 
 	if leaked == 0 {
 		// All workers completed their cleanup; safe to free the pending
-		// map. Any remaining entries (from timeout sweep removals where
-		// the worker had already decremented workers_alive) own no live
-		// references at this point.
+		// and sockets maps. Any remaining sockets entries (from a worker
+		// that closed normally without unregistering, in theory) own
+		// nothing — the fds are already closed by `response_destroy`.
 		sync.lock(&hc.pending_mutex)
 		for _, entry in hc.pending do delete(entry.id_owned)
 		delete(hc.pending)
 		sync.unlock(&hc.pending_mutex)
+
+		sync.lock(&hc.sockets_mutex)
+		delete(hc.sockets)
+		sync.unlock(&hc.sockets_mutex)
 	}
-	// Otherwise we deliberately leak `hc.pending` — workers may still
-	// look at it. Leaked entries leak with the Http_Client.
+	// Otherwise we deliberately leak `hc.pending` / `hc.sockets` —
+	// workers may still look at them. Leaked entries leak with the
+	// Http_Client.
 }
 
 http_response_destroy :: proc(r: ^Http_Response) {
@@ -199,8 +263,8 @@ http_client_request :: proc(hc: ^Http_Client, req: Http_Request) {
 	// the contract for callers on other threads.
 	sync.lock(&hc.pending_mutex)
 	inflight := len(hc.pending)
-	shutting_down := hc.destroying
 	sync.unlock(&hc.pending_mutex)
+	shutting_down := sync.atomic_load(&hc.destroying)
 
 	if inflight >= MAX_INFLIGHT_HTTP {
 		// Move req.id into the rejection response (mirrors execute_http_request,
@@ -314,10 +378,10 @@ http_client_poll :: proc(hc: ^Http_Client, results: ^[dynamic]Http_Response) {
 @(private = "file")
 http_thread_proc :: proc(raw_data_ptr: rawptr) {
 	data := cast(^Http_Thread_Data)raw_data_ptr
-	response := execute_http_request(data.request)
+	response := execute_http_request(data.request, data.client)
 
 	sync.lock(&data.client.pending_mutex)
-	if data.client.destroying {
+	if sync.atomic_load(&data.client.destroying) {
 		// Client is being torn down. Don't touch results; just remove
 		// our entry to allow the drain loop to make progress. Any
 		// synthesized timeout response in `results` for this id has
@@ -378,7 +442,11 @@ http_request_destroy :: proc(req: ^Http_Request) {
 	delete(req.headers)
 }
 
-execute_http_request :: proc(req: Http_Request) -> Http_Response {
+// `client` is optional. When non-nil, the request's socket is registered
+// in `client.sockets` while in flight so `http_client_destroy` can
+// force-close it during shutdown. Tests that drive `execute_http_request`
+// synchronously (no thread, no destroy) pass nil and skip registration.
+execute_http_request :: proc(req: Http_Request, client: ^Http_Client = nil) -> Http_Response {
 	response: Http_Response
 	response.id = req.id
 	response.headers = make(map[string]string)
@@ -444,7 +512,18 @@ execute_http_request :: proc(req: Http_Request) -> Http_Response {
 		bytes.buffer_write_string(&http_req.body, req.body)
 	}
 
-	res, err := http_client.request(&http_req, req.url)
+	res: http_client.Response
+	err: http_client.Error
+	if client != nil {
+		// Address of `reg` is fine — the hook runs synchronously inside
+		// `request()`, so `reg` is alive for the call.
+		reg := Socket_Registration{client = client, id = req.id}
+		res, err = http_client.request(&http_req, req.url, context.allocator,
+		                               register_socket, &reg)
+		unregister_socket(client, req.id)
+	} else {
+		res, err = http_client.request(&http_req, req.url)
+	}
 	if err != nil {
 		response.status = 0
 		response.error_msg = fmt.aprintf("Request failed: %v", err)

--- a/src/redin/bridge/http_client.odin
+++ b/src/redin/bridge/http_client.odin
@@ -104,8 +104,9 @@ Http_Client :: struct {
 	pending_mutex: sync.Mutex,
 	// Set by http_client_destroy to signal in-flight workers to bail
 	// without touching `results` or freeing state we'll free below.
-	// Atomic so the socket hook can observe shutdown without taking
-	// pending_mutex. Issue #99 M1 B, #156.
+	// Atomic so workers can check it under `sockets_mutex` between
+	// dial and register without lock-ordering hazards on `pending_mutex`.
+	// Issue #99 M1 B, #156.
 	destroying:    bool,
 	// Atomic counter of workers that have begun execute_http_request and
 	// not yet completed their cleanup. Drain waits for this to reach 0
@@ -113,46 +114,15 @@ Http_Client :: struct {
 	// `len(pending)` because the timeout sweep removes pending entries
 	// while the worker is still running. Issue #99 M1 B.
 	workers_alive: i32,
-	// Socket fds of in-flight requests, keyed by request id. Populated
-	// from inside odin-http's `request()` via the socket_hook callback
-	// right after dial, and force-closed by `http_client_destroy` on
-	// shutdown to unblock workers parked in `parse_response`'s blocking
-	// `net.recv_tcp`. The fork's `defer` in `parse_response` frees the
-	// scanner buffer once recv returns Connection_Closed. Issue #156.
+	// Socket fds of in-flight requests, keyed by request id. Workers
+	// dial via `http_client.dial`, insert here while `request_on` is
+	// running, and remove on completion. `http_client_destroy`
+	// force-closes any still registered to unblock workers parked in
+	// `parse_response`'s blocking `net.recv_tcp`. The fork's `defer`
+	// in `parse_response` frees the scanner buffer once recv returns
+	// Connection_Closed. Issue #156.
 	sockets:       map[string]net.TCP_Socket,
 	sockets_mutex: sync.Mutex,
-}
-
-@(private = "file")
-Socket_Registration :: struct {
-	client: ^Http_Client,
-	id:     string,
-}
-
-// Hook passed to odin-http's `http_client.request()`. Invoked once with
-// the freshly-dialed TCP socket. Registers the socket in the client's
-// `sockets` map so `http_client_destroy` can force-close it during
-// shutdown. If destroy already started, closes the socket immediately
-// — the subsequent send/recv inside `request()` fails and the worker
-// returns through normal error cleanup.
-@(private = "file")
-register_socket :: proc(sock: net.TCP_Socket, user: rawptr) {
-	reg := cast(^Socket_Registration)user
-	sync.lock(&reg.client.sockets_mutex)
-	if sync.atomic_load(&reg.client.destroying) {
-		sync.unlock(&reg.client.sockets_mutex)
-		net.close(sock)
-		return
-	}
-	reg.client.sockets[reg.id] = sock
-	sync.unlock(&reg.client.sockets_mutex)
-}
-
-@(private = "file")
-unregister_socket :: proc(hc: ^Http_Client, id: string) {
-	sync.lock(&hc.sockets_mutex)
-	delete_key(&hc.sockets, id)
-	sync.unlock(&hc.sockets_mutex)
 }
 
 http_client_init :: proc(hc: ^Http_Client) {
@@ -512,23 +482,48 @@ execute_http_request :: proc(req: Http_Request, client: ^Http_Client = nil) -> H
 		bytes.buffer_write_string(&http_req.body, req.body)
 	}
 
-	res: http_client.Response
-	err: http_client.Error
-	if client != nil {
-		// Address of `reg` is fine — the hook runs synchronously inside
-		// `request()`, so `reg` is alive for the call.
-		reg := Socket_Registration{client = client, id = req.id}
-		res, err = http_client.request(&http_req, req.url, context.allocator,
-		                               register_socket, &reg)
-		unregister_socket(client, req.id)
-	} else {
-		res, err = http_client.request(&http_req, req.url)
-	}
-	if err != nil {
+	// Dial first, then register the socket so destroy can force-close
+	// it. Splitting the dial out is what makes this possible — the old
+	// monolithic `request()` never exposed the underlying fd. When
+	// `client` is nil (sync test callers) we skip the registry dance
+	// entirely.
+	sock, url, dial_err := http_client.dial(req.url)
+	if dial_err != nil {
 		response.status = 0
-		response.error_msg = fmt.aprintf("Request failed: %v", err)
+		response.error_msg = fmt.aprintf("Request failed: %v", dial_err)
 		return response
 	}
+
+	if client != nil {
+		sync.lock(&client.sockets_mutex)
+		if sync.atomic_load(&client.destroying) {
+			sync.unlock(&client.sockets_mutex)
+			net.close(sock)
+			response.status = 0
+			response.error_msg = strings.clone("http client shutting down")
+			return response
+		}
+		client.sockets[req.id] = sock
+		sync.unlock(&client.sockets_mutex)
+	}
+
+	res, req_err := http_client.request_on(&http_req, sock, url, context.allocator)
+
+	if client != nil {
+		sync.lock(&client.sockets_mutex)
+		delete_key(&client.sockets, req.id)
+		sync.unlock(&client.sockets_mutex)
+	}
+
+	if req_err != nil {
+		// `request_on` leaves socket ownership with us on error.
+		net.close(sock)
+		response.status = 0
+		response.error_msg = fmt.aprintf("Request failed: %v", req_err)
+		return response
+	}
+	// Success: ownership of `sock` transferred to `res`; closed by the
+	// `response_destroy` call below.
 
 	response.status = int(res.status)
 

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -522,14 +522,10 @@ test_http_timeout_fires :: proc(t: ^testing.T) {
 }
 
 @(test)
-// Known leak (tracked in #156): the 64 in-flight workers are blocked in
-// odin-http's http_client.request, which has no cancellation knob.
-// http_client_destroy waits 3 s for them to drain via the timeout sweep,
-// then logs and gives up. The tracking allocator reports each worker's
-// scanner buffer (~4 KiB, allocated in lib/odin-http/client/
-// communication.odin:141) as leaked. Bounded at MAX_INFLIGHT_HTTP × ~4 KiB
-// = 256 KiB; shutdown-only. Eliminating it requires either an upstream
-// cancellation API or tracking + closing pending sockets from destroy.
+// Fills the in-flight cap with slow requests so the destroy path has to
+// force-close every registered socket. Together with the upstream defer
+// in parse_response, this exercises the full #156 fix end-to-end —
+// previously this test leaked 64 × 4 KiB of scanner buffers at shutdown.
 test_http_inflight_cap_rejects :: proc(t: ^testing.T) {
 	sync.lock(&g_test_http_state_mutex)
 	defer sync.unlock(&g_test_http_state_mutex)


### PR DESCRIPTION
## Summary

Closes #156 by force-closing the TCP sockets of in-flight HTTP workers during `http_client_destroy`. Combined with the upstream `defer` that frees the scanner buffer on error returns, the ~4 KiB-per-stuck-worker shutdown leak (bounded at 256 KiB, documented in #157) is gone.

## Approach

**Upstream (`sstoehrm/odin-http` branch `fix/parse-response-leak-socket-hook`, two commits):**

1. `parse_response` now does `defer if err != nil { bufio.scanner_destroy(&scanner) }` — frees the scanner buffer on every error-return path (early EOF, malformed status, header parse failures, etc.). Safe on never-allocated buffers (`delete` on a nil slice).
2. `request()` is split into two halves so callers can stash the underlying socket fd without going through a callback:

   ```odin
   dial       :: proc(target: string)
                  -> (socket: net.TCP_Socket, url: http.URL, err: Error)
   request_on :: proc(req, socket, url, allocator)
                  -> (res: Response, err: Error)
   request    :: proc(req, target, allocator) -> (res: Response, err: Error)  // unchanged
   ```

   `request()` is preserved as a thin convenience wrapper around `dial` + `request_on` (and additionally closes the socket on error, fixing a pre-existing leak when the SSL handshake fails). `get()` and existing call sites compile unchanged.

Both commits will be sent upstream as separate PRs to laytan/odin-http. The submodule URL change is `laytan` → `sstoehrm` until those land; bumping back to upstream when they do is a one-line `.gitmodules` change.

**Bridge:**

- `Http_Client` gains `sockets: map[string]net.TCP_Socket` plus a mutex.
- `execute_http_request` dials directly via `http_client.dial`, registers the resulting fd under `sockets_mutex` (with an inline `destroying` short-circuit that closes-and-bails if shutdown is already in progress), calls `request_on`, and removes the entry on completion. On error, the bridge closes the socket itself; on success, `Response._socket` owns it and `response_destroy` closes.
- `http_client_destroy` adds a Phase 2 force-close pass after the existing 3 s drain, then Phase 3 waits up to 1 s for workers to unwind through the now-unblocked `recv_tcp`.
- `destroying` is now accessed via atomics so the dial→register window can observe shutdown without taking `pending_mutex`.
- `execute_http_request` takes an optional `^Http_Client` so synchronous test callers (no thread, no destroy) skip the registry plumbing entirely.

No rawptr-userdata callbacks anywhere — the registration is plain procedural code in the bridge against typed odin-http procs.

## Test plan

- [x] `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:/tmp/redin-rel` — clean.
- [x] `luajit test/lua/runner.lua test/lua/test_*.fnl` — 134 pass.
- [x] `odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit` — **57 pass, zero allocations not freed** (previously 64+ scanner-buffer leaks across the three documented tests).
- [x] `odin test src/redin/{parser,markdown,profile,input}` (with flags) — 28+27+4+25 pass.
- [x] `bash test/ui/run-all.sh --headless` — all suites green, no leak lines.

## Out of band

Standalone reproducer at `../http-leak/` (private workspace) — minimal Odin program pinned to upstream `3b46a46` that demonstrates the original leak with a loopback peer that closes immediately. Ready to attach to the upstream PR for the `defer` fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)