### PR TITLE
fix(devserver): defense-in-depth hardening for header parsing

### DIFF
--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -653,6 +653,7 @@ int_to_str :: proc(buf: []u8, val: int) -> string {
 		buf[0] = '0'
 		return string(buf[:1])
 	}
+	assert(val > 0 && len(buf) >= 20)
 	i := len(buf)
 	v := val
 	for v > 0 {
@@ -703,7 +704,7 @@ find_header_value :: proc(headers: string, name_lower: string) -> string {
 check_host_header :: proc(headers: string, expected_v4: string, expected_name: string) -> bool {
 	host := find_header_value(headers, "host")
 	if len(host) == 0 do return false
-	return host == expected_v4 || host == expected_name
+	return strings.equal_fold(host, expected_v4) || strings.equal_fold(host, expected_name)
 }
 
 // Constant-time compare of the Authorization bearer token against
@@ -711,13 +712,9 @@ check_host_header :: proc(headers: string, expected_v4: string, expected_name: s
 check_bearer_token :: proc(headers: string, expected: string) -> bool {
 	if len(expected) == 0 do return false
 	auth := find_header_value(headers, "authorization")
-	prefix := "Bearer "
-	if !strings.has_prefix(auth, prefix) {
-		// Tolerate lowercase prefix (some clients).
-		if !strings.has_prefix(auth, "bearer ") do return false
-	}
-	got := auth[len(prefix):]
-	return constant_time_eq(got, expected)
+	if len(auth) < 7 do return false
+	if !strings.equal_fold(auth[:7], "Bearer ") do return false
+	return constant_time_eq(auth[7:], expected)
 }
 
 // Length-independent equality check to avoid leaking token length via
@@ -747,7 +744,7 @@ find_content_length :: proc(headers: string) -> int {
 	for c in val {
 		if c >= '0' && c <= '9' {
 			digits += 1
-			if digits > 12 { return -1 }
+			if digits > 7 { return -1 }
 			n = n*10 + int(c - '0')
 		} else {
 			break

--- a/src/redin/bridge/devserver_headers_test.odin
+++ b/src/redin/bridge/devserver_headers_test.odin
@@ -53,12 +53,65 @@ test_find_header_value_trims_whitespace :: proc(t: ^testing.T) {
 
 @(test)
 test_find_content_length_overflow_returns_negative :: proc(t: ^testing.T) {
-	// 13 digits — exceeds the 12-digit cap but well within int64 range,
-	// so the unpatched parser would have returned 1_000_000_000_000 (positive)
-	// and slipped past MAX_BODY checks. Patched parser must return -1.
-	headers := "POST / HTTP/1.1\r\nContent-Length: 1000000000000\r\n"
+	// 8 digits — exceeds the 7-digit cap.
+	headers := "POST / HTTP/1.1\r\nContent-Length: 10000000\r\n"
 	testing.expect(t, find_content_length(headers) < 0,
-		"expected negative when digit count exceeds 12-digit cap")
+		"expected negative when digit count exceeds 7-digit cap")
+}
+
+@(test)
+test_find_content_length_7_digits_ok :: proc(t: ^testing.T) {
+	headers := "POST / HTTP/1.1\r\nContent-Length: 9999999\r\n"
+	testing.expect_value(t, find_content_length(headers), 9999999)
+}
+
+@(test)
+test_check_host_header_case_insensitive :: proc(t: ^testing.T) {
+	headers := "GET / HTTP/1.1\r\nHost: LOCALHOST:8800\r\n"
+	testing.expect(t, check_host_header(headers, "127.0.0.1:8800", "localhost:8800"),
+		"expected uppercase LOCALHOST to match")
+}
+
+@(test)
+test_check_host_header_v4 :: proc(t: ^testing.T) {
+	headers := "GET / HTTP/1.1\r\nHost: 127.0.0.1:8800\r\n"
+	testing.expect(t, check_host_header(headers, "127.0.0.1:8800", "localhost:8800"),
+		"expected 127.0.0.1 to match")
+}
+
+@(test)
+test_check_host_header_rejects_foreign :: proc(t: ^testing.T) {
+	headers := "GET / HTTP/1.1\r\nHost: evil.com:8800\r\n"
+	testing.expect(t, !check_host_header(headers, "127.0.0.1:8800", "localhost:8800"),
+		"expected foreign host to be rejected")
+}
+
+@(test)
+test_check_bearer_token_mixed_case :: proc(t: ^testing.T) {
+	headers := "GET / HTTP/1.1\r\nAuthorization: BEARER abc123\r\n"
+	testing.expect(t, check_bearer_token(headers, "abc123"),
+		"expected mixed-case BEARER prefix to be accepted")
+}
+
+@(test)
+test_check_bearer_token_lowercase :: proc(t: ^testing.T) {
+	headers := "GET / HTTP/1.1\r\nAuthorization: bearer abc123\r\n"
+	testing.expect(t, check_bearer_token(headers, "abc123"),
+		"expected lowercase bearer prefix to be accepted")
+}
+
+@(test)
+test_check_bearer_token_wrong_token :: proc(t: ^testing.T) {
+	headers := "GET / HTTP/1.1\r\nAuthorization: Bearer wrong\r\n"
+	testing.expect(t, !check_bearer_token(headers, "abc123"),
+		"expected wrong token to be rejected")
+}
+
+@(test)
+test_check_bearer_token_empty_expected :: proc(t: ^testing.T) {
+	headers := "GET / HTTP/1.1\r\nAuthorization: Bearer anything\r\n"
+	testing.expect(t, !check_bearer_token(headers, ""),
+		"expected empty expected token to reject all")
 }
 
 @(test)


### PR DESCRIPTION
## Summary

Closes #160. Defense-in-depth hardening for dev-server header parsing — all four findings from the security audit:

- **L1** — `check_host_header`: use `strings.equal_fold` for RFC 7230 §5.4 case-insensitive host comparison
- **L2** — `check_bearer_token`: fold-compare the `Bearer ` prefix uniformly instead of checking two literal cases
- **L3** — `find_content_length`: tighten digit cap from 12 to 7 (max ~10 MiB vs ~1 TiB; MAX_BODY is 1 MiB)
- **L4** — `int_to_str`: add `assert(val > 0 && len(buf) >= 20)` to guard against negative values and undersized buffers

## Test plan

- [x] Release build compiles clean
- [x] Dev build compiles clean
- [x] 65 bridge unit tests pass (7 new tests for L1–L3 behavior)
- [x] 134 Fennel runtime tests pass
- [x] All UI integration tests pass headless

🤖 Generated with [Claude Code](https://claude.com/claude-code)