### PR TITLE
fix(input,render): UTF-8 cursor boundary (#179) + u8 scrollbar radius overflow (#181)

### DIFF
--- a/src/redin/input/codepoint_test.odin
+++ b/src/redin/input/codepoint_test.odin
@@ -1,0 +1,16 @@
+package input
+
+import "core:testing"
+
+// #179: a byte offset that lands inside a multibyte UTF-8 sequence must snap
+// back to the codepoint start, so a later insert/delete can't split it.
+@(test)
+test_clamp_to_codepoint_start :: proc(t: ^testing.T) {
+	// "aé" = 0x61 0xC3 0xA9 (the 'é' is a 2-byte sequence).
+	text := []u8{0x61, 0xC3, 0xA9}
+	testing.expect_value(t, clamp_to_codepoint_start(text, 2), 1) // continuation byte -> snap to 'é' start
+	testing.expect_value(t, clamp_to_codepoint_start(text, 1), 1) // already a boundary (lead byte)
+	testing.expect_value(t, clamp_to_codepoint_start(text, 0), 0)
+	testing.expect_value(t, clamp_to_codepoint_start(text, 3), 3) // end is a boundary
+	testing.expect_value(t, clamp_to_codepoint_start(text, 9), 3) // past end -> clamp to len
+}

--- a/src/redin/input/state.odin
+++ b/src/redin/input/state.odin
@@ -98,6 +98,19 @@ focus_leave :: proc() {
 	state.active = false
 }
 
+// Snap a byte offset back to the start of the UTF-8 codepoint it lands on,
+// so a clamped cursor/selection offset never sits on a continuation byte
+// (#179). Also clamps to [0, len(text)]; len(text) (the end) is a boundary.
+clamp_to_codepoint_start :: proc(text: []u8, off: int) -> int {
+	o := off
+	if o > len(text) do o = len(text)
+	if o < 0 do o = 0
+	for o > 0 && o < len(text) && (text[o] & 0xC0) == 0x80 {
+		o -= 1
+	}
+	return o
+}
+
 // Controlled sync: if Fennel changed the value, update the buffer.
 // Call once per frame while active. Returns true if the buffer was replaced.
 controlled_sync :: proc(node_value: string) -> bool {
@@ -107,10 +120,12 @@ controlled_sync :: proc(node_value: string) -> bool {
 	// Fennel transformed the value — replace buffer
 	clear(&state.text)
 	append(&state.text, ..transmute([]u8)node_value)
-	state.cursor = min(state.cursor, len(state.text))
+	// #179: clamp to a UTF-8 boundary, not just a byte index, or a later
+	// edit would split a multibyte codepoint the offset now lands inside.
+	state.cursor = clamp_to_codepoint_start(state.text[:], state.cursor)
 	if state.selection_start >= 0 {
-		state.selection_start = min(state.selection_start, len(state.text))
-		state.selection_end = min(state.selection_end, len(state.text))
+		state.selection_start = clamp_to_codepoint_start(state.text[:], state.selection_start)
+		state.selection_end = clamp_to_codepoint_start(state.text[:], state.selection_end)
 		if state.selection_start == state.selection_end {
 			state.selection_start = -1
 			state.selection_end = -1

--- a/src/redin/render.odin
+++ b/src/redin/render.odin
@@ -943,7 +943,7 @@ draw_box_children :: proc(
 			max_scroll := fixed_total - content_rect.height
 			scroll_ratio := scroll_off / max_scroll if max_scroll > 0 else 0
 			bar_y := content_rect.y + scroll_ratio * (content_rect.height - bar_h)
-			roundness := f32(t.radius * 2) / bar_w if bar_w > 0 else 1
+			roundness := f32(t.radius) * 2 / bar_w if bar_w > 0 else 1
 			rl.DrawRectangleRounded(
 				{bar_x, bar_y, bar_w, bar_h}, roundness, 4,
 				scrollbar_color(t),
@@ -957,7 +957,7 @@ draw_box_children :: proc(
 			max_scroll := fixed_total - content_rect.width
 			scroll_ratio := scroll_off / max_scroll if max_scroll > 0 else 0
 			bar_x := content_rect.x + scroll_ratio * (content_rect.width - bar_w)
-			roundness := f32(t.radius * 2) / bar_h if bar_h > 0 else 1
+			roundness := f32(t.radius) * 2 / bar_h if bar_h > 0 else 1
 			rl.DrawRectangleRounded(
 				{bar_x, bar_y, bar_w, bar_h}, roundness, 4,
 				scrollbar_color(t),


### PR DESCRIPTION
### #179 — cursor/selection can land mid-codepoint
`controlled_sync` clamped the cursor/selection with `min(.., len(text))` but not to a **codepoint** boundary. When app code changed `n.value` so the old byte offset now fell inside a multibyte UTF-8 sequence, the next insert/delete split the codepoint (orphaned continuation byte → malformed UTF-8 into MeasureTextEx/clipboard/the Change_Event). Added `clamp_to_codepoint_start`, applied to cursor and both selection offsets.

**Test (TDD, input pkg):** `clamp_to_codepoint_start` snaps an offset on a continuation byte back to the codepoint start — RED returned the unsnapped offset.

### #181 — u8 scrollbar radius overflow
Scrollbar roundness was `f32(t.radius * 2)` — `t.radius` is `u8`, so `t.radius * 2` wrapped in `u8` (radius 200 → 144) before the `f32` cast. Now widen first: `f32(t.radius) * 2`, matching the other radius sites in `render.odin`.

Cosmetic (raylib clamps roundness to [0,1]); package `redin` has no unit-test harness, so this is **build-verified** + covered by the existing scroll UI tests in CI.

`odin test src/redin/input` → 26 pass; release build OK.

Closes #179
Closes #181