### PR TITLE
fix(http): reject CRLF in request URL (#175) + duplicate in-flight ids (#174)

### DIFF
--- a/src/redin/bridge/http_client.odin
+++ b/src/redin/bridge/http_client.odin
@@ -276,11 +276,35 @@ http_client_request :: proc(hc: ^Http_Client, req: Http_Request) {
 	// both the map key and id_owned, so a single delete frees both.
 	id_clone := strings.clone(req.id)
 	sync.lock(&hc.pending_mutex)
-	hc.pending[id_clone] = Pending_Http{
-		id_owned = id_clone,
-		deadline = time.time_add(time.now(), time.Duration(timeout) * time.Millisecond),
+	_, dup := hc.pending[id_clone]
+	if !dup {
+		hc.pending[id_clone] = Pending_Http{
+			id_owned = id_clone,
+			deadline = time.time_add(time.now(), time.Duration(timeout) * time.Millisecond),
+		}
 	}
 	sync.unlock(&hc.pending_mutex)
+
+	// #174: a duplicate in-flight id would overwrite the first entry's
+	// map-key allocation (leak) and cause the second worker's real response
+	// to be dropped (ok=false on completion). Reject synchronously instead.
+	// The supported :http effect always generates unique ids; this hardens
+	// the native-bridge contract where the caller supplies req.id.
+	if dup {
+		delete(id_clone)
+		r := Http_Response {
+			id        = req.id,
+			status    = 0,
+			error_msg = strings.clone("duplicate http request id (already in flight)"),
+			headers   = make(map[string]string),
+		}
+		sync.lock(&hc.results_mutex)
+		append(&hc.results, r)
+		sync.unlock(&hc.results_mutex)
+		req := req
+		http_request_destroy(&req)
+		return
+	}
 
 	data := new(Http_Thread_Data)
 	data.client = hc
@@ -430,6 +454,16 @@ execute_http_request :: proc(req: Http_Request, client: ^Http_Client = nil) -> H
 			response.error_msg = strings.clone("http scheme must be http or https")
 			return response
 		}
+	}
+
+	// #175: the URL's path/query is written verbatim into the request line,
+	// so control bytes (CR/LF/NUL) could smuggle extra header lines or a
+	// second request. header_safe is applied to header keys/values below;
+	// apply it to the URL too, before dial.
+	if !header_safe(req.url) {
+		response.status = 0
+		response.error_msg = strings.clone("http url contains invalid character")
+		return response
 	}
 
 	// Whitelist guard. Opt-in via bridge.set_http_whitelist. M4 from issue #99.

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -618,3 +618,92 @@ test_http_destroy_drains_or_times_out :: proc(t: ^testing.T) {
 	testing.expect(t, elapsed < 4 * time.Second,
 		"http_client_destroy should drain within ~3 s, not hang")
 }
+
+// #175: the request URL is written verbatim into the request line, so
+// control bytes in the path/query could smuggle extra headers / a second
+// request. header_safe is applied to header keys/values; it must apply to
+// the URL too.
+@(test)
+test_http_url_rejects_crlf :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+	allow_open_http()
+	defer set_http_whitelist(nil)
+
+	req := Http_Request {
+		id     = strings.clone("url-crlf"),
+		url    = strings.clone("http://127.0.0.1:1/x\r\nX-Injected: 1"),
+		method = strings.clone("GET"),
+	}
+	defer {
+		delete(req.id)
+		delete(req.url)
+		delete(req.method)
+	}
+
+	got := execute_http_request(req)
+	defer {
+		delete(got.body)
+		delete(got.error_msg)
+		for k, v in got.headers {delete(k);delete(v)}
+		delete(got.headers)
+	}
+
+	testing.expect(t, got.status == 0, "expected error status for CRLF in URL")
+	testing.expectf(t, strings.contains(got.error_msg, "invalid character"),
+		"expected 'invalid character' rejection before dial, got %q (#175)", got.error_msg)
+}
+
+// #174: pending/sockets are keyed by caller-supplied req.id. Two in-flight
+// requests sharing an id make the second insert overwrite the first's
+// map-key allocation (leak) and the second's real response gets dropped.
+// http_client_request must reject a duplicate in-flight id synchronously
+// instead of starting a second worker.
+@(test)
+test_http_duplicate_id_rejected :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+	allow_open_http()
+	defer set_http_whitelist(nil)
+
+	hc: Http_Client
+	http_client_init(&hc)
+	defer http_client_destroy(&hc)
+
+	m := mock_start_slow() // accepts, then sleeps — keeps req1 in flight
+	if m == nil do testing.fail_now(t, "could not bind a mock server port")
+	defer mock_stop(m)
+
+	url := fmt.tprintf("http://127.0.0.1:%d/", m.port)
+
+	// First request: inserts pending["dup"] synchronously, then runs.
+	req1 := Http_Request {
+		id     = strings.clone("dup"),
+		url    = strings.clone(url),
+		method = strings.clone("GET"),
+	}
+	http_client_request(&hc, req1)
+	after_first := sync.atomic_load(&hc.workers_alive)
+
+	// Second request with the SAME id must be rejected without a new worker.
+	req2 := Http_Request {
+		id     = strings.clone("dup"),
+		url    = strings.clone(url),
+		method = strings.clone("GET"),
+	}
+	http_client_request(&hc, req2)
+
+	testing.expectf(t, sync.atomic_load(&hc.workers_alive) == after_first,
+		"duplicate-id request must not start another worker (#174); workers_alive %d -> %d",
+		after_first, sync.atomic_load(&hc.workers_alive))
+
+	results: [dynamic]Http_Response
+	defer delete(results)
+	http_client_poll(&hc, &results)
+	found := false
+	for &r in results {
+		if strings.contains(r.error_msg, "duplicate") do found = true
+		http_response_destroy(&r)
+	}
+	testing.expect(t, found, "expected a 'duplicate' rejection result (#174)")
+}


### PR DESCRIPTION
Two host-side `http_client.odin` robustness fixes (LOW tier).

### #175 — URL not CRLF-checked
`header_safe` (rejecting `\r \n \x00`) was applied to header keys/values but **not** to `req.url`, whose path/query is written verbatim into the request line. A URL like `http://host/x\r\nX-Injected: 1` could smuggle headers / a second request. Now `header_safe(req.url)` runs before `dial`.

### #174 — duplicate in-flight id leaks a map key + drops a response
`pending`/`sockets` are keyed by caller-supplied `req.id`. Two in-flight requests with the same id make the second insert overwrite the first's map-key allocation (heap leak) and the second worker's real response is dropped (`ok==false` on completion). Now a duplicate in-flight id is rejected synchronously with an error result, no second worker started. (Misuse-only — the `:http` effect generates unique ids — but hardens the native-bridge contract.)

### Tests (TDD, watched fail first)
- `test_http_url_rejects_crlf` — RED reached `dial` ("Request failed: Refused"); GREEN rejects with "invalid character".
- `test_http_duplicate_id_rejected` — RED started a 2nd worker (workers_alive 1→2) and the tracker flagged the leaked id clone; GREEN surfaces a "duplicate" rejection, no new worker.

`odin test src/redin/bridge` → 67 pass (no leaks); release build OK.

Closes #174
Closes #175