### PR TITLE
fix(canvas): free provider name-key on unregister/re-register (#182)

### DIFF
--- a/.claude/skills/redin-maintenance/SKILL.md
+++ b/.claude/skills/redin-maintenance/SKILL.md
@@ -35,6 +35,7 @@ odin test src/redin/markdown -collection:lib=lib -collection:luajit=vendor/luaji
 odin test src/redin/profile  -collection:lib=lib -collection:luajit=vendor/luajit
 odin test src/redin/input    -collection:lib=lib -collection:luajit=vendor/luajit -define:ODIN_TEST_THREADS=1
 odin test src/redin/bridge   -collection:lib=lib -collection:luajit=vendor/luajit
+odin test src/redin/canvas   -collection:lib=lib -collection:luajit=vendor/luajit
 ```
 
 When you add a new `src/redin/<pkg>/*_test.odin`, add a matching step to `.github/workflows/test.yml` so the suite stays visible in CI. The `input` package needs `-define:ODIN_TEST_THREADS=1` until #118 lands; once it does, drop the flag here and in the workflow.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Run Odin bridge tests
         run: odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit
 
+      - name: Run Odin canvas tests
+        run: odin test src/redin/canvas -collection:lib=lib -collection:luajit=vendor/luajit
+
       - name: Build redin
         run: |
           mkdir -p build

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -537,7 +537,8 @@ fennel_canvas_provider := canvas.Canvas_Provider {
 redin_canvas_register :: proc "c" (L: ^Lua_State) -> i32 {
 	context = g_context
 	if lua_isstring(L, 1) {
-		name := strings.clone_from_cstring(lua_tostring_raw(L, 1))
+		// #182: pass a transient name; canvas.register clones and owns the key.
+		name := string(lua_tostring_raw(L, 1))
 		canvas.register(name, fennel_canvas_provider)
 	}
 	return 0

--- a/src/redin/canvas/canvas.odin
+++ b/src/redin/canvas/canvas.odin
@@ -7,6 +7,7 @@ package canvas
 REDIN_DEV :: #config(REDIN_DEV, false)
 
 import "core:fmt"
+import "core:strings"
 import rl "vendor:raylib"
 
 Canvas_Provider :: struct {
@@ -23,27 +24,40 @@ Canvas_Lifecycle :: enum {
 }
 
 Canvas_Entry :: struct {
-	provider:  Canvas_Provider,
-	lifecycle: Canvas_Lifecycle,
-	visited:   bool,
+	provider:   Canvas_Provider,
+	lifecycle:  Canvas_Lifecycle,
+	visited:    bool,
+	name_owned: string, // #182: heap-owned map key; freed on unregister/destroy
 }
 
 entries: map[string]Canvas_Entry
 current_name: string
 
 register :: proc(name: string, provider: Canvas_Provider) {
-	if existing, ok := entries[name]; ok {
+	if existing, ok := &entries[name]; ok {
 		when REDIN_DEV {
 			fmt.eprintfln("redin: warn: canvas.register(%q) replaces an existing provider", name)
 		}
 		if existing.provider.stop != nil {
 			existing.provider.stop()
 		}
+		// #182: reuse the existing owned key; only the value changes. (The
+		// incoming `name` is transient — Odin keeps the original map key on
+		// assignment to an existing slot — so storing it would dangle and
+		// re-cloning it would leak.)
+		existing.provider = provider
+		existing.lifecycle = .Idle
+		existing.visited = false
+		return
 	}
-	entries[name] = Canvas_Entry {
-		provider  = provider,
-		lifecycle = .Idle,
-		visited   = false,
+	// #182: own the key so it can be freed on unregister/destroy. Callers
+	// pass a transient name.
+	owned := strings.clone(name)
+	entries[owned] = Canvas_Entry {
+		provider   = provider,
+		lifecycle  = .Idle,
+		visited    = false,
+		name_owned = owned,
 	}
 }
 
@@ -52,7 +66,10 @@ unregister :: proc(name: string) {
 		if entry.provider.stop != nil {
 			entry.provider.stop()
 		}
+		// #182: free the heap-owned key; delete_key only erases the slot.
+		key := entry.name_owned
 		delete_key(&entries, name)
+		delete(key)
 	}
 }
 
@@ -96,13 +113,12 @@ end_frame :: proc() {
 
 // Called on shutdown. Stops all providers and clears the registry.
 destroy :: proc() {
-	for k, &entry in entries {
+	for _, &entry in entries {
 		if entry.provider.stop != nil {
 			entry.provider.stop()
 		}
-		// Keys are heap-allocated by redin_canvas_register; the map
-		// doesn't own them, so we have to delete each one explicitly.
-		delete(k)
+		// #182: keys are heap-cloned in `register` (name_owned); free each.
+		delete(entry.name_owned)
 	}
 	delete(entries)
 }

--- a/src/redin/canvas/canvas_test.odin
+++ b/src/redin/canvas/canvas_test.odin
@@ -1,0 +1,41 @@
+package canvas
+
+import "core:mem"
+import "core:testing"
+
+// #182: register clones the provider name as the map key; unregister (and
+// re-registration) must free it. Track allocations across a full
+// register/re-register/unregister cycle and assert nothing leaks once the
+// (empty) registry backing is torn down.
+@(test)
+test_canvas_register_unregister_frees_key :: proc(t: ^testing.T) {
+	track: mem.Tracking_Allocator
+	mem.tracking_allocator_init(&track, context.allocator)
+	old := context.allocator
+	context.allocator = mem.tracking_allocator(&track)
+	defer {
+		context.allocator = old
+		mem.tracking_allocator_destroy(&track)
+	}
+
+	// Isolate from the package-global registry for the duration of the test.
+	saved := entries
+	entries = nil
+	defer entries = saved
+
+	register("prov", Canvas_Provider{})
+	register("prov", Canvas_Provider{}) // re-register must not leak a second key
+	unregister("prov") // must free the cloned key
+
+	// Tear down the now-empty registry; only a leaked key would survive.
+	delete(entries)
+	entries = nil
+
+	leaks := len(track.allocation_map)
+	testing.expectf(
+		t,
+		leaks == 0,
+		"canvas register/re-register/unregister leaked %d allocation(s) (#182)",
+		leaks,
+	)
+}


### PR DESCRIPTION
The provider name was heap-cloned by `redin_canvas_register` and stored as the registry map key, but two paths leaked it:
- `unregister` → `delete_key` erases the slot but never frees the key string;
- re-registering an existing name discarded the *new* clone (Odin keeps the original key on assignment to an existing slot).

Fix: `canvas.register` now owns the key lifecycle — it clones the (transient) name into `Canvas_Entry.name_owned` for a new provider, **reuses** the existing key on re-registration, and `unregister`/`destroy` free `name_owned`. `redin_canvas_register` stops cloning.

**Test (TDD):** a `mem.Tracking_Allocator` over a register → re-register → unregister cycle asserts zero outstanding allocations once the (empty) registry backing is torn down — RED leaked 1. Adds an `odin test src/redin/canvas` CI step and updates the maintenance skill's package list.

`odin test src/redin/canvas` → 1 pass; release build OK.

Closes #182