### PR TITLE
fix(security): L-tier hardening — lstat, app-path NUL guard, generic HTTP errors (#162 L1/L2/L4)

### DIFF
--- a/docs/reference/effects.md
+++ b/docs/reference/effects.md
@@ -105,6 +105,7 @@ Make an async HTTP request. The response is routed back as an event.
 | `"http timeout exceeded"` | Wall-clock timeout (per-call `:timeout`, default 30000 ms) elapsed. |
 | `"too many concurrent http requests (cap 64)"` | Submitted while 64 in-flight requests were already running. |
 | `"host <name> not in http whitelist"` | Whitelist denies this host. Deny-by-default since #136 H2 — set `bridge.set_http_whitelist([]string{"*"})` to allow any host. See [native bridge](native-bridge.md). |
+| `"http request failed"` | A dial, request, or body-read error (e.g. connection refused, no route to host, malformed response). The specific underlying error is logged to the host's stderr; the caller receives this generic message so the response body can't be used to probe internal network topology (#162 L4). |
 
 **Shutdown behavior.** `http_client_destroy` waits up to 3 s for in-flight workers to drain naturally, then force-closes the TCP sockets of any still parked inside `parse_response`'s blocking read, then waits up to 1 s more for them to unwind. Closing the socket surfaces as `Connection_Closed` inside `recv_tcp`, which lets the parser return through its error path with the scanner buffer freed (#156). The "N HTTP worker(s) still in flight at shutdown" warning only fires if a worker survives both phases, which should be rare in practice.
 

--- a/src/redin/bridge/hotreload.odin
+++ b/src/redin/bridge/hotreload.odin
@@ -83,7 +83,10 @@ hotreload_execute :: proc(b: ^Bridge) {
 
 @(private = "file")
 get_file_mtime :: proc(path: string) -> i64 {
-	fi, err := os.stat(path, context.temp_allocator)
+	// #162 L1: lstat, not stat — don't dereference symlinks. A symlink
+	// swap in the watched directory should be observed as the watched
+	// path changing, not silently followed to whatever it now points at.
+	fi, err := os.lstat(path, context.temp_allocator)
 	if err != os.ERROR_NONE do return 0
 	return time.time_to_unix(fi.modification_time)
 }

--- a/src/redin/bridge/http_client.odin
+++ b/src/redin/bridge/http_client.odin
@@ -523,8 +523,14 @@ execute_http_request :: proc(req: Http_Request, client: ^Http_Client = nil) -> H
 	// entirely.
 	sock, url, dial_err := http_client.dial(req.url)
 	if dial_err != nil {
+		// #162 L4: the raw dial error names the host/IP and the OS-level
+		// reason ("connection refused on 10.0.x.x:80", "no route to
+		// host"), which lets an authenticated caller map the internal
+		// network one host at a time. Log the detail to stderr for the
+		// developer; return a generic message to the app.
+		fmt.eprintfln("redin: http dial failed for %s: %v", url_host(req.url), dial_err)
 		response.status = 0
-		response.error_msg = fmt.aprintf("Request failed: %v", dial_err)
+		response.error_msg = strings.clone("http request failed")
 		return response
 	}
 
@@ -561,8 +567,10 @@ execute_http_request :: proc(req: Http_Request, client: ^Http_Client = nil) -> H
 	if req_err != nil {
 		// `request_on` leaves socket ownership with us on error.
 		net.close(sock)
+		// #162 L4: generic to the caller, detail to stderr.
+		fmt.eprintfln("redin: http request failed for %s: %v", url_host(req.url), req_err)
 		response.status = 0
-		response.error_msg = fmt.aprintf("Request failed: %v", req_err)
+		response.error_msg = strings.clone("http request failed")
 		return response
 	}
 	// Success: ownership of `sock` transferred to `res`; closed by the
@@ -585,7 +593,9 @@ execute_http_request :: proc(req: Http_Request, client: ^Http_Client = nil) -> H
 			"Response body too large (cap %d bytes)", HTTP_MAX_BODY,
 		)
 	} else {
-		response.error_msg = fmt.aprintf("Body read failed: %v", body_err)
+		// #162 L4: generic to the caller, detail to stderr.
+		fmt.eprintfln("redin: http body read failed for %s: %v", url_host(req.url), body_err)
+		response.error_msg = strings.clone("http request failed")
 	}
 
 	for k, v in res.headers._kv {

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -328,8 +328,8 @@ test_http_accepts_uppercase_https :: proc(t: ^testing.T) {
 	defer set_http_whitelist(nil)
 
 	// Just confirms scheme matching is case-insensitive — no real connect.
-	// We expect a connect error (status 0, error_msg contains "Request failed"
-	// or similar), NOT the scheme-rejection error_msg.
+	// We expect a generic connect failure (status 0, "http request failed"
+	// per #162 L4), NOT the scheme-rejection error_msg.
 	req := Http_Request{
 		id = strings.clone("scheme-3"),
 		url = strings.clone("HTTPS://127.0.0.1:1/"),

--- a/src/redin/bridge/loader.odin
+++ b/src/redin/bridge/loader.odin
@@ -3,9 +3,21 @@ package bridge
 import "core:fmt"
 import "core:strings"
 
+// #162 L2: the app path is forwarded to fennel.dofile / luaL_dofile as a
+// C string. An embedded NUL truncates there, so the loader would silently
+// act on a prefix of the supplied path. Reject empty or NUL-containing
+// paths up front. The user controls the CLI argument, so this is a
+// robustness guard (clean refusal over confusing downstream errors), not
+// an exploit barrier — hence absolute paths and any extension stay valid.
+valid_app_path :: proc(path: string) -> bool {
+	if len(path) == 0 do return false
+	if strings.contains_rune(path, 0) do return false
+	return true
+}
+
 load_app :: proc(b: ^Bridge, app_file: string) -> bool {
-	if len(app_file) == 0 {
-		fmt.eprintfln("No app file specified")
+	if !valid_app_path(app_file) {
+		fmt.eprintfln("Invalid app file path (empty or contains NUL)")
 		return false
 	}
 

--- a/src/redin/bridge/loader_path_test.odin
+++ b/src/redin/bridge/loader_path_test.odin
@@ -1,0 +1,29 @@
+package bridge
+
+// #162 L2: load_app forwards os.args[1] straight to fennel.dofile /
+// luaL_dofile. A path with an embedded NUL truncates at the C-string
+// boundary, so the bytes after the NUL silently vanish and the loader
+// acts on a different path than the one supplied — confusing at best.
+// valid_app_path is the pure guard load_app consults before handing the
+// path to Lua.
+
+import "core:testing"
+
+@(test)
+test_valid_app_path_accepts_normal :: proc(t: ^testing.T) {
+	testing.expect(t, valid_app_path("main.fnl"), "ordinary .fnl path")
+	testing.expect(t, valid_app_path("examples/kitchen-sink.fnl"), "nested path")
+	testing.expect(t, valid_app_path("app.lua"), "lua path")
+	testing.expect(t, valid_app_path("/abs/path/main.fnl"), "absolute is fine — user controls the CLI")
+}
+
+@(test)
+test_valid_app_path_rejects_empty :: proc(t: ^testing.T) {
+	testing.expect(t, !valid_app_path(""), "empty path rejected")
+}
+
+@(test)
+test_valid_app_path_rejects_nul :: proc(t: ^testing.T) {
+	testing.expect(t, !valid_app_path("main.fnl\x00.lua"), "embedded NUL rejected")
+	testing.expect(t, !valid_app_path("\x00"), "lone NUL rejected")
+}


### PR DESCRIPTION
## Summary

Three **Low**-severity robustness / defence-in-depth findings from the #162 security review. All in `package bridge`, branched from `main` (which already has #198 H-tier and #199 M1/M2).

### L1 — hotreload followed symlinks
`get_file_mtime` used `os.stat`, which dereferences symlinks, so a symlink swap in the watched directory would silently start tracking a different file. Switched to `os.lstat`.

### L2 — app path forwarded to `dofile` without a NUL check
`load_app` passes the CLI app path to `fennel.dofile` / `luaL_dofile` as a C string; an embedded NUL truncates there, so the loader would act on a prefix of the supplied path. Added a pure `valid_app_path` guard (reject empty / NUL) consulted before handing the path to Lua. The user controls the CLI argument, so this is a clean-refusal robustness fix — **absolute paths and any extension stay valid**.

### L4 — raw network errors leaked to the app
The outbound HTTP client put the raw `dial`/`request`/body-read error (`"connection refused on 10.0.x.x:80"`, `"no route to host"`) verbatim into the response the app sees, letting an authenticated caller map the internal network one host at a time. Now the **full error is logged to stderr** for the developer and the caller receives a generic **`"http request failed"`**. Documented in `docs/reference/effects.md`.

## Tests (TDD — RED verified before the fix)
- `loader_path_test.odin` — `valid_app_path` accepts normal/absolute paths, rejects empty and embedded-NUL. RED confirmed: undeclared symbol before the fix.

L1 (symlink semantics) and L4 (stderr-vs-return split) are awkward to unit-test in this harness; L4's path is exercised by the existing connect-failure test (`test_http_accepts_uppercase_https`), and L1 is a one-line semantic swap.

## Verification
- `odin test src/redin/bridge` → **88 pass**
- Fennel runtime tests → 135 pass
- Release build clean

## #162 status after this PR
Done: **H1/H2/H3** (#198), **M1/M2** (#199), **M4/M5** (already fixed earlier), **L1/L2/L4** (this PR). **Remaining: M3** (SSRF denylist + DNS-rebinding) and **L3** (compile-time dev gate).

Refs #162 (L1, L2, L4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
