### PR TITLE
fix(http): odin-http SSL + response-header leak fixes (#176, #177)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "lib/odin-http"]
 	path = lib/odin-http
 	url = https://github.com/sstoehrm/odin-http.git
-	branch = fix/parse-response-leak-socket-hook
+	branch = main

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -12,6 +12,7 @@ package bridge
 // execute_http_request reports an error rather than streaming the body.
 
 import "core:fmt"
+import "core:mem"
 import "core:net"
 import "core:strings"
 import "core:sync"
@@ -617,4 +618,53 @@ test_http_destroy_drains_or_times_out :: proc(t: ^testing.T) {
 
 	testing.expect(t, elapsed < 4 * time.Second,
 		"http_client_destroy should drain within ~3 s, not hang")
+}
+
+// #177: parse_response cloned header keys/values into res.headers, but on a
+// malformed-header error return only the scanner was destroyed — the headers
+// map (and the bytes cloned before the bad line) leaked, since redin's caller
+// net.closes rather than response_destroy on error. A valid header followed
+// by a colon-less line exercises that path.
+@(test)
+test_http_malformed_response_no_header_leak :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+	allow_open_http()
+	defer set_http_whitelist(nil)
+
+	m := mock_start("HTTP/1.1 200 OK\r\nX-Good: 1\r\nMalformedHeaderNoColon\r\n\r\n")
+	if m == nil do testing.fail_now(t, "could not bind a mock server port")
+	defer mock_stop(m)
+	url := fmt.tprintf("http://127.0.0.1:%d/", m.port)
+
+	track: mem.Tracking_Allocator
+	mem.tracking_allocator_init(&track, context.allocator)
+	old := context.allocator
+	context.allocator = mem.tracking_allocator(&track)
+	defer {
+		context.allocator = old
+		mem.tracking_allocator_destroy(&track)
+	}
+
+	req := Http_Request {
+		id     = strings.clone("hdr-leak"),
+		url    = strings.clone(url),
+		method = strings.clone("GET"),
+	}
+	got := execute_http_request(req)
+
+	// Free everything redin owns from the (error) response. got.id aliases
+	// req.id (response.id = req.id), so free it once via got.id.
+	delete(req.url)
+	delete(req.method)
+	delete(got.id)
+	delete(got.body)
+	delete(got.error_msg)
+	for k, v in got.headers {delete(k);delete(v)}
+	delete(got.headers)
+
+	leaks := len(track.allocation_map)
+	testing.expectf(t, leaks == 0,
+		"malformed response leaked %d allocation(s) — parse_response must free its partial headers (#177)",
+		leaks)
 }


### PR DESCRIPTION
Bumps the `lib/odin-http` submodule to `e5290c7` (**sstoehrm/odin-http#3**) and tracks `main`.

### #176 — SSL/SSL_CTX leaked on HTTPS error paths
`request_on` only freed the OpenSSL objects on the success path (via `res._socket` → `response_destroy`); they leaked on every HTTPS handshake (`Controlled_Shutdown`/`Fatal_Shutdown`), `SSL_write`, and `parse_response` failure. Now a single `defer if err != nil { SSL_free; SSL_CTX_free }` over the HTTPS branch frees them (no double-free — callers `net.close` an errored response, never `response_destroy`).

### #177 — response headers leaked on a malformed response
`parse_response` initialized `res.headers` and cloned keys/values, but on any error return only the scanner was destroyed — the headers map + cloned bytes (+ cookies) leaked. Now frees the partial response on error, mirroring `response_destroy`.

### Tests
- `test_http_malformed_response_no_header_leak` (TDD) — a `mem.Tracking_Allocator` over `execute_http_request` against a mock returning a valid header then a colon-less line asserts **zero** outstanding allocations. RED (pinned to the pre-fix `8047db5`) leaked **3** (headers map + cloned key/value); GREEN (`e5290c7`) leaks 0.
- #176's HTTPS-failure SSL leak is build- and regression-verified (an in-process TLS-handshake-failure mock is impractical).

`odin test src/redin/bridge` → 66 pass; release build OK.

> **Supersedes the submodule bump in #189:** `e5290c7` is a descendant of `8047db5`, so it already includes the #163 negative-slice guards **plus** #176/#177. If both merge, this pin wins; they touch the same gitlink/`.gitmodules`, so expect a trivial conflict resolved in favor of `e5290c7`.

Closes #176
Closes #177