### PR TITLE
fix(shell): reject non-string :cmd elements (#172)

### DIFF
--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -975,6 +975,28 @@ deliver_http_response :: proc(b: ^Bridge, resp: ^Http_Response) {
 }
 
 // redin.shell(id, cmd_table, stdin) — queue async shell command
+// Reads a Lua sequence at `idx` into an owned []string. Returns ok=false
+// (after freeing any partial result) if any element is not a string, so
+// callers don't silently substitute "" for a non-string argv entry (#172).
+// lua_isstring here is strict (type == LUA_TSTRING), so numbers/bools/tables
+// are rejected rather than coerced.
+read_string_array :: proc(L: ^Lua_State, idx: i32) -> (out: []string, ok: bool) {
+	count := int(lua_objlen(L, idx))
+	out = make([]string, count)
+	for i in 0 ..< count {
+		lua_rawgeti(L, idx, i32(i + 1))
+		is_str := lua_isstring(L, -1)
+		if is_str do out[i] = strings.clone_from_cstring(lua_tostring_raw(L, -1))
+		lua_pop(L, 1)
+		if !is_str {
+			for s in out do if len(s) > 0 do delete(s)
+			delete(out)
+			return nil, false
+		}
+	}
+	return out, true
+}
+
 redin_shell :: proc "c" (L: ^Lua_State) -> i32 {
 	context = g_context
 	if g_bridge == nil do return 0
@@ -983,17 +1005,16 @@ redin_shell :: proc "c" (L: ^Lua_State) -> i32 {
 
 	if lua_isstring(L, 1) do req.id = strings.clone_from_cstring(lua_tostring_raw(L, 1))
 
-	// Read cmd table (sequential array of strings)
+	// Read cmd table (sequential array of strings).
 	if lua_istable(L, 2) {
-		cmd_idx := i32(2)
-		count := int(lua_objlen(L, cmd_idx))
-		cmd := make([]string, count)
-		for i in 0 ..< count {
-			lua_rawgeti(L, cmd_idx, i32(i + 1))
-			if lua_isstring(L, -1) {
-				cmd[i] = strings.clone_from_cstring(lua_tostring_raw(L, -1))
-			}
-			lua_pop(L, 1)
+		cmd, ok := read_string_array(L, 2)
+		if !ok {
+			// #172: a non-string argv element would otherwise become "",
+			// silently corrupting the command. Reject with an error result
+			// so the on-error handler fires instead.
+			shell_emit_error(&g_bridge.shell_client, req.id, "shell :cmd contains a non-string element")
+			if len(req.id) > 0 do delete(req.id)
+			return 0
 		}
 		req.cmd = cmd
 	}

--- a/src/redin/bridge/shell.odin
+++ b/src/redin/bridge/shell.odin
@@ -52,6 +52,21 @@ shell_response_destroy :: proc(r: ^Shell_Response) {
 	delete(r.error_msg)
 }
 
+// Append a synthesized failure result for a request rejected before it is
+// ever spawned (e.g. a malformed :cmd, #172), so the matching on-error
+// handler still fires with a clear message instead of the request silently
+// misbehaving.
+shell_emit_error :: proc(sc: ^Shell_Client, id: string, msg: string) {
+	r := Shell_Response {
+		id        = strings.clone(id),
+		exit_code = -1,
+		error_msg = strings.clone(msg),
+	}
+	sync.lock(&sc.results_mutex)
+	append(&sc.results, r)
+	sync.unlock(&sc.results_mutex)
+}
+
 Shell_Thread_Data :: struct {
 	client:  ^Shell_Client,
 	request: Shell_Request,

--- a/src/redin/bridge/shell_cmd_test.odin
+++ b/src/redin/bridge/shell_cmd_test.odin
@@ -1,0 +1,33 @@
+package bridge
+
+import "core:testing"
+
+// #172: a non-string element in the :cmd table must be rejected, not
+// silently turned into an empty-string argv entry (which corrupts the
+// command and produces a confusing "Failed to start process").
+@(test)
+test_read_string_array_rejects_non_string :: proc(t: ^testing.T) {
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	// All-string sequence -> accepted, elements preserved in order.
+	testing.expect(t, luaL_dostring(L, "return {'echo', 'hi'}") == 0, "lua build failed")
+	good, ok1 := read_string_array(L, lua_gettop(L))
+	testing.expect(t, ok1, "all-string array should be accepted")
+	testing.expect(
+		t,
+		len(good) == 2 && good[0] == "echo" && good[1] == "hi",
+		"elements should be preserved in order",
+	)
+	for s in good do delete(s)
+	delete(good)
+	lua_pop(L, 1)
+
+	// A non-string (number) element -> rejected, nil result (no partial leak).
+	testing.expect(t, luaL_dostring(L, "return {'echo', 5, 'hi'}") == 0, "lua build failed")
+	bad, ok2 := read_string_array(L, lua_gettop(L))
+	testing.expect(t, !ok2, "a non-string element must be rejected (#172)")
+	testing.expect(t, bad == nil, "rejected result must be nil (freed)")
+	lua_pop(L, 1)
+}


### PR DESCRIPTION
`redin_shell` built `req.cmd` by cloning only elements where `lua_isstring` is true (strict — `type == LUA_TSTRING`, no number coercion), leaving any non-string element as `""`. A non-string `argv[0]` became `command[0]==""` (PATH-searched the empty name → confusing `Not_Exist`/`EISDIR`); interior non-string args silently changed the command.

Fix: a `read_string_array` helper that rejects (and frees) on any non-string element; `redin_shell` surfaces a typed on-error result via `shell_emit_error` instead of queuing a corrupted command. Kept entirely in `bridge.odin` + a small `shell.odin` helper (placed away from the lifecycle code) to avoid conflicting with the open shell PR #188.

**Test (TDD):** `read_string_array` accepts an all-string sequence and rejects one containing a number (RED: the old substitute-`""` behavior accepted it).

`odin test src/redin/bridge` → 66 pass (no leaks); release build OK.

---
**#171 deferred (not in this PR):** killing the child's *process group* on timeout/cap needs the child in its own group, but `os.process_start` exposes no pre-exec hook and a post-spawn `setpgid` races the child's `exec` (EACCES). A robust fix requires a custom `fork`/`setpgid`/`execve` — left open rather than shipping a fragile partial fix.

Closes #172