### PR TITLE
fix(devserver): reject non-finite /input/scroll deltas (#184) + anchor find_content_length (#185)

### DIFF
--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -730,15 +730,11 @@ constant_time_eq :: proc(a: string, b: string) -> bool {
 }
 
 find_content_length :: proc(headers: string) -> int {
-	lower := strings.to_lower(headers, context.temp_allocator)
-	idx := strings.index(lower, "content-length:")
-	if idx < 0 do return 0
-	// Trim from `lower` (same index) so lookup and extraction don't
-	// reference different case representations of the header block.
-	rest := strings.trim_left_space(lower[idx + len("content-length:"):])
-	end := strings.index_any(rest, "\r\n")
-	if end < 0 do end = len(rest)
-	val := strings.trim_space(rest[:end])
+	// #185: reuse find_header_value, which skips the request line and
+	// anchors to a line start, so a "content-length:<n>" substring inside
+	// the request-line URL/query is no longer mistaken for the header
+	// (the previous unanchored strings.index matched it).
+	val := find_header_value(headers, "content-length")
 	n := 0
 	digits := 0
 	for c in val {
@@ -2037,6 +2033,14 @@ handle_post_input_scroll :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: s
 	y := get_num(L, "y")
 	dx := get_num(L, "delta_x")
 	dy := get_num(L, "delta_y")
+	// #184: reject non-finite values (mirrors /click and /input/mouse/move).
+	// A +Inf delta passes apply_scroll_events' clamps and poisons the
+	// scroll offset, and /scroll-info would then emit invalid JSON (%g Inf).
+	if math.is_nan(x) || math.is_inf(x) || math.is_nan(y) || math.is_inf(y) ||
+	   math.is_nan(dx) || math.is_inf(dx) || math.is_nan(dy) || math.is_inf(dy) {
+		respond_json_error(ch, 400, `{"error":"x/y/delta_x/delta_y must be finite"}`)
+		return
+	}
 	append(&ds.event_queue, types.InputEvent(types.ScrollEvent{
 		x = x, y = y, delta_x = dx, delta_y = dy,
 	}))

--- a/src/redin/bridge/devserver_headers_test.odin
+++ b/src/redin/bridge/devserver_headers_test.odin
@@ -125,3 +125,12 @@ test_find_content_length_zero :: proc(t: ^testing.T) {
 	headers := "GET / HTTP/1.1\r\nContent-Length: 0\r\n"
 	testing.expect_value(t, find_content_length(headers), 0)
 }
+
+@(test)
+test_find_content_length_ignores_request_line :: proc(t: ^testing.T) {
+	// #185: "content-length:" inside the request-line URL/query must not be
+	// parsed as the body length (find_content_length now skips the request
+	// line via find_header_value, like the #78 hardening for other headers).
+	headers := "GET /state/x?content-length:9 HTTP/1.1\r\nHost: localhost:8800\r\n"
+	testing.expect_value(t, find_content_length(headers), 0)
+}


### PR DESCRIPTION
Two dev-server (`REDIN_DEV`/`REDIN_AGENT`) robustness fixes in `devserver.odin`.

### #184 — `/input/scroll` accepts non-finite deltas
`handle_post_input_scroll` read `x/y/delta_x/delta_y` as `f32` with **no** finiteness check, unlike `/click` and `/input/mouse/move`. A finite-as-`f64` but `f32`-overflowing delta (e.g. `1e300` → `+Inf`) passed `apply_scroll_events`' clamps, poisoning the scroll offset to `Inf` and making `/scroll-info` emit invalid JSON (`%g` Inf). Now reject `NaN`/`Inf` with 400, mirroring the other input handlers.

### #185 — `find_content_length` unanchored substring match
It used an unanchored `strings.index` over the whole header block (including the request line), so a `content-length:<n>` substring in the request-line URL/query was parsed as the body length (~2 s latency or a spurious 400). Now reuse `find_header_value`, which skips the request line and anchors to a line start (the #78 hardening).

### Tests
- `test_find_content_length_ignores_request_line` — RED returned `9` from the request-line substring, GREEN returns `0`; existing content-length tests still pass.
- #184 verified by integration: `POST /input/scroll {"delta_y":1e300}` → **400** (`"… must be finite"`) and `/scroll-info` stays valid JSON.

`odin test src/redin/bridge` → 66 pass; release build OK.

Closes #184
Closes #185