### PR TITLE
fix(security): gate dev-only endpoints at compile time, drop dev_mode flag (#162 L3)

### DIFF
--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -46,7 +46,6 @@ Bridge :: struct {
 	shell_client:    Shell_Client,
 	hot_reload:      Hot_Reload,
 	dev_server:      Dev_Server,
-	dev_mode:        bool,
 	frame_changed:   bool,
 	source_tree:     bool,
 }
@@ -137,9 +136,9 @@ init :: proc(b: ^Bridge) {
 // otherwise the first /frames request queues up against load_app and
 // can take seconds to respond, which breaks bb-side test timeouts (#132).
 start_devserver :: proc(b: ^Bridge) {
-	when REDIN_DEV {
-		b.dev_mode = true
-	}
+	// #162 L3: the former `dev_mode` runtime flag is gone — dev-only
+	// mutating endpoints are now gated at compile time via `when REDIN_DEV`
+	// in devserver.odin, so a non-dev build can't reach them at all.
 	when REDIN_DEV || REDIN_AGENT {
 		devserver_init(&b.dev_server, b)
 	}

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -926,7 +926,8 @@ process_request :: proc(ds: ^Dev_Server, req: ^Pending_Request) {
 		} else if req.path == "/input/key" {
 			handle_post_input_key(ds, ch, req.body)
 		} else if req.path == "/shutdown" {
-			if ds.bridge.dev_mode {
+			// #162 L3: compile-time gate (see handler guards below).
+			when REDIN_DEV {
 				ds.shutdown_requested = true
 				respond_json_ok(ch)
 			} else {
@@ -935,14 +936,14 @@ process_request :: proc(ds: ^Dev_Server, req: ^Pending_Request) {
 		} else if req.path == "/resize" {
 			handle_post_resize(ds, ch, req.body)
 		} else if req.path == "/maximize" {
-			if ds.bridge.dev_mode {
+			when REDIN_DEV {
 				rl.MaximizeWindow()
 				respond_json_ok(ch)
 			} else {
 				respond_text(ch, 404, "Not found")
 			}
 		} else if req.path == "/restore" {
-			if ds.bridge.dev_mode {
+			when REDIN_DEV {
 				rl.RestoreWindow()
 				respond_json_ok(ch)
 			} else {
@@ -1769,7 +1770,11 @@ theme_to_json :: proc(b: ^strings.Builder, t: types.Theme) {
 // --- POST handlers ---
 
 handle_post_events :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
-	if !ds.bridge.dev_mode {
+	// #162 L3: compile-time gate. In a non-dev build (e.g. REDIN_AGENT
+	// without REDIN_DEV) this becomes an unconditional 404 + return, and
+	// the mutating body below is eliminated as dead code rather than left
+	// reachable behind a runtime flag.
+	when !REDIN_DEV {
 		respond_text(ch, 404, "Not found")
 		return
 	}
@@ -1799,7 +1804,11 @@ handle_post_events :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string)
 }
 
 handle_post_click :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
-	if !ds.bridge.dev_mode {
+	// #162 L3: compile-time gate. In a non-dev build (e.g. REDIN_AGENT
+	// without REDIN_DEV) this becomes an unconditional 404 + return, and
+	// the mutating body below is eliminated as dead code rather than left
+	// reachable behind a runtime flag.
+	when !REDIN_DEV {
 		respond_text(ch, 404, "Not found")
 		return
 	}
@@ -1837,7 +1846,11 @@ handle_post_click :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) 
 }
 
 handle_post_input_takeover :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
-	if !ds.bridge.dev_mode {
+	// #162 L3: compile-time gate. In a non-dev build (e.g. REDIN_AGENT
+	// without REDIN_DEV) this becomes an unconditional 404 + return, and
+	// the mutating body below is eliminated as dead code rather than left
+	// reachable behind a runtime flag.
+	when !REDIN_DEV {
 		respond_text(ch, 404, "Not found")
 		return
 	}
@@ -1850,7 +1863,11 @@ handle_post_input_takeover :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
 }
 
 handle_post_input_release :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
-	if !ds.bridge.dev_mode {
+	// #162 L3: compile-time gate. In a non-dev build (e.g. REDIN_AGENT
+	// without REDIN_DEV) this becomes an unconditional 404 + return, and
+	// the mutating body below is eliminated as dead code rather than left
+	// reachable behind a runtime flag.
+	when !REDIN_DEV {
 		respond_text(ch, 404, "Not found")
 		return
 	}
@@ -1877,7 +1894,11 @@ read_mouse_button :: proc(L: ^Lua_State) -> (rl.MouseButton, bool) {
 }
 
 handle_post_input_mouse_move :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
-	if !ds.bridge.dev_mode {
+	// #162 L3: compile-time gate. In a non-dev build (e.g. REDIN_AGENT
+	// without REDIN_DEV) this becomes an unconditional 404 + return, and
+	// the mutating body below is eliminated as dead code rather than left
+	// reachable behind a runtime flag.
+	when !REDIN_DEV {
 		respond_text(ch, 404, "Not found")
 		return
 	}
@@ -1911,7 +1932,11 @@ handle_post_input_mouse_move :: proc(ds: ^Dev_Server, ch: ^Response_Channel, bod
 }
 
 handle_post_input_mouse_down :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
-	if !ds.bridge.dev_mode {
+	// #162 L3: compile-time gate. In a non-dev build (e.g. REDIN_AGENT
+	// without REDIN_DEV) this becomes an unconditional 404 + return, and
+	// the mutating body below is eliminated as dead code rather than left
+	// reachable behind a runtime flag.
+	when !REDIN_DEV {
 		respond_text(ch, 404, "Not found")
 		return
 	}
@@ -1969,7 +1994,11 @@ handle_post_input_mouse_down :: proc(ds: ^Dev_Server, ch: ^Response_Channel, bod
 }
 
 handle_post_input_mouse_up :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
-	if !ds.bridge.dev_mode {
+	// #162 L3: compile-time gate. In a non-dev build (e.g. REDIN_AGENT
+	// without REDIN_DEV) this becomes an unconditional 404 + return, and
+	// the mutating body below is eliminated as dead code rather than left
+	// reachable behind a runtime flag.
+	when !REDIN_DEV {
 		respond_text(ch, 404, "Not found")
 		return
 	}
@@ -2051,7 +2080,11 @@ key_string_to_raylib :: proc(s: string) -> (rl.KeyboardKey, bool) {
 }
 
 handle_post_input_key :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
-	if !ds.bridge.dev_mode {
+	// #162 L3: compile-time gate. In a non-dev build (e.g. REDIN_AGENT
+	// without REDIN_DEV) this becomes an unconditional 404 + return, and
+	// the mutating body below is eliminated as dead code rather than left
+	// reachable behind a runtime flag.
+	when !REDIN_DEV {
 		respond_text(ch, 404, "Not found")
 		return
 	}
@@ -2097,7 +2130,11 @@ handle_post_input_key :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: stri
 }
 
 handle_post_input_scroll :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
-	if !ds.bridge.dev_mode {
+	// #162 L3: compile-time gate. In a non-dev build (e.g. REDIN_AGENT
+	// without REDIN_DEV) this becomes an unconditional 404 + return, and
+	// the mutating body below is eliminated as dead code rather than left
+	// reachable behind a runtime flag.
+	when !REDIN_DEV {
 		respond_text(ch, 404, "Not found")
 		return
 	}
@@ -2178,7 +2215,11 @@ handle_get_window :: proc(ch: ^Response_Channel) {
 }
 
 handle_post_resize :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
-	if !ds.bridge.dev_mode {
+	// #162 L3: compile-time gate. In a non-dev build (e.g. REDIN_AGENT
+	// without REDIN_DEV) this becomes an unconditional 404 + return, and
+	// the mutating body below is eliminated as dead code rather than left
+	// reachable behind a runtime flag.
+	when !REDIN_DEV {
 		respond_text(ch, 404, "Not found")
 		return
 	}
@@ -2221,7 +2262,11 @@ handle_post_resize :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string)
 // --- PUT handlers ---
 
 handle_put_aspects :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string) {
-	if !ds.bridge.dev_mode {
+	// #162 L3: compile-time gate. In a non-dev build (e.g. REDIN_AGENT
+	// without REDIN_DEV) this becomes an unconditional 404 + return, and
+	// the mutating body below is eliminated as dead code rather than left
+	// reachable behind a runtime flag.
+	when !REDIN_DEV {
 		respond_text(ch, 404, "Not found")
 		return
 	}


### PR DESCRIPTION
## Summary

Closes the final #162 finding (**L3**) — a defensive-design improvement. Dev-only mutating dev-server endpoints were gated by a runtime `if !ds.bridge.dev_mode { 404 }` check. In a `REDIN_AGENT=true REDIN_DEV=false` build the listener is up but `dev_mode` is false, so these handlers were present in the binary and one forgotten `if` in a future refactor would silently expose a mutator. This moves the gate to compile time so the bodies are eliminated from non-dev builds entirely.

### What changed
- The 11 identical handler-top guards (`/events`, `/click`, all `/input/*`, `/resize`, `/aspects`) became `when !REDIN_DEV { respond 404; return }`. In a non-dev build the mutating body below is dead code and compiled out; in a dev build the `when` is empty.
- The 3 inline dispatch guards (`/shutdown`, `/maximize`, `/restore`) became `when REDIN_DEV { … } else { 404 }`.
- The now-dead `Bridge.dev_mode` field and its single assignment are removed — it was only ever written, never read, once the checks became compile-time. (Leaving a write-only runtime flag around is exactly the drift hazard the finding warns about.)

### Why this is behaviour-preserving
`dev_mode` was set `true` **only** `when REDIN_DEV` (one assignment, confirmed the sole writer), and the server only dispatches after that — so `ds.bridge.dev_mode` was always exactly equal to the compile-time `REDIN_DEV` at every check site. Swapping the runtime checks for `when REDIN_DEV` changes nothing observable:

| Build | Before | After |
|-------|--------|-------|
| dev (`REDIN_DEV=true`) | mutators served | mutators served (identical) |
| agent-only (`REDIN_AGENT=true`) | mutators 404 at runtime | mutators 404, **compiled out** |
| release | server absent | server absent |

## Verification
- Builds clean in all three flavors: release, `REDIN_AGENT=true`, `REDIN_DEV=true`.
- `odin test src/redin/bridge` → **99 pass**.
- Headless UI suite (`run-all.sh --headless`, a `REDIN_DEV=true` build) → all pass — this is the behavioural proof that the dev-build mutators (`/events`, `/resize`, `/click`, `/input/*`) still work, since every UI test drives them.

## #162 — complete
With this, **every High, Medium, and Low finding** from the review is addressed: H1/H2/H3 (#198), M1/M2 (#199), M4/M5 (pre-existing), M3 (#201), L1/L2/L4 (#200), L3 (this PR).

Refs #162 (L3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
