### PR TITLE
test(ci): raise UI suite global timeout 120s → 180s (#132)

### DIFF
--- a/test/ui/run-all.sh
+++ b/test/ui/run-all.sh
@@ -45,10 +45,13 @@ TOTAL_FAILED=0
 
 # Per-test and total wall-clock budgets (#132). Defaults are tight on
 # purpose: a healthy test runs in seconds, so 30s catches a hang fast,
-# and a 120s total cap keeps a runaway suite from pinning CI for hours
-# while still leaving room for the fast-path of 25-ish tests.
+# and the total cap keeps a runaway suite from pinning CI for hours while
+# still leaving room for the full suite to finish. Raised 120s -> 180s
+# because the agent flavour (REDIN_AGENT=true, which runs extra suites
+# including the agent channel) was legitimately exceeding the 2-minute cap
+# in CI and skipping its tail, even though every test passed.
 TEST_TIMEOUT="${REDIN_TEST_TIMEOUT:-30}"
-GLOBAL_TIMEOUT="${REDIN_GLOBAL_TIMEOUT:-120}"
+GLOBAL_TIMEOUT="${REDIN_GLOBAL_TIMEOUT:-180}"
 GLOBAL_START=$SECONDS
 
 # Build


### PR DESCRIPTION
## Summary

The `test-agent` CI job (`REDIN_AGENT=true`, which runs extra UI suites including the agent channel) was failing on a **global suite timeout**, not on any test:

```
GLOBAL TIMEOUT: suite exceeded 120s; remaining tests skipped (#132)
2 test suite(s) had failures
##[error]Process completed with exit code 1.
```

Every individual test passed — the suite simply outgrew the 120s (2-minute) wall-clock cap in `test/ui/run-all.sh` and skipped its tail, which fails the job.

## Change

`GLOBAL_TIMEOUT` default `120` → `180` (2 min → 3 min). Still overridable via `REDIN_GLOBAL_TIMEOUT`, and the per-test `TEST_TIMEOUT=30s` is unchanged, so a real hang is still caught fast — this only gives the full agent-flavour suite room to finish.

## Context

This is the failing run that motivated it: `test` passed, `test-agent` hit the cap. Raising to 180s lets the suite complete; a real runaway is still bounded well short of pinning CI for hours.

Refs #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)