### PR TITLE
fix(json): preserve embedded NUL bytes in encode/decode (#173)

### DIFF
--- a/src/redin/bridge/json.odin
+++ b/src/redin/bridge/json.odin
@@ -118,7 +118,7 @@ lua_value_to_json_inner :: proc(b: ^strings.Builder, L: ^Lua_State, index: i32, 
 	case LUA_TNUMBER:
 		json_number(b, lua_tonumber(L, abs_idx))
 	case LUA_TSTRING:
-		json_string(b, string(lua_tostring_raw(L, abs_idx)))
+		json_string(b, lua_tostring_len(L, abs_idx))
 	case LUA_TTABLE:
 		ptr := lua_topointer(L, abs_idx)
 		if ptr in ctx.path {
@@ -155,7 +155,7 @@ lua_value_to_json_inner :: proc(b: ^strings.Builder, L: ^Lua_State, index: i32, 
 				if lua_isstring(L, -2) {
 					if !first do json_comma(b)
 					first = false
-					json_key(b, string(lua_tostring_raw(L, -2)))
+					json_key(b, lua_tostring_len(L, -2))
 					lua_value_to_json_inner(b, L, -1, ctx)
 				}
 				lua_pop(L, 1)
@@ -183,7 +183,7 @@ redin_json_encode :: proc "c" (L: ^Lua_State) -> i32 {
 
 redin_json_decode :: proc "c" (L: ^Lua_State) -> i32 {
 	context = runtime.default_context()
-	s := string(lua_tostring_raw(L, 1))
+	s := lua_tostring_len(L, 1)
 	if len(s) == 0 {
 		lua_pushnil(L)
 		return 1
@@ -193,6 +193,17 @@ redin_json_decode :: proc "c" (L: ^Lua_State) -> i32 {
 		luaL_error(L, "invalid JSON")
 	}
 	return 1
+}
+
+// #173: read a Lua string with its explicit length so embedded NULs are
+// preserved. string(cstring) is strlen-based and truncates at the first NUL;
+// Lua strings carry a length and may contain NULs. Mirrors the length-carrying
+// read at bridge.odin:396.
+@(private = "file")
+lua_tostring_len :: proc(L: ^Lua_State, index: i32) -> string {
+	n: uint
+	p := lua_tolstring(L, index, &n)
+	return string(([^]u8)(p)[:n])
 }
 
 // ---------------------------------------------------------------------------

--- a/src/redin/bridge/json_nul_test.odin
+++ b/src/redin/bridge/json_nul_test.odin
@@ -1,0 +1,31 @@
+package bridge
+
+import "core:strings"
+import "core:testing"
+
+// #173: Lua strings carry an explicit length and may contain embedded NULs.
+// The encoder read values via lua_tostring_raw (strlen-based), which
+// truncates at the first NUL. It must use a length-carrying read so the full
+// value is serialized (the NUL escaped, the bytes after it preserved).
+@(test)
+test_json_encode_preserves_embedded_nul :: proc(t: ^testing.T) {
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	// "a" + NUL + "b" — 3 bytes.
+	buf := [3]u8{'a', 0, 'b'}
+	lua_pushlstring(L, cstring(raw_data(buf[:])), 3)
+
+	b := strings.builder_make()
+	defer strings.builder_destroy(&b)
+	lua_value_to_json(&b, L, lua_gettop(L))
+
+	out := strings.to_string(b)
+	// Truncating at the NUL yields `"a"`; the correct output escapes the NUL
+	// (json_string emits a 4-hex-digit \u escape) and keeps the trailing 'b'.
+	testing.expectf(t, strings.contains(out, "b"),
+		"byte after embedded NUL was dropped; got %q (#173)", out)
+	testing.expectf(t, strings.contains(out, "0000"),
+		"embedded NUL should be escaped, not dropped; got %q (#173)", out)
+}


### PR DESCRIPTION
Lua strings carry an explicit length and may contain embedded NULs. The JSON encoder read string values (`json.odin:121`) and object keys (`:158`) via `lua_tostring_raw` (`string(cstring)`, strlen-based), truncating at the first NUL; `redin_json_decode` truncated its input the same way (`:186`).

Fix: a length-carrying `lua_tostring_len` (mirrors the existing read at `bridge.odin:396`) used for JSON string values, object keys, and the decode input, so binary/framed values round-trip on the public `redin.json_encode`/`redin.json_decode` API.

**Test (TDD):** encoding a Lua string `"a\x00b"` must keep the trailing `b` and escape the NUL — RED produced just `"a"`.

`odin test src/redin/bridge` → 66 pass; release build OK.

---
**#180 deferred (not in this PR):** the `u8` path-step truncation (colliding for >256 direct siblings) can't be fixed safely in isolation — `find_node_by_path` matches paths by byte-equality, so a collision-free fix needs a wider step encoding applied **consistently** across both `lua_flatten_node` and the markdown `flatten_subtree` builders. Getting that wrong would break text-selection identity for *every* node, not just the >255 case, so it's not worth the risk for a rare, transient, self-healing mis-selection. Left open.

Closes #173