### PR TITLE
fix(bridge): unref button click_ctx (#165) + cap view-tree recursion (#170)

### DIFF
--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -54,6 +54,17 @@ Bridge :: struct {
 g_bridge: ^Bridge
 g_context: runtime.Context
 
+// #170: hard cap on view-tree nesting depth. flatten/layout/draw each
+// recurse once per level with no native-stack guard, so a deeply
+// self-nesting view (e.g. recursive Fennel) would overflow the C stack
+// uncatchably (the surrounding lua_pcall can't catch a native overflow).
+// We cap at flatten — the single upstream choke point — so the flat tree,
+// and therefore every render pass over it, is bounded. Mirrors the EDN
+// parser's MAX_NESTING. Subtrees deeper than the cap are dropped with a
+// one-time warning rather than crashing.
+MAX_VIEW_DEPTH :: 256
+g_view_depth_warned: bool
+
 init :: proc(b: ^Bridge) {
 	g_bridge = b
 	g_context = context
@@ -331,6 +342,11 @@ clear_node_strings :: proc(n: types.Node) {
 		if len(v.click) > 0 do delete(v.click)
 		if len(v.label) > 0 do delete(v.label)
 		if len(v.aspect) > 0 do delete(v.aspect)
+		// #165: release the registry ref taken by lua_get_event_ctx for a
+		// `:click [:event ctx]` payload. Mirrors clear_dropable_attrs; the
+		// click consumer only ever reads the ref (never retains it across
+		// frames), so an unconditional unref of a nonzero ref is correct.
+		if v.click_ctx != 0 do luaL_unref(g_bridge.L, LUA_REGISTRYINDEX, v.click_ctx)
 	case types.NodeText:
 		if len(v.content) > 0 do delete(v.content)
 		if len(v.aspect) > 0 do delete(v.aspect)
@@ -1370,11 +1386,22 @@ lua_flatten_node :: proc(L: ^Lua_State, index: i32, cur: ^[dynamic]u8, b: ^Bridg
 			if lua_isstring(L, -1) {
 				// It's a child frame
 				lua_pop(L, 1)
-				child_idx := i32(len(b.nodes))
-				append(&child_indices, child_idx)
-				append(cur, u8(len(child_indices) - 1))
-				lua_flatten_node(L, lua_gettop(L), cur, b, my_idx)
-				pop(cur)
+				// #170: len(cur) is this node's nesting depth; cap recursion
+				// so the flat tree (and every render pass over it) stays
+				// bounded. Subtrees deeper than the cap are dropped.
+				if len(cur) < MAX_VIEW_DEPTH {
+					child_idx := i32(len(b.nodes))
+					append(&child_indices, child_idx)
+					append(cur, u8(len(child_indices) - 1))
+					lua_flatten_node(L, lua_gettop(L), cur, b, my_idx)
+					pop(cur)
+				} else if !g_view_depth_warned {
+					g_view_depth_warned = true
+					fmt.eprintfln(
+						"redin: view tree nested deeper than %d levels; dropping deeper subtrees to avoid a native stack overflow (#170)",
+						MAX_VIEW_DEPTH,
+					)
+				}
 			} else {
 				lua_pop(L, 1)
 			}

--- a/src/redin/bridge/clear_node_test.odin
+++ b/src/redin/bridge/clear_node_test.odin
@@ -1,0 +1,56 @@
+package bridge
+
+import "core:strings"
+import "core:sync"
+import "core:testing"
+import "../types"
+
+// Shared by tests that mutate the package-global g_bridge (clear_node_strings
+// and clear_frame unref via g_bridge.L). Odin's test runner runs tests in
+// parallel, so any test touching g_bridge must serialize on this. Mirrors
+// g_test_http_state_mutex in http_client_test.odin.
+g_test_bridge_global_mutex: sync.Mutex
+
+// Regression for #165: a NodeButton whose :click carries a context payload
+// (the documented `:click [:event ctx]` form) takes a Lua registry ref via
+// luaL_ref in lua_get_event_ctx. clear_node_strings rebuilds every frame, so
+// if it fails to luaL_unref click_ctx the registry grows without bound.
+//
+// We detect the leak via Lua 5.1 / LuaJIT's ref freelist: luaL_unref pushes
+// the slot onto the freelist and the next luaL_ref hands it straight back.
+// So a freed slot is reused; a leaked slot is not.
+@(test)
+test_clear_node_unrefs_button_click_ctx :: proc(t: ^testing.T) {
+	sync.lock(&g_test_bridge_global_mutex)
+	defer sync.unlock(&g_test_bridge_global_mutex)
+
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	// clear_node_strings unrefs against g_bridge.L (mirrors
+	// clear_dropable_attrs); point the global at our throwaway state.
+	b := Bridge{L = L}
+	saved := g_bridge
+	g_bridge = &b
+	defer g_bridge = saved
+
+	lua_pushboolean(L, 1)
+	ref := luaL_ref(L, LUA_REGISTRYINDEX)
+	testing.expect(t, ref > 0, "expected a valid registry ref")
+
+	btn := types.NodeButton{click = strings.clone("event/click"), click_ctx = ref}
+	node: types.Node = btn
+	clear_node_strings(node)
+
+	lua_pushboolean(L, 1)
+	ref2 := luaL_ref(L, LUA_REGISTRYINDEX)
+	luaL_unref(L, LUA_REGISTRYINDEX, ref2)
+	testing.expectf(
+		t,
+		ref2 == ref,
+		"click_ctx ref %d was not freed by clear_node_strings (next ref was %d) -> registry leak",
+		ref,
+		ref2,
+	)
+}

--- a/src/redin/bridge/flatten_depth_test.odin
+++ b/src/redin/bridge/flatten_depth_test.odin
@@ -1,0 +1,53 @@
+package bridge
+
+import "core:sync"
+import "core:testing"
+
+// Regression for #170: lua_flatten_node (and the render passes that walk its
+// output) recurse once per nesting level with no native-stack guard. A deeply
+// self-nesting view tree would overflow the C stack and SIGSEGV uncatchably.
+// flatten must cap the depth so the flat tree — and thus every render pass —
+// is bounded.
+@(test)
+test_flatten_caps_deep_nesting :: proc(t: ^testing.T) {
+	sync.lock(&g_test_bridge_global_mutex)
+	defer sync.unlock(&g_test_bridge_global_mutex)
+
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	b: Bridge
+	b.L = L
+	saved := g_bridge
+	g_bridge = &b
+	defer g_bridge = saved
+	defer clear_frame(&b)
+
+	// Build a 1000-deep nested vbox on the Lua stack. 1000 > MAX_VIEW_DEPTH
+	// (256) but shallow enough that the unfixed full recursion fails the
+	// assertion cleanly rather than overflowing the test thread's stack.
+	code: cstring = `local t = {"vbox", {}}
+for i = 1, 1000 do t = {"vbox", {}, t} end
+return t`
+	rc := luaL_dostring(L, code)
+	testing.expectf(t, rc == 0, "failed to build nested table (rc=%d)", rc)
+
+	cur: [dynamic]u8
+	defer delete(cur)
+	lua_flatten_node(L, lua_gettop(L), &cur, &b, -1)
+
+	testing.expect(t, len(b.nodes) > 0, "expected nodes to be emitted")
+
+	max_depth := 0
+	for p in b.paths {
+		if int(p.length) > max_depth do max_depth = int(p.length)
+	}
+	testing.expectf(
+		t,
+		max_depth <= MAX_VIEW_DEPTH,
+		"view-tree depth %d exceeded cap %d -> unbounded native recursion risk (#170)",
+		max_depth,
+		MAX_VIEW_DEPTH,
+	)
+}


### PR DESCRIPTION
Two **release-build** hardening fixes from the audit, both in `src/redin/bridge/bridge.odin`.

### #165 — NodeButton `:click [:ev ctx]` registry-ref leak
`lua_get_event_ctx` takes a `luaL_ref` for a click context payload, but `clear_node_strings`'s `NodeButton` case never released it (its sibling `clear_dropable_attrs` does). Every state-changing reflatten of such a button orphaned a registry slot and pinned the payload → unbounded `LUA_REGISTRYINDEX` growth. Added the missing `luaL_unref`.

### #170 — unbounded native recursion in flatten/layout/draw
`lua_flatten_node` and the render passes recurse once per nesting level with no native-stack guard, so a deeply self-nesting view tree overflowed the C stack (uncatchable SIGSEGV; the surrounding `lua_pcall` can't catch it). Capped depth at **flatten** — the single upstream choke point, keyed off `len(cur)` — so the flat tree and every render pass over it are bounded to `MAX_VIEW_DEPTH` (256), mirroring the EDN parser's `MAX_NESTING`. Capping at flatten means the render passes can no longer receive an over-deep tree, so no change was needed there. Deeper subtrees are dropped with a one-time warning.

### Tests
New bridge unit tests (TDD — both watched fail first):
- `test_clear_node_unrefs_button_click_ctx` — detects the leak via Lua 5.1/LuaJIT ref-freelist reuse.
- `test_flatten_caps_deep_nesting` — a 1000-deep tree must flatten to depth ≤ cap.

Both share a `g_test_bridge_global_mutex` (mirrors `g_test_http_state_mutex`) since they mutate the package-global `g_bridge` under the parallel test runner.

### Verification
- `odin test src/redin/bridge` → 67 tests pass (parallel, no leaks)
- release build OK; dev build + `test_button` UI suite headless → 8/8, no leak/bad-free on shutdown

Closes #165
Closes #170