### PR TITLE
fix(http): socket read timeout (#169) + odin-http negative-slice crash guards (#163)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "lib/odin-http"]
 	path = lib/odin-http
 	url = https://github.com/sstoehrm/odin-http.git
-	branch = fix/parse-response-leak-socket-hook
+	branch = main

--- a/src/redin/bridge/http_client.odin
+++ b/src/redin/bridge/http_client.odin
@@ -494,6 +494,15 @@ execute_http_request :: proc(req: Http_Request, client: ^Http_Client = nil) -> H
 		return response
 	}
 
+	// #169: bound the socket read. The poll-side timeout in http_client_poll
+	// only synthesizes a response and frees the in-flight slot; it never
+	// touches the socket, so without this a worker parked in
+	// request_on -> recv against a hung/tarpit peer would block (and hold
+	// its fd) forever, defeating MAX_INFLIGHT_HTTP. A real receive deadline
+	// makes recv return and the worker unwind.
+	recv_timeout_ms := req.timeout_ms <= 0 ? HTTP_DEFAULT_TIMEOUT_MS : req.timeout_ms
+	net.set_option(sock, .Receive_Timeout, time.Duration(recv_timeout_ms) * time.Millisecond)
+
 	if client != nil {
 		sync.lock(&client.sockets_mutex)
 		if sync.atomic_load(&client.destroying) {

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -12,6 +12,7 @@ package bridge
 // execute_http_request reports an error rather than streaming the body.
 
 import "core:fmt"
+import "core:log"
 import "core:net"
 import "core:strings"
 import "core:sync"
@@ -617,4 +618,107 @@ test_http_destroy_drains_or_times_out :: proc(t: ^testing.T) {
 
 	testing.expect(t, elapsed < 4 * time.Second,
 		"http_client_destroy should drain within ~3 s, not hang")
+}
+
+// --- #163: malformed responses must not abort the process (negative-slice) ---
+
+@(private = "file")
+expect_no_crash_with_error :: proc(t: ^testing.T, label: string, response: string) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+	allow_open_http()
+	defer set_http_whitelist(nil)
+
+	m := mock_start(response)
+	if m == nil do testing.fail_now(t, "could not bind a mock server port")
+	defer mock_stop(m)
+
+	url := fmt.tprintf("http://127.0.0.1:%d/", m.port)
+	req := Http_Request {
+		id     = strings.clone("neg"),
+		url    = strings.clone(url),
+		method = strings.clone("GET"),
+	}
+	defer {
+		delete(req.id)
+		delete(req.url)
+		delete(req.method)
+	}
+
+	// The point of the test: this call must RETURN (with an error), not
+	// abort the whole process on a negative-index slice (#163).
+	got := execute_http_request(req)
+	defer {
+		delete(got.body)
+		delete(got.error_msg)
+		for k, v in got.headers {delete(k);delete(v)}
+		delete(got.headers)
+	}
+
+	testing.expectf(t, len(got.error_msg) > 0, "%s: expected an error, not success/crash", label)
+}
+
+@(test)
+test_http_negative_content_length_no_crash :: proc(t: ^testing.T) {
+	expect_no_crash_with_error(t, "negative Content-Length",
+		"HTTP/1.1 200 OK\r\nContent-Length: -1\r\nConnection: close\r\n\r\nx")
+}
+
+@(test)
+test_http_negative_chunk_size_no_crash :: proc(t: ^testing.T) {
+	expect_no_crash_with_error(t, "negative chunk size",
+		"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n-1\r\n")
+}
+
+@(test)
+test_http_spaceless_status_line_no_crash :: proc(t: ^testing.T) {
+	expect_no_crash_with_error(t, "spaceless status line",
+		"HTTP/1.1200OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+}
+
+// --- #169: a hung peer must not pin the worker past the timeout ---
+
+@(test)
+test_http_socket_timeout_unblocks_hung_peer :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+	allow_open_http()
+	defer set_http_whitelist(nil)
+
+	m := mock_start_slow() // accepts, reads the request, then sleeps ~2s without replying
+	if m == nil do testing.fail_now(t, "could not bind a mock server port")
+	defer mock_stop(m)
+
+	url := fmt.tprintf("http://127.0.0.1:%d/", m.port)
+	req := Http_Request {
+		id         = strings.clone("slow"),
+		url        = strings.clone(url),
+		method     = strings.clone("GET"),
+		timeout_ms = 500,
+	}
+	defer {
+		delete(req.id)
+		delete(req.url)
+		delete(req.method)
+	}
+
+	// Suppress odin-http's log.error on the expected recv timeout (Would_Block),
+	// mirroring the production worker (http_client_request sets nil_logger);
+	// otherwise the test runner counts that error log as a failure.
+	context.logger = log.nil_logger()
+
+	start := time.now()
+	got := execute_http_request(req)
+	elapsed := time.diff(start, time.now())
+	defer {
+		delete(got.body)
+		delete(got.error_msg)
+		for k, v in got.headers {delete(k);delete(v)}
+		delete(got.headers)
+	}
+
+	testing.expectf(t, elapsed < 1500 * time.Millisecond,
+		"execute_http_request blocked %v on a non-responding peer; the 500ms socket Receive_Timeout should unblock recv (#169)",
+		elapsed)
+	testing.expect(t, got.status == 0, "expected a timeout error status, not success")
 }


### PR DESCRIPTION
HTTP network hardening: one host-side change and one vendored-fork bump.

### #169 — per-request timeout doesn't unblock a hung peer
The documented timeout was enforced only poll-side (`http_client_poll` synthesizes a response and frees the in-flight slot) and never touched the socket. A worker parked in `request_on → recv` against a hung/tarpit peer blocked — holding its fd — **forever**, and since the in-flight cap counts `pending` (not live workers), freeing the slot let another request launch into another stuck worker, defeating `MAX_INFLIGHT_HTTP`.

Fix: set `net` `Receive_Timeout = timeout_ms` on the socket right after `dial`, so `recv` returns and the worker unwinds (freeing thread + fd + slot).

### #163 — negative-slice response-parse crashes (submodule bump)
Bumps the `lib/odin-http` submodule (`de976dc → 48cddfc`, **sstoehrm/odin-http#1**) to reject:
- negative `Content-Length` (default framing) — `_response_body_length`
- negative chunk size — `_response_body_chunked` (+ server-side `body.odin`)
- a space-less status line — `parse_response` (`rline_str[:si]` with `si == -1`)

Each previously drove a negative-index slice that aborted the whole redin process via the bounds-check trap (SIGILL); any server the app contacts could crash it.

### Tests (TDD, watched fail first — all in `http_client_test.odin`)
- `test_http_negative_content_length_no_crash`, `test_http_negative_chunk_size_no_crash`, `test_http_spaceless_status_line_no_crash` — drive a mock server returning each malformed response; assert `execute_http_request` returns an error. RED caught `Illegal_Instruction`; GREEN returns cleanly.
- `test_http_socket_timeout_unblocks_hung_peer` — a non-responding mock; asserts the call returns in <1.5s (GREEN ~0.5s) vs blocking until the peer closes (RED ~2s). (Logger nil'd to suppress odin-http's expected `Would_Block` error log, mirroring the production worker.)

### Verification
- `odin test src/redin/bridge` → 69 pass (no leaks)
- release build OK (compiles submodule + host)

> ⚠️ **Merge order:** the submodule PR **sstoehrm/odin-http#1** should merge first; this PR pins commit `48cddfc`, which is already pushed and fetchable, so CI/build works regardless.

Closes #169
Closes #163