### PR TITLE
fix(runtime): subscribe tracking save/restore (#178) + hot-reload re-evals agent/markdown/canvas (#183)

### DIFF
--- a/src/redin/bridge/hotreload.odin
+++ b/src/redin/bridge/hotreload.odin
@@ -22,6 +22,10 @@ hotreload_init :: proc(hr: ^Hot_Reload, source_tree: bool) {
 		"src/runtime/theme.fnl",
 		"src/runtime/view.fnl",
 		"src/runtime/init.fnl",
+		// #183: also watch these so editing them triggers a reload.
+		"src/runtime/agent.fnl",
+		"src/runtime/markdown.fnl",
+		"src/runtime/canvas.fnl",
 	}
 	for f in files {
 		append(&hr.watch_paths, f)
@@ -58,6 +62,14 @@ hotreload_execute :: proc(b: ^Bridge) {
 		package.loaded["theme"]    = nil
 		package.loaded["view"]     = nil
 		package.loaded["init"]     = nil
+		-- #183: these modules capture dataflow/theme at load time. Without
+		-- invalidating them, a reload re-evaluates dataflow into a fresh
+		-- module but agent/markdown/canvas keep their stale captures, so
+		-- (require :agent).install registers into the old dataflow and the
+		-- agent edit channel / overrides break for the rest of the session.
+		package.loaded["agent"]    = nil
+		package.loaded["markdown"] = nil
+		package.loaded["canvas"]   = nil
 		require("init")
 	`
 	if luaL_dostring(b.L, cstring(raw_data(code))) != 0 {

--- a/src/runtime/dataflow.fnl
+++ b/src/runtime/dataflow.fnl
@@ -153,12 +153,16 @@
         nil)
       (do
         (when sub.dirty
-          (set tracking [])
-          (let [value (sub.fn raw-db)]
-            (set sub.deps tracking)
-            (set tracking nil)
-            (set sub.cached value)
-            (set sub.dirty false)))
+          ;; #178: save/restore `tracking` (like M.dispatch) so a query fn
+          ;; that itself calls subscribe doesn't clobber it to nil, which
+          ;; would drop this sub's deps and later (ipairs nil) in flush.
+          (let [saved-tracking tracking]
+            (set tracking [])
+            (let [value (sub.fn raw-db)]
+              (set sub.deps tracking)
+              (set tracking saved-tracking)
+              (set sub.cached value)
+              (set sub.dirty false))))
         sub.cached))))
 
 ;; ===== Public API: flush =====

--- a/test/lua/test_dataflow.fnl
+++ b/test/lua/test_dataflow.fnl
@@ -430,4 +430,24 @@
     (dataflow.flush)
     (assert (= (_G.subscribe "sub/counter") 1) "globals work end-to-end")))
 
+;; #178: a subscription query that itself calls subscribe must not clobber
+;; the outer subscription's dependency tracking. The buggy code set
+;; `tracking` to nil after the nested subscribe, so the outer sub recorded
+;; deps = nil and the next flush did (ipairs nil) and errored, wedging the
+;; render tick.
+(fn t.test-nested-subscribe-preserves-tracking []
+  (setup)
+  (let [db (dataflow.init {:a 1 :b 2})]
+    (dataflow.reg-sub "sub/b" (fn [d] (dataflow.get d :b)))
+    (dataflow.reg-sub "sub/a"
+      (fn [d]
+        (dataflow.subscribe "sub/b") ;; nested subscribe
+        (dataflow.get d :a)))
+    (assert (= (dataflow.subscribe "sub/a") 1) "sub/a computes to 1")
+    ;; Record a change and flush. With the bug, sub/a.deps was nil here, so
+    ;; flush would (ipairs nil) and raise; this must complete cleanly.
+    (dataflow.assoc db :b 99)
+    (dataflow.flush)
+    (assert true "flush completed without ipairs(nil) on sub/a.deps")))
+
 t


### PR DESCRIPTION
### #178 — `subscribe` clobbers dependency tracking
`M.subscribe` set the module-global `tracking` to `nil` after running a query fn, unlike `M.dispatch` which saves/restores it. A subscription whose query *itself calls `subscribe`* therefore had its own `deps` recorded as `nil`, and the next `flush` did `(ipairs nil)` → raised → wedged the render tick (and stderr-spammed) for the session. Fix: save/restore `tracking` around the query, mirroring `M.dispatch`.

**Test (TDD, Fennel runtime):** a sub whose query calls `subscribe` for another sub must not break the next `flush` — RED raised `bad argument #1 to 'ipairs' (table expected, got nil)` at `dataflow.fnl`.

### #183 — hot reload leaves agent/markdown/canvas stale
`hotreload_execute` nil'd `package.loaded` for `dataflow/effect/frame/theme/view/init` but **not** `agent`/`markdown`/`canvas`, which capture `dataflow`/`theme` at load time. After editing any watched runtime file, those stale modules registered into the *old* `dataflow`, breaking the `REDIN_AGENT` edit channel + overrides (HTTP 500 "No handler registered for: event/agent-edit") for the rest of the session. Now invalidate them too, and add them to the watched-files list so editing them also triggers a reload.

Dev/source-tree-only path with no unit-test seam → build-verified.

`luajit … test_*.fnl` → 135 pass; `odin test src/redin/bridge` → 65 pass; release build OK.

Closes #178
Closes #183