### PR TITLE
fix(security): cap DoS vectors in dev server + layout (#162 H1/H2/H3)

### DIFF
--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -50,6 +50,13 @@ Sync_Queue :: struct {
 // beats a 2-second timer to keep the server fully wedged.
 HANDLER_POOL_SIZE :: 16
 
+// #162 H2: hard cap on connections queued for a handler. The acceptor
+// drops (closes) any connection arriving past this, so a client opening
+// sockets faster than the handler pool drains them can't grow
+// accepted_conns — and the fds it pins — without bound. Sized well above
+// HANDLER_POOL_SIZE so legitimate bursts still queue comfortably.
+MAX_PENDING_CONNS :: 256
+
 Pending_Conn :: struct {
 	socket: net.TCP_Socket,
 }
@@ -65,6 +72,23 @@ conn_push :: proc(cq: ^Conn_Queue, c: ^Pending_Conn) {
 	queue.push_back(&cq.q, c)
 	sync.unlock(&cq.mu)
 	sync.sema_post(&cq.sema)
+}
+
+// conn_try_push enqueues `c` only while the queue holds fewer than
+// `max_len` entries, returning false (without enqueuing) when full so the
+// caller can close the socket instead of leaking it. The nil shutdown
+// sentinel always enqueues — handlers must observe the stop signal even
+// when the queue is saturated. #162 H2.
+conn_try_push :: proc(cq: ^Conn_Queue, c: ^Pending_Conn, max_len: int) -> bool {
+	sync.lock(&cq.mu)
+	if c != nil && queue.len(cq.q) >= max_len {
+		sync.unlock(&cq.mu)
+		return false
+	}
+	queue.push_back(&cq.q, c)
+	sync.unlock(&cq.mu)
+	sync.sema_post(&cq.sema)
+	return true
 }
 
 conn_pop_blocking :: proc(cq: ^Conn_Queue) -> ^Pending_Conn {
@@ -444,7 +468,13 @@ acceptor_thread_proc :: proc(ds: ^Dev_Server) {
 		}
 		pc := new(Pending_Conn)
 		pc.socket = client
-		conn_push(&ds.accepted_conns, pc)
+		// #162 H2: refuse to grow the pending queue without bound. On
+		// overflow, close the socket and drop it rather than pinning the
+		// fd + allocation until a handler frees up.
+		if !conn_try_push(&ds.accepted_conns, pc, MAX_PENDING_CONNS) {
+			net.close(pc.socket)
+			free(pc)
+		}
 	}
 	// Wake every handler so they observe the nil sentinel and exit.
 	for _ in 0 ..< HANDLER_POOL_SIZE {
@@ -816,6 +846,7 @@ status_text :: proc(code: int) -> string {
 	case 404: return "404 Not Found"
 	case 405: return "405 Method Not Allowed"
 	case 408: return "408 Request Timeout"
+	case 413: return "413 Payload Too Large"
 	case 500: return "500 Internal Server Error"
 	case:     return "200 OK"
 	}
@@ -2216,7 +2247,29 @@ handle_put_aspects :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string)
 
 // --- Screenshot ---
 
+// #162 H3: upper bound on the pixel count /screenshot will capture.
+// LoadImageFromScreen + ExportImageToMemory allocate an RGBA buffer plus
+// a PNG-encoded copy; at the 8192x8192 window /resize permits that is
+// ~256 MB transient per call, so an authenticated caller could OOM the
+// host by driving the window large and hammering the endpoint. 16 MP sits
+// comfortably above any real display while capping that allocation.
+MAX_SCREENSHOT_PIXELS :: 16 * 1024 * 1024
+
+// Pure predicate so the cap is unit-testable without a GL context: a
+// capture is allowed only when both dimensions are positive and their
+// product is within the cap. Multiply in i64 to avoid i32 overflow at
+// the extreme dimensions /resize allows.
+screenshot_dims_ok :: proc(width, height: int) -> bool {
+	if width <= 0 || height <= 0 do return false
+	return i64(width) * i64(height) <= i64(MAX_SCREENSHOT_PIXELS)
+}
+
 handle_screenshot :: proc(ch: ^Response_Channel) {
+	// #162 H3: reject oversized captures before any allocation happens.
+	if !screenshot_dims_ok(int(rl.GetScreenWidth()), int(rl.GetScreenHeight())) {
+		respond_text(ch, 413, "Screenshot exceeds maximum size")
+		return
+	}
 	// Encode PNG in-memory (no temp file). Avoids the fixed-path
 	// TOCTOU where a local attacker could symlink-swap a predictable
 	// /tmp path between export and readback. Raylib returns a buffer

--- a/src/redin/bridge/devserver_pending_cap_test.odin
+++ b/src/redin/bridge/devserver_pending_cap_test.odin
@@ -1,0 +1,74 @@
+package bridge
+
+// Tests for the acceptor's pending-connection bound (#162 H2). The
+// acceptor previously pushed every accepted socket onto accepted_conns
+// with no upper bound, so a client opening connections faster than the
+// 16-handler pool drains them grows the queue (and the held fds)
+// without limit — a memory / fd-exhaustion DoS. conn_try_push refuses
+// to enqueue past MAX_PENDING_CONNS so the acceptor can close the
+// straggler instead.
+
+import "core:container/queue"
+import "core:testing"
+
+@(test)
+test_conn_try_push_enforces_cap :: proc(t: ^testing.T) {
+	cq: Conn_Queue
+	queue.init(&cq.q)
+	defer queue.destroy(&cq.q)
+
+	CAP :: 4
+	conns: [CAP]^Pending_Conn
+	for i in 0 ..< CAP {
+		conns[i] = new(Pending_Conn)
+		ok := conn_try_push(&cq, conns[i], CAP)
+		testing.expectf(t, ok, "push %d within cap should succeed", i)
+	}
+
+	// Queue is now full. The next push must be refused without growing
+	// the queue, so the caller knows to close the socket itself.
+	overflow := new(Pending_Conn)
+	defer free(overflow)
+	ok := conn_try_push(&cq, overflow, CAP)
+	testing.expect(t, !ok, "push beyond cap must be rejected")
+	testing.expect_value(t, queue.len(cq.q), CAP)
+
+	// Drain + free the accepted entries.
+	for _ in 0 ..< CAP {
+		got := conn_pop_blocking(&cq)
+		free(got)
+	}
+}
+
+@(test)
+test_conn_try_push_nil_sentinel_bypasses_cap :: proc(t: ^testing.T) {
+	// The shutdown sentinel (nil) must always enqueue regardless of the
+	// cap — handlers can only observe the stop signal if it reaches the
+	// queue. A full queue at shutdown must not swallow the sentinel.
+	cq: Conn_Queue
+	queue.init(&cq.q)
+	defer queue.destroy(&cq.q)
+
+	pc := new(Pending_Conn)
+	ok := conn_try_push(&cq, pc, 1)
+	testing.expect(t, ok, "first push fills the cap")
+
+	// Even though the queue is at cap, a nil sentinel still goes in.
+	ok2 := conn_try_push(&cq, nil, 1)
+	testing.expect(t, ok2, "nil sentinel must bypass the cap")
+	testing.expect_value(t, queue.len(cq.q), 2)
+
+	got1 := conn_pop_blocking(&cq)
+	testing.expect(t, got1 == pc, "first pop is the real conn")
+	free(got1)
+	got2 := conn_pop_blocking(&cq)
+	testing.expect(t, got2 == nil, "second pop is the sentinel")
+}
+
+@(test)
+test_max_pending_conns_constant :: proc(t: ^testing.T) {
+	// Pool bound is part of the contract; pin it so an accidental tweak
+	// trips this test. Sized well above HANDLER_POOL_SIZE (16) so normal
+	// bursts queue fine, but low enough to cap a flood. #162 H2.
+	testing.expect_value(t, MAX_PENDING_CONNS, 256)
+}

--- a/src/redin/bridge/devserver_screenshot_cap_test.odin
+++ b/src/redin/bridge/devserver_screenshot_cap_test.odin
@@ -1,0 +1,54 @@
+package bridge
+
+// Tests for the /screenshot pixel cap (#162 H3). handle_screenshot
+// allocates an RGBA frame buffer plus a PNG-encoded copy via raylib. At
+// the maximum window size /resize allows (8192x8192) that is ~256 MB of
+// transient allocation per request — an authenticated caller can drive
+// the window large then hammer /screenshot to OOM the host. The cap
+// rejects captures whose pixel count exceeds MAX_SCREENSHOT_PIXELS
+// before any allocation happens.
+
+import "core:testing"
+
+@(test)
+test_screenshot_dims_ok_accepts_normal :: proc(t: ^testing.T) {
+	testing.expect(t, screenshot_dims_ok(1920, 1080), "1080p is well under the cap")
+	testing.expect(t, screenshot_dims_ok(1, 1), "a 1x1 capture is fine")
+}
+
+@(test)
+test_screenshot_dims_ok_rejects_oversize :: proc(t: ^testing.T) {
+	// 8192x8192 = 67 MP, far past the 16 MP cap.
+	testing.expect(t, !screenshot_dims_ok(8192, 8192), "max-window capture must be rejected")
+}
+
+@(test)
+test_screenshot_dims_ok_boundary :: proc(t: ^testing.T) {
+	// Exactly at the cap is allowed; one pixel over is not.
+	testing.expect(t, screenshot_dims_ok(MAX_SCREENSHOT_PIXELS, 1), "exactly the cap is allowed")
+	testing.expect(t, !screenshot_dims_ok(MAX_SCREENSHOT_PIXELS + 1, 1), "one over the cap is rejected")
+}
+
+@(test)
+test_screenshot_dims_ok_rejects_nonpositive :: proc(t: ^testing.T) {
+	// A degenerate window (minimized / zero-area) has nothing to capture
+	// and must not reach the allocator with a zero or negative extent.
+	testing.expect(t, !screenshot_dims_ok(0, 1080), "zero width is rejected")
+	testing.expect(t, !screenshot_dims_ok(1920, 0), "zero height is rejected")
+	testing.expect(t, !screenshot_dims_ok(-1, -1), "negative dims are rejected")
+}
+
+@(test)
+test_max_screenshot_pixels_constant :: proc(t: ^testing.T) {
+	// 16 MP — comfortably above any real display, well below the
+	// 8192x8192 (67 MP) ceiling /resize permits. #162 H3.
+	testing.expect_value(t, MAX_SCREENSHOT_PIXELS, 16 * 1024 * 1024)
+}
+
+@(test)
+test_status_text_has_413 :: proc(t: ^testing.T) {
+	// handle_screenshot replies 413 when the capture is too large; the
+	// status line must say 413, not fall through to the "200 OK" default.
+	// #162 H3.
+	testing.expect_value(t, status_text(413), "413 Payload Too Large")
+}

--- a/src/redin/layout_depth_test.odin
+++ b/src/redin/layout_depth_test.odin
@@ -1,0 +1,31 @@
+package redin
+
+// Defense-in-depth backstop for the layout / intrinsic-height recursion
+// (#162 H1). The bridge flatten pass already caps view-tree depth at
+// bridge.MAX_VIEW_DEPTH (#170), which bounds every render walk over the
+// flat tree — so this backstop never trips on a legitimate tree. It
+// exists only so a future change to the flatten cap (or a new path that
+// builds the flat arrays) can't silently reintroduce the unbounded
+// native-stack recursion H1 describes.
+
+import "bridge"
+import "core:testing"
+
+@(test)
+test_layout_depth_within_bound :: proc(t: ^testing.T) {
+	testing.expect(t, !layout_depth_exceeded(0), "depth 0 is fine")
+	testing.expect(t, !layout_depth_exceeded(LAYOUT_DEPTH_BACKSTOP), "exactly the backstop is allowed")
+}
+
+@(test)
+test_layout_depth_past_bound :: proc(t: ^testing.T) {
+	testing.expect(t, layout_depth_exceeded(LAYOUT_DEPTH_BACKSTOP + 1), "one past the backstop is refused")
+}
+
+@(test)
+test_layout_backstop_exceeds_flatten_cap :: proc(t: ^testing.T) {
+	// Keep the backstop strictly above the flatten cap so it never trips
+	// on an already-bounded tree and only catches a regression that lets
+	// a deeper flat tree through. #162 H1, #170.
+	testing.expect(t, LAYOUT_DEPTH_BACKSTOP > bridge.MAX_VIEW_DEPTH, "backstop must exceed the flatten cap")
+}

--- a/src/redin/render.odin
+++ b/src/redin/render.odin
@@ -211,22 +211,29 @@ layout_node :: proc(
 	nodes: []types.Node,
 	children_list: []types.Children,
 	theme: map[string]types.Theme,
+	depth := 0,
 ) {
 	if idx < 0 || idx >= len(nodes) do return
+	// #162 H1: backstop the layout recursion symmetrically with the
+	// intrinsic-height walk. Unreachable behind the flatten cap (#170).
+	if layout_depth_exceeded(depth) {
+		warn_layout_depth()
+		return
+	}
 	node_rects[idx] = rect
 	node_content_rects[idx] = rect
 
 	switch n in nodes[idx] {
 	case types.NodeStack:
 		if len(n.viewport) > 0 {
-			layout_children_viewport(idx, n, nodes, children_list, theme)
+			layout_children_viewport(idx, n, nodes, children_list, theme, depth)
 		} else {
-			layout_children_stack(idx, rect, nodes, children_list, theme)
+			layout_children_stack(idx, rect, nodes, children_list, theme, depth)
 		}
 	case types.NodeVbox:
-		layout_box(idx, rect, n.aspect, n.layout, true, n.overflow, nodes, children_list, theme)
+		layout_box(idx, rect, n.aspect, n.layout, true, n.overflow, nodes, children_list, theme, depth)
 	case types.NodeHbox:
-		layout_box(idx, rect, n.aspect, n.layout, false, n.overflow, nodes, children_list, theme)
+		layout_box(idx, rect, n.aspect, n.layout, false, n.overflow, nodes, children_list, theme, depth)
 	case types.NodeCanvas:
 		// Apply padding to content_rect; draw pass uses this for canvas.process.
 		content_rect := rect
@@ -250,12 +257,12 @@ layout_node :: proc(
 	case types.NodeInput, types.NodeButton, types.NodeText, types.NodeImage:
 		// Leaf — no children, rect already stored.
 	case types.NodePopout:
-		layout_children_stack(idx, rect, nodes, children_list, theme)
+		layout_children_stack(idx, rect, nodes, children_list, theme, depth)
 	case types.NodeModal:
 		screen := rl.Rectangle{0, 0, f32(rl.GetScreenWidth()), f32(rl.GetScreenHeight())}
 		node_rects[idx] = screen
 		node_content_rects[idx] = screen
-		layout_children_stack(idx, screen, nodes, children_list, theme)
+		layout_children_stack(idx, screen, nodes, children_list, theme, depth)
 	}
 }
 
@@ -265,11 +272,12 @@ layout_children_stack :: proc(
 	nodes: []types.Node,
 	children_list: []types.Children,
 	theme: map[string]types.Theme,
+	depth: int,
 ) {
 	ch := children_list[idx]
 	for i in 0 ..< int(ch.length) {
 		child_idx := int(ch.value[i])
-		layout_node(child_idx, rect, nodes, children_list, theme)
+		layout_node(child_idx, rect, nodes, children_list, theme, depth + 1)
 	}
 }
 
@@ -308,6 +316,7 @@ layout_children_viewport :: proc(
 	nodes: []types.Node,
 	children_list: []types.Children,
 	theme: map[string]types.Theme,
+	depth: int,
 ) {
 	ch := children_list[idx]
 	if int(ch.length) != len(stack.viewport) {
@@ -338,7 +347,7 @@ layout_children_viewport :: proc(
 		}
 		child_rect := rl.Rectangle{px(x), px(y), w, h}
 		child_idx := int(ch.value[i])
-		layout_node(child_idx, child_rect, nodes, children_list, theme)
+		layout_node(child_idx, child_rect, nodes, children_list, theme, depth + 1)
 	}
 }
 
@@ -352,6 +361,7 @@ layout_box :: proc(
 	nodes: []types.Node,
 	children_list: []types.Children,
 	theme: map[string]types.Theme,
+	depth: int,
 ) {
 	content_rect := rect
 	pad: [4]u8
@@ -384,7 +394,7 @@ layout_box :: proc(
 		s: f32
 		if vertical {
 			s = scrollable_y \
-				? intrinsic_height(child_idx, nodes, children_list, theme, content_rect.width) \
+				? intrinsic_height(child_idx, nodes, children_list, theme, content_rect.width, depth) \
 				: node_preferred_height(child_idx, nodes, theme, content_rect.width)
 		} else {
 			s = node_preferred_width(child_idx, nodes)
@@ -450,7 +460,7 @@ layout_box :: proc(
 		child_rect: rl.Rectangle
 		if vertical {
 			h := scrollable_y \
-				? intrinsic_height(child_idx, nodes, children_list, theme, content_rect.width) \
+				? intrinsic_height(child_idx, nodes, children_list, theme, content_rect.width, depth) \
 				: node_preferred_height(child_idx, nodes, theme, content_rect.width)
 			if h <= 0 do h = fill_size
 			child_x := content_rect.x; child_w := content_rect.width
@@ -481,7 +491,7 @@ layout_box :: proc(
 			child_rect = rl.Rectangle{pos, child_y, w, child_h}
 			pos += w
 		}
-		layout_node(child_idx, child_rect, nodes, children_list, theme)
+		layout_node(child_idx, child_rect, nodes, children_list, theme, depth + 1)
 	}
 }
 
@@ -1078,24 +1088,58 @@ node_preferred_height :: proc(
 	return 0
 }
 
+// #162 H1: defense-in-depth ceiling on the layout / intrinsic-height
+// recursion. The bridge flatten pass already caps view-tree nesting at
+// bridge.MAX_VIEW_DEPTH (256, #170), which bounds every render walk over
+// the flat tree — so this backstop never trips on a tree that flatten
+// produced. It exists purely so a future change to the flatten cap (or a
+// new code path that builds the flat arrays without it) can't silently
+// reintroduce the unbounded native-stack recursion. Kept strictly above
+// MAX_VIEW_DEPTH; verified by test_layout_backstop_exceeds_flatten_cap.
+LAYOUT_DEPTH_BACKSTOP :: 1024
+
+g_layout_depth_warned: bool
+
+layout_depth_exceeded :: proc(depth: int) -> bool {
+	return depth > LAYOUT_DEPTH_BACKSTOP
+}
+
+// Emit the one-shot backstop warning. Separate from the predicate so the
+// predicate stays pure (and unit-testable without side effects).
+@(private)
+warn_layout_depth :: proc() {
+	if g_layout_depth_warned do return
+	g_layout_depth_warned = true
+	fmt.eprintfln(
+		"redin: layout recursion hit the %d-level backstop; truncating. This should be unreachable behind the flatten cap (#162 H1, #170).",
+		LAYOUT_DEPTH_BACKSTOP,
+	)
+}
+
 // Natural content height for use in scrollable containers. When a child
 // inside a scroll-y vbox has no explicit height, layout must still give
 // it a non-zero rect — otherwise children collapse to the same Y. For
-// nested boxes this means recursing over the subtree.
+// nested boxes this means recursing over the subtree. `depth` is the
+// recursion depth from the measurement root, bounded by the backstop.
 intrinsic_height :: proc(
 	idx: int,
 	nodes: []types.Node,
 	children_list: []types.Children,
 	theme: map[string]types.Theme,
 	available_width: f32,
+	depth := 0,
 ) -> f32 {
 	if idx < 0 || idx >= len(nodes) do return 0
+	if layout_depth_exceeded(depth) {
+		warn_layout_depth()
+		return 0
+	}
 
 	if cached, ok := text_pkg.lookup_intrinsic(idx, available_width); ok {
 		return cached
 	}
 
-	h := intrinsic_height_impl(idx, nodes, children_list, theme, available_width)
+	h := intrinsic_height_impl(idx, nodes, children_list, theme, available_width, depth)
 	text_pkg.cache_intrinsic(idx, available_width, h)
 	return h
 }
@@ -1107,6 +1151,7 @@ intrinsic_height_impl :: proc(
 	children_list: []types.Children,
 	theme: map[string]types.Theme,
 	available_width: f32,
+	depth: int,
 ) -> f32 {
 	switch n in nodes[idx] {
 	case types.NodeVbox:
@@ -1120,7 +1165,7 @@ intrinsic_height_impl :: proc(
 		total := f32(pad[0]) + f32(pad[2])
 		ch := children_list[idx]
 		for i in 0 ..< int(ch.length) {
-			total += intrinsic_height(int(ch.value[i]), nodes, children_list, theme, inner_w)
+			total += intrinsic_height(int(ch.value[i]), nodes, children_list, theme, inner_w, depth + 1)
 		}
 		return total
 
@@ -1137,7 +1182,7 @@ intrinsic_height_impl :: proc(
 		share := inner_w / f32(ch.length)
 		max_h: f32 = 0
 		for i in 0 ..< int(ch.length) {
-			ch_h := intrinsic_height(int(ch.value[i]), nodes, children_list, theme, share)
+			ch_h := intrinsic_height(int(ch.value[i]), nodes, children_list, theme, share, depth + 1)
 			if ch_h > max_h do max_h = ch_h
 		}
 		return max_h + f32(pad[0]) + f32(pad[2])
@@ -1146,7 +1191,7 @@ intrinsic_height_impl :: proc(
 		ch := children_list[idx]
 		max_h: f32 = 0
 		for i in 0 ..< int(ch.length) {
-			ch_h := intrinsic_height(int(ch.value[i]), nodes, children_list, theme, available_width)
+			ch_h := intrinsic_height(int(ch.value[i]), nodes, children_list, theme, available_width, depth + 1)
 			if ch_h > max_h do max_h = ch_h
 		}
 		return max_h


### PR DESCRIPTION
## Summary

Closes the three **High**-severity DoS findings from the security review (#162): two real fixes (H2, H3) plus a defense-in-depth backstop for H1, which was already transitively mitigated by the #170 flatten cap.

Threat model unchanged: the dev/agent server is localhost + bearer-token only, but a token-holder (or co-resident process that read `.redin-token`) could previously crash or OOM the host. These caps close that.

### H2 — acceptor pending-connection queue was unbounded (mem/fd exhaustion)
`acceptor_thread_proc` pushed every accepted socket onto `accepted_conns` with no upper bound; `HANDLER_POOL_SIZE` only caps *concurrent* handlers, not *pending* connections. A client opening sockets faster than the 16 handlers drain them grew the queue (and the fds it pins) without limit.

- New `MAX_PENDING_CONNS = 256` and `conn_try_push`, which refuses to enqueue past the cap (the `nil` shutdown sentinel always enqueues so handlers still observe stop). On overflow the acceptor closes the socket and drops it.

### H3 — `/screenshot` had no size cap (~256 MB transient per call)
`LoadImageFromScreen` + `ExportImageToMemory` allocate an RGBA buffer plus a PNG copy. `/resize` permits an 8192×8192 window (≈67 MP ≈ 256 MB/call), so an authenticated caller could repeatedly OOM the host.

- New `MAX_SCREENSHOT_PIXELS = 16 MP` and a pure `screenshot_dims_ok` predicate; `handle_screenshot` returns **413** before any allocation when the window exceeds the cap. Added the `413 Payload Too Large` status line (it was missing, so the handler would otherwise have sent a 413 body under a `200 OK` status line).

### H1 — layout recursion (defense-in-depth)
The original finding (unbounded `intrinsic_height`/layout recursion → stack overflow) is **already mitigated**: the #170 flatten pass caps view-tree depth at `bridge.MAX_VIEW_DEPTH = 256`, which bounds every render walk over the flat tree.

- Added a `LAYOUT_DEPTH_BACKSTOP = 1024` (> the flatten cap) threaded through `intrinsic_height` and `layout_node`. It never trips on a tree flatten produced; it exists so a future change to the flatten cap (or a new flat-array builder) can't silently reintroduce the overflow. A test asserts `LAYOUT_DEPTH_BACKSTOP > bridge.MAX_VIEW_DEPTH`.

## Findings reviewed but not in this PR
Re-verified against current `main`: **M4** (NUL-safe `lua_tolstring`) and **M5** (`lua_isnumber` guards) are already fixed. Remaining from #162: M1, M2, M3 (SSRF), and the L-tier — left for follow-up PRs.

## Tests (TDD — RED verified before each fix)
- `devserver_pending_cap_test.odin` — cap enforcement, nil-sentinel bypass, constant pin (3)
- `devserver_screenshot_cap_test.odin` — predicate boundaries, non-positive dims, constant pin, 413 status line (6)
- `layout_depth_test.odin` — backstop bounds + linkage to the flatten cap (3); adds the first test target for `package redin`, now wired into CI

## Verification
- `odin test src/redin/bridge` → 91 pass
- `odin test src/redin` → 3 pass (new target)
- `luajit test/lua/runner.lua test/lua/test_*.fnl` → 135 pass
- Release build clean
- Headless UI suite (`run-all.sh --headless`) — layout regression check

Refs #162 (H1, H2, H3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
