### PR TITLE
fix(shell): shutdown drain/UAF (#166) + SIGPIPE & stdin deadlock (#167)

### DIFF
--- a/src/redin/bridge/shell.odin
+++ b/src/redin/bridge/shell.odin
@@ -11,6 +11,24 @@ import "core:time"
 
 SHELL_DEFAULT_MAX_OUTPUT :: 16 * 1024 * 1024 // 16 MiB
 SHELL_DEFAULT_TIMEOUT_MS :: 30_000
+SHELL_MAX_STDIN :: 64 * 1024 * 1024 // 64 MiB cap on child stdin (#167)
+
+// #167: SIGPIPE's default disposition terminates the whole process. redin
+// does pipe I/O (child stdin) and socket I/O (http client, dev server), any
+// of which can write to a peer that closed its read end. Ignore SIGPIPE
+// process-wide once and handle EPIPE via return values instead. Installed
+// from shell_client_init (bridge init); idempotent.
+@(private = "file")
+g_sigpipe_ignored: bool
+
+ignore_sigpipe :: proc() {
+	if g_sigpipe_ignored do return
+	g_sigpipe_ignored = true
+	sa := linux.Sig_Action(rawptr) {
+		handler = transmute(linux.Sig_Handler_Fn)(uintptr(linux.Sig_Action_Special.SIG_IGN)),
+	}
+	linux.rt_sigaction(.SIGPIPE, &sa, (^linux.Sig_Action(rawptr))(nil))
+}
 
 Shell_Request :: struct {
 	id:               string,
@@ -31,18 +49,59 @@ Shell_Response :: struct {
 Shell_Client :: struct {
 	results:       [dynamic]Shell_Response,
 	results_mutex: sync.Mutex,
+	// #166: shutdown drain, mirroring Http_Client. Workers run on detached
+	// threads and append into `results`; freeing it while one is still in
+	// flight is a use-after-free. `workers_alive` counts workers holding a
+	// pointer into this struct (destroy waits for it to reach 0 before
+	// freeing); `processes` lets destroy kill in-flight children to bound
+	// that wait. Both `destroying` and `workers_alive` are accessed
+	// atomically.
+	destroying:    bool,
+	workers_alive: i32,
+	processes:     map[string]os.Process,
+	procs_mutex:   sync.Mutex,
 }
 
 shell_client_init :: proc(sc: ^Shell_Client) {
+	ignore_sigpipe()
 }
 
 shell_client_destroy :: proc(sc: ^Shell_Client) {
-	sync.lock(&sc.results_mutex)
-	for &r in sc.results {
-		shell_response_destroy(&r)
+	// Signal shutdown, then kill any in-flight children so their workers
+	// unblock fast, then wait (bounded) for every worker to finish before
+	// freeing state they would otherwise touch (#166).
+	sync.atomic_store(&sc.destroying, true)
+
+	sync.lock(&sc.procs_mutex)
+	for _, p in sc.processes {
+		_ = os.process_kill(p)
 	}
-	delete(sc.results)
-	sync.unlock(&sc.results_mutex)
+	sync.unlock(&sc.procs_mutex)
+
+	deadline := time.time_add(time.now(), 3 * time.Second)
+	for {
+		if sync.atomic_load(&sc.workers_alive) == 0 do break
+		if time.diff(time.now(), deadline) <= 0 do break
+		time.sleep(10 * time.Millisecond)
+	}
+
+	leaked := sync.atomic_load(&sc.workers_alive)
+	if leaked == 0 {
+		sync.lock(&sc.results_mutex)
+		for &r in sc.results {
+			shell_response_destroy(&r)
+		}
+		delete(sc.results)
+		sync.unlock(&sc.results_mutex)
+
+		sync.lock(&sc.procs_mutex)
+		delete(sc.processes)
+		sync.unlock(&sc.procs_mutex)
+	} else {
+		// A worker may still append to results / touch the maps; leak them
+		// deliberately rather than risk a use-after-free.
+		fmt.eprintfln("redin: warning: %d shell worker(s) still in flight at shutdown", leaked)
+	}
 }
 
 shell_response_destroy :: proc(r: ^Shell_Response) {
@@ -61,6 +120,9 @@ shell_client_request :: proc(sc: ^Shell_Client, req: Shell_Request) {
 	data := new(Shell_Thread_Data)
 	data.client = sc
 	data.request = req
+	// Count this worker before it starts so shell_client_destroy can wait
+	// for it (#166). The worker decrements last, after its final access.
+	sync.atomic_add(&sc.workers_alive, 1)
 	thread.create_and_start_with_data(data, shell_thread_proc, self_cleanup = true)
 }
 
@@ -76,14 +138,23 @@ shell_client_poll :: proc(sc: ^Shell_Client, results: ^[dynamic]Shell_Response) 
 @(private = "file")
 shell_thread_proc :: proc(raw_data_ptr: rawptr) {
 	data := cast(^Shell_Thread_Data)raw_data_ptr
-	response := execute_shell(data.request)
+	response := execute_shell(data.request, data.client)
 
 	sync.lock(&data.client.results_mutex)
-	append(&data.client.results, response)
+	if !sync.atomic_load(&data.client.destroying) {
+		append(&data.client.results, response)
+	} else {
+		// Client is being torn down; don't append into state it may free.
+		shell_response_destroy(&response)
+	}
 	sync.unlock(&data.client.results_mutex)
 
 	shell_request_destroy(&data.request)
+	client := data.client
 	free(data)
+	// Decrement LAST so shell_client_destroy doesn't observe 0 and free the
+	// client while we still hold a pointer into it (#166).
+	sync.atomic_sub(&client.workers_alive, 1)
 }
 
 @(private = "file")
@@ -96,12 +167,21 @@ shell_request_destroy :: proc(req: ^Shell_Request) {
 	delete(req.cmd)
 }
 
-execute_shell :: proc(req: Shell_Request) -> Shell_Response {
+execute_shell :: proc(req: Shell_Request, client: ^Shell_Client = nil) -> Shell_Response {
 	response: Shell_Response
 	response.id = strings.clone(req.id)
 
 	if len(req.cmd) == 0 {
 		response.error_msg = strings.clone("Empty command")
+		response.exit_code = -1
+		return response
+	}
+
+	// #167: bound the cloned stdin so a pathological :stdin can't pin
+	// unbounded memory; the poll-loop writer below handles any size safely,
+	// this is just a documented ceiling.
+	if len(req.stdin) > SHELL_MAX_STDIN {
+		response.error_msg = fmt.aprintf("shell stdin exceeds %d MiB cap", SHELL_MAX_STDIN / (1024 * 1024))
 		response.exit_code = -1
 		return response
 	}
@@ -208,11 +288,37 @@ execute_shell :: proc(req: Shell_Request) -> Shell_Response {
 		return response
 	}
 
-	// Write stdin
-	if stdin_w != nil {
-		os.write(stdin_w, transmute([]u8)req.stdin)
-		os.close(stdin_w)
+	// #166: register the child so shell_client_destroy can kill it to bound
+	// the shutdown drain. Check `destroying` under the same lock so a request
+	// racing destroy can't leave an unkillable child running; unregister on
+	// every return path via the defer below.
+	if client != nil {
+		sync.lock(&client.procs_mutex)
+		if sync.atomic_load(&client.destroying) {
+			sync.unlock(&client.procs_mutex)
+			_ = os.process_kill(process)
+			_, _ = os.process_wait(process)
+			if stdin_w != nil do os.close(stdin_w)
+			response.error_msg = strings.clone("shell client shutting down")
+			response.exit_code = -1
+			return response
+		}
+		client.processes[req.id] = process
+		sync.unlock(&client.procs_mutex)
 	}
+	defer if client != nil {
+		sync.lock(&client.procs_mutex)
+		delete_key(&client.processes, req.id)
+		sync.unlock(&client.procs_mutex)
+	}
+
+	// #167: stdin is fed inside the poll loop below (POLLOUT) rather than
+	// with one blocking os.write. A large stdin to a child that doesn't
+	// drain it (or exits early) would otherwise block here forever -- past
+	// the timeout/output-cap checks, which only run in the read loop -- and
+	// writing to a closed read end would raise SIGPIPE (now ignored).
+	stdin_off := 0
+	stdin_done := stdin_w == nil
 
 	// Read stdout and stderr
 	stdout_buf: [dynamic]u8
@@ -253,10 +359,11 @@ execute_shell :: proc(req: Shell_Request) -> Shell_Response {
 			break
 		}
 
-		fds: [2]linux.Poll_Fd
+		fds: [3]linux.Poll_Fd
 		n_fds := 0
 		stdout_idx := -1
 		stderr_idx := -1
+		stdin_idx := -1
 		if !stdout_done {
 			fds[n_fds] = linux.Poll_Fd {
 				fd     = linux.Fd(os.fd(stdout_r)),
@@ -271,6 +378,14 @@ execute_shell :: proc(req: Shell_Request) -> Shell_Response {
 				events = {.IN},
 			}
 			stderr_idx = n_fds
+			n_fds += 1
+		}
+		if !stdin_done {
+			fds[n_fds] = linux.Poll_Fd {
+				fd     = linux.Fd(os.fd(stdin_w)),
+				events = {.OUT},
+			}
+			stdin_idx = n_fds
 			n_fds += 1
 		}
 
@@ -306,6 +421,35 @@ execute_shell :: proc(req: Shell_Request) -> Shell_Response {
 					append(&stderr_buf, ..read_buf[:n])
 				}
 			}
+			// #167: feed stdin a chunk at a time, only when the pipe is
+			// writable. A write of <= PIPE_BUF (4096) bytes is non-blocking
+			// once POLLOUT signals room, so this never blocks the loop and
+			// the timeout/cap checks above keep firing. EPIPE/HUP (child
+			// closed its read end) ends stdin without a SIGPIPE crash.
+			if stdin_idx >= 0 {
+				r := fds[stdin_idx].revents
+				if .OUT in r {
+					chunk := len(req.stdin) - stdin_off
+					if chunk > 4096 do chunk = 4096
+					n, werr := os.write(stdin_w, transmute([]u8)req.stdin[stdin_off:stdin_off + chunk])
+					if werr != nil || n <= 0 {
+						stdin_done = true
+						os.close(stdin_w)
+						stdin_w = nil
+					} else {
+						stdin_off += n
+						if stdin_off >= len(req.stdin) {
+							stdin_done = true
+							os.close(stdin_w)
+							stdin_w = nil
+						}
+					}
+				} else if .ERR in r || .HUP in r {
+					stdin_done = true
+					os.close(stdin_w)
+					stdin_w = nil
+				}
+			}
 		}
 
 		if len(stdout_buf) + len(stderr_buf) > output_cap {
@@ -321,6 +465,10 @@ execute_shell :: proc(req: Shell_Request) -> Shell_Response {
 			break
 		}
 	}
+
+	// Close the stdin pipe if the child never drained it (timeout/cap kill,
+	// or a child that exited without reading all input). #167.
+	if stdin_w != nil do os.close(stdin_w)
 
 	if killed {
 		// Reap the child to avoid a zombie. The exit_code from a SIGKILL'd

--- a/src/redin/bridge/shell_hardening_test.odin
+++ b/src/redin/bridge/shell_hardening_test.odin
@@ -1,0 +1,104 @@
+package bridge
+
+import "core:strings"
+import "core:sync"
+import "core:sys/linux"
+import "core:testing"
+import "core:thread"
+import "core:time"
+
+// #167: SIGPIPE's default disposition terminates the process. After
+// ignore_sigpipe(), a self-directed SIGPIPE must be a no-op; without the
+// fix this test binary would die (exit 141) instead of reaching the assert.
+@(test)
+test_sigpipe_ignored :: proc(t: ^testing.T) {
+	ignore_sigpipe()
+	linux.kill(linux.getpid(), .SIGPIPE)
+	testing.expect(t, true, "process survived a self-directed SIGPIPE")
+}
+
+// #167: a large :stdin to a child that never drains it must not block past
+// the timeout. The pre-fix blocking os.write ran before the read loop, so
+// the timeout/output-cap checks could never fire and the worker hung for
+// the child's entire lifetime.
+@(test)
+test_shell_large_stdin_respects_timeout :: proc(t: ^testing.T) {
+	ignore_sigpipe() // the kill-on-timeout closes the child's stdin read end
+
+	big := make([]u8, 256 * 1024) // > pipe buffer: can't be written in one go
+	defer delete(big)
+	for i in 0 ..< len(big) do big[i] = 'x'
+
+	cmd := make([]string, 2)
+	cmd[0] = strings.clone("/usr/bin/sleep")
+	cmd[1] = strings.clone("10")
+	req := Shell_Request {
+		id         = strings.clone("stdin-timeout"),
+		cmd        = cmd,
+		stdin      = strings.clone(string(big)),
+		timeout_ms = 500,
+	}
+	defer {
+		delete(req.id)
+		delete(req.stdin)
+		for s in req.cmd do delete(s)
+		delete(req.cmd)
+	}
+
+	t0 := time.now()
+	resp := execute_shell(req)
+	elapsed := time.diff(t0, time.now())
+	shell_response_destroy(&resp)
+
+	testing.expectf(
+		t,
+		elapsed < 3 * time.Second,
+		"execute_shell blocked %v on a large stdin to a non-reading child; the 500ms timeout never fired (#167)",
+		elapsed,
+	)
+}
+
+@(private = "file")
+Drain_Sim_Ctx :: struct {
+	sc:       ^Shell_Client,
+	delay_ms: int,
+}
+
+// Mimics shell_thread_proc's tail: respect `destroying`, then drop the
+// worker count last — without doing real work.
+@(private = "file")
+shell_drain_sim_worker :: proc(raw: rawptr) {
+	c := cast(^Drain_Sim_Ctx)raw
+	time.sleep(time.Duration(c.delay_ms) * time.Millisecond)
+	sync.lock(&c.sc.results_mutex)
+	// (destroying is set by the time we wake; nothing to append in the sim)
+	_ = sync.atomic_load(&c.sc.destroying)
+	sync.unlock(&c.sc.results_mutex)
+	sync.atomic_sub(&c.sc.workers_alive, 1)
+}
+
+// #166: shell_client_destroy must wait for in-flight workers to finish
+// before freeing the client, or a late worker writes into freed memory.
+@(test)
+test_shell_destroy_waits_for_inflight_worker :: proc(t: ^testing.T) {
+	sc: Shell_Client
+	shell_client_init(&sc)
+
+	sync.atomic_add(&sc.workers_alive, 1)
+	ctx := Drain_Sim_Ctx {
+		sc       = &sc,
+		delay_ms = 40,
+	}
+	h := thread.create_and_start_with_data(&ctx, shell_drain_sim_worker)
+
+	shell_client_destroy(&sc)
+
+	testing.expect(
+		t,
+		sync.atomic_load(&sc.workers_alive) == 0,
+		"shell_client_destroy returned with a worker still in flight (use-after-free risk) (#166)",
+	)
+
+	thread.join(h)
+	thread.destroy(h)
+}


### PR DESCRIPTION
Two **release-build** shell hardening fixes in `src/redin/bridge/shell.odin`.

### #166 — use-after-free on shutdown
Shell commands ran on detached threads with no in-flight tracking; `shell_client_destroy` freed `sc.results` without waiting, so a command still running at shutdown later did `append(&sc.results, …)` into freed Bridge memory.

Fix mirrors the existing `Http_Client` drain protocol: `destroying` + `workers_alive` (atomic) and a `processes` map of in-flight children. `destroy` signals shutdown, SIGKILLs registered children to unblock their workers fast, waits (bounded, 3 s) for `workers_alive` to reach 0, then frees — or, if a worker is somehow still alive, leaks + warns rather than freeing under it. Workers register/unregister their child under `procs_mutex` (with a `destroying` re-check to avoid an unkillable child racing destroy) and decrement `workers_alive` last.

### #167 — stdin deadlock + SIGPIPE host kill
Both in the single blocking stdin write that ran **before** the read loop:
- **(a) deadlock:** a large `:stdin` to a child that doesn't drain it blocked the `os.write` forever — past the timeout/output-cap checks, which only run in the read loop. stdin is now fed in ≤`PIPE_BUF` chunks **inside** the poll loop via `POLLOUT`, so it never blocks and the deadline keeps firing. Added a 64 MiB stdin ceiling.
- **(b) SIGPIPE:** writing to a child that closed its read end raised SIGPIPE, whose default disposition terminates the whole host. `ignore_sigpipe` (installed process-wide from `shell_client_init`) sets `SIGPIPE → SIG_IGN`; the write's EPIPE return is handled instead.

### Tests (TDD, watched fail first)
- `test_sigpipe_ignored` — RED: the test binary is killed by the self-directed SIGPIPE.
- `test_shell_large_stdin_respects_timeout` — 256 KiB stdin to `sleep 10`, 500 ms timeout; RED ~10 s, GREEN ~0.5 s.
- `test_shell_destroy_waits_for_inflight_worker` — destroy must drain `workers_alive` to 0 before returning.

### Verification
- `odin test src/redin/bridge` → 68 pass (no leaks); Fennel runtime → 134 pass
- release build OK
- end-to-end: `sleep 5` dispatched via `/events`, then `/shutdown` 0.4 s later → process exits cleanly in ~0.45 s (child killed, worker drained), no leak/UAF/warning

Closes #166
Closes #167