### PR TITLE
fix(devserver): byte-aligned header lowercasing (#164) + shutdown drain (#168)

### DIFF
--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -130,6 +130,25 @@ sync_queue_drain :: proc(sq: ^Sync_Queue, out: ^[dynamic]^Pending_Request) {
 	sync.unlock(&sq.mu)
 }
 
+// #168: answer every request a handler enqueued and is now parked on with
+// 503 so its sync.sema_wait(&channel.done) unblocks. The render loop's
+// devserver_poll is the only other poster of `done`, and at shutdown it
+// has already exited; a parked handler can't be woken by closing the
+// socket (it's a futex wait, not a recv), so without this devserver_destroy
+// deadlocks in thread.join. Mirrors devserver_poll's ownership: respond_*
+// waits for the handler's ack, after which we own and free the channel +
+// pending.
+drain_incoming_503 :: proc(ds: ^Dev_Server) {
+	stranded: [dynamic]^Pending_Request
+	defer delete(stranded)
+	sync_queue_drain(&ds.incoming, &stranded)
+	for req in stranded {
+		respond_json_error(req.response, 503, `{"error":"server shutting down"}`)
+		free(req.response)
+		free(req)
+	}
+}
+
 // --- Signal-driven cleanup ---
 //
 // Without this, a SIGSEGV / SIGKILL / Ctrl-C / kill -9 / OOM leaves
@@ -338,7 +357,25 @@ devserver_destroy :: proc(ds: ^Dev_Server) {
 			thread.destroy(ds.acceptor_thread)
 		}
 		// Acceptor pushed HANDLER_POOL_SIZE nils on its way out; each
-		// handler will pop one nil and exit.
+		// handler will pop one nil and exit. But a handler that already
+		// popped a real connection may be parked on channel.done waiting
+		// for a devserver_poll that will never run again (#168). Repeatedly
+		// drain `incoming` (answering 503) to wake those handlers until
+		// every handler has finished — one pass isn't enough, since a
+		// handler can pop another queued connection and re-park between
+		// drains. Only then is thread.join guaranteed not to deadlock.
+		for {
+			drain_incoming_503(ds)
+			all_done := true
+			for t in ds.handler_threads {
+				if t != nil && !thread.is_done(t) {
+					all_done = false
+					break
+				}
+			}
+			if all_done do break
+			time.sleep(time.Millisecond)
+		}
 		for t in ds.handler_threads {
 			if t != nil {
 				thread.join(t)
@@ -664,6 +701,22 @@ int_to_str :: proc(buf: []u8, val: int) -> string {
 	return string(buf[i:])
 }
 
+// ASCII-only lowercasing that preserves byte length 1:1. Header field
+// names are ASCII per RFC 7230, so folding only 'A'..'Z' is sufficient.
+// strings.to_lower iterates Unicode runes and re-encodes each invalid
+// UTF-8 byte as U+FFFD (1 byte -> 3), which desynchronizes the lowercased
+// copy from the original string; an index found in the copy then no longer
+// aligns with the original (#164). This byte-for-byte fold keeps them
+// aligned so value extraction below is always safe.
+ascii_lower :: proc(s: string, allocator := context.allocator) -> string {
+	buf := make([]u8, len(s), allocator)
+	for i in 0 ..< len(s) {
+		c := s[i]
+		buf[i] = c + 32 if c >= 'A' && c <= 'Z' else c
+	}
+	return string(buf)
+}
+
 // Case-insensitive lookup for a header value. Returns the trimmed
 // value, or "" if the header is absent.
 //
@@ -673,8 +726,12 @@ int_to_str :: proc(buf: []u8, val: int) -> string {
 // first non-boundary match short-circuited the lookup with "", which
 // turned benign URLs like /state/host:foo into spurious 403s and
 // could be turned into a Host/auth bypass by a future refactor.
+//
+// #164: lowercasing must preserve byte length (ascii_lower, not
+// strings.to_lower) so the index located in `lower` stays aligned with
+// `headers`, from which the value is sliced below.
 find_header_value :: proc(headers: string, name_lower: string) -> string {
-	lower := strings.to_lower(headers, context.temp_allocator)
+	lower := ascii_lower(headers, context.temp_allocator)
 	needle := strings.concatenate({name_lower, ":"}, context.temp_allocator)
 
 	start := 0

--- a/src/redin/bridge/devserver_headers_test.odin
+++ b/src/redin/bridge/devserver_headers_test.odin
@@ -19,6 +19,19 @@ test_find_header_value_simple :: proc(t: ^testing.T) {
 }
 
 @(test)
+test_find_header_value_invalid_utf8_before_host :: proc(t: ^testing.T) {
+	// #164: a header value with invalid UTF-8 before Host. strings.to_lower
+	// re-encodes each invalid byte as U+FFFD (1 byte -> 3), so an index
+	// located in the lowercased copy no longer aligns with the original
+	// `headers`, corrupting (or OOB-panicking on) the value-extraction
+	// slice. This is reachable PRE-AUTH via check_host_header. The lookup
+	// must stay byte-aligned and still return the real header values.
+	headers := "GET / HTTP/1.1\r\nX-Junk: \xff\xfe\xc3\x28\r\nHost: localhost:8800\r\nAuthorization: Bearer abc\r\n"
+	testing.expect_value(t, find_header_value(headers, "host"), "localhost:8800")
+	testing.expect_value(t, find_header_value(headers, "authorization"), "Bearer abc")
+}
+
+@(test)
 test_find_header_value_missing :: proc(t: ^testing.T) {
 	headers := "GET / HTTP/1.1\r\nHost: localhost:8800"
 	testing.expect_value(t, find_header_value(headers, "x-not-here"), "")

--- a/src/redin/bridge/devserver_shutdown_test.odin
+++ b/src/redin/bridge/devserver_shutdown_test.odin
@@ -1,0 +1,57 @@
+package bridge
+
+import "core:container/queue"
+import "core:sync"
+import "core:testing"
+import "core:thread"
+
+// Mirrors the relevant half of handle_one_connection: enqueue a request,
+// park on channel.done, and once woken post ack (without touching the
+// channel afterward, since the drainer owns and frees it then).
+@(private = "file")
+Drain_Test_Ctx :: struct {
+	ch:   ^Response_Channel,
+	woke: bool,
+}
+
+@(private = "file")
+drain_test_parked_handler :: proc(raw: rawptr) {
+	c := cast(^Drain_Test_Ctx)raw
+	sync.sema_wait(&c.ch.done)
+	c.woke = true
+	sync.sema_post(&c.ch.ack)
+}
+
+// Regression for #168: a handler that enqueued a request and parked on
+// channel.done is only woken by the main render loop, which has exited at
+// shutdown. drain_incoming_503 must wake every parked handler (post done +
+// observe ack) so devserver_destroy's thread.join doesn't deadlock.
+@(test)
+test_devserver_drain_incoming_wakes_parked_handler :: proc(t: ^testing.T) {
+	ds: Dev_Server
+	queue.init(&ds.incoming.q)
+	defer queue.destroy(&ds.incoming.q)
+
+	ctx := Drain_Test_Ctx {
+		ch = new(Response_Channel),
+	}
+	pending := new(Pending_Request)
+	pending.method = "GET"
+	pending.path = "/state"
+	pending.response = ctx.ch
+	sync_queue_push(&ds.incoming, pending)
+
+	h := thread.create_and_start_with_data(&ctx, drain_test_parked_handler)
+
+	// Blocks inside respond_* until the handler posts ack; on return the
+	// channel + pending have been freed and the handler has exited.
+	drain_incoming_503(&ds)
+
+	testing.expect(t, ctx.woke, "drain_incoming_503 must wake the parked handler (#168)")
+	testing.expect(t, queue.len(ds.incoming.q) == 0, "incoming queue must be empty after drain")
+
+	if ctx.woke {
+		thread.join(h)
+		thread.destroy(h)
+	}
+}


### PR DESCRIPTION
Two dev-server (`REDIN_DEV`/`REDIN_AGENT`) hardening fixes in `src/redin/bridge/devserver.odin`.

### #164 — pre-auth process crash on invalid-UTF-8 header bytes
`find_header_value` located the header index in a `strings.to_lower` copy but sliced the **original** `headers` at that index. `to_lower` re-encodes each invalid UTF-8 byte as U+FFFD (1 byte → 3), so the copy is longer than the original and the index misaligns — returning the wrong value or, with enough junk, an out-of-bounds slice that panics the whole process. Reachable **pre-auth** (`check_host_header` runs before the OPTIONS/token checks), so any local process that finds the port could crash the dev session with one request.

Fix: a byte-length-preserving `ascii_lower` (header names are ASCII per RFC 7230) so the index stays aligned with the original string.

### #168 — shutdown deadlock
Handlers process bodies on the main thread: they enqueue a `Pending_Request` and block on `sync.sema_wait(&channel.done)`, posted only by `devserver_poll` (the render loop). At shutdown that loop has exited, so a parked handler is never woken and `devserver_destroy`'s `thread.join` deadlocks forever (a futex wait can't be unblocked by closing the socket).

Fix: `drain_incoming_503`, called in a loop in `devserver_destroy` **before** joining, until every handler reports `thread.is_done` — waking each parked handler with a 503 so it finishes its request, pops the acceptor's nil sentinel, and exits. The loop (vs. a single pass) handles a handler popping another queued connection and re-parking between drains.

### Tests (both watched fail first)
- `test_find_header_value_invalid_utf8_before_host` — `\xff\xfe\xc3\x28` before `Host:`; RED returned `host:8800`/`r abc`, GREEN returns the correct values.
- `test_devserver_drain_incoming_wakes_parked_handler` — a real parked handler thread; RED never woke, GREEN wakes + reclaims.

### Verification
- `odin test src/redin/bridge` → 67 pass (no leaks)
- release build OK
- `test_devserver_pool` integration + a concurrent-requests-then-`/shutdown` stress → clean exit (no deadlock), no leaks

Closes #164
Closes #168