### PR TITLE
fix(security): #204 audit hardening — 6 low/info items

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           submodules: recursive
 
@@ -108,7 +108,7 @@ jobs:
         run: bash scripts/smoke-native.sh "redin-${VERSION}-linux-amd64.tar.gz"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: redin-${{ steps.version.outputs.tag }}-linux-amd64
           path: |
@@ -143,7 +143,7 @@ jobs:
             > "redin-${VERSION}-agent-linux-amd64.tar.gz.sha256"
 
       - name: Upload agent artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: redin-${{ steps.version.outputs.tag }}-agent-linux-amd64
           path: |
@@ -158,10 +158,10 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: artifacts
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           submodules: recursive
 
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           submodules: recursive
 

--- a/docs/app-api.md
+++ b/docs/app-api.md
@@ -350,6 +350,10 @@ Dispatch another event immediately.
  :dispatch [:event/notify "Saved"]}
 ```
 
+Dispatches run synchronously, so a self-dispatching chain is capped at depth
+**64** — past it the event is dropped with a warning instead of overflowing
+the host stack. See [reference/effects.md](reference/effects.md#built-in-dispatch).
+
 #### `:dispatch-later`
 
 Schedule event dispatch after a delay.
@@ -365,7 +369,7 @@ Schedule event dispatch after a delay.
                   {:ms 5000 :dispatch [:session/timeout]}]}
 ```
 
-Each entry: `{:ms N :dispatch event-vector}`. Timer fires when `poll-timers` is called with `now >= start + ms`. The host calls `poll-timers` once per frame.
+Each entry: `{:ms N :dispatch event-vector}`. Timer fires when `poll-timers` is called with `now >= start + ms`. The host calls `poll-timers` once per frame. The pending-timer queue is capped at **10,000** entries; beyond it new timers are dropped with a warning.
 
 #### `:log`
 

--- a/docs/reference/effects.md
+++ b/docs/reference/effects.md
@@ -47,6 +47,13 @@ Dispatch another event immediately.
  :dispatch [:event/notify "Saved"]}
 ```
 
+A `:dispatch` runs synchronously, so a handler that dispatches an event whose
+handler dispatches back forms a recursive chain. That chain is capped at depth
+**64**: past it the event is dropped with a `Warning: dispatch depth exceeded`
+log rather than overflowing the host stack. The cap is a footgun guard for
+unbounded self-dispatch, not a normal control-flow limit — real chains are
+far shallower.
+
 ---
 
 ## Built-in: `:dispatch-later`
@@ -63,6 +70,11 @@ Schedule event dispatch after a delay. Accepts a single timer map or a sequence 
 ```
 
 Each entry: `{:ms N :dispatch event-vector}`. The timer fires when `poll-timers` is called with `now >= start + ms`. The host calls `poll-timers` once per frame.
+
+The pending-timer queue is capped at **10,000** entries. A handler that
+schedules a timer every frame without them firing would otherwise grow the
+queue without bound; past the cap, new `:dispatch-later` timers are dropped
+with a `Warning: timer queue at cap` log. No legitimate use approaches this.
 
 ---
 

--- a/docs/reference/native-bridge.md
+++ b/docs/reference/native-bridge.md
@@ -8,6 +8,31 @@ Import from your `app.odin`:
 import "./.redin/src/redin/bridge"
 ```
 
+## Trust model
+
+**redin is not a sandbox.** Your app's `.fnl` / `.lua` files are the trusted
+principal, not untrusted content. They load with the **full Lua standard
+library** — including `os` (`os.execute`, `os.getenv`, `os.remove`), `io`,
+`debug`, and `package` — and on top of that the host hands them `redin.shell`
+and `redin.http`. App code can therefore run arbitrary commands and read or
+write the filesystem with the privileges of the process. This is intentional:
+the app *is* the program, so withholding `os.execute` while shipping
+`redin.shell` would be theatre.
+
+The deny-by-default effect policies below (`set_http_whitelist`,
+`set_shell_env_allowlist`) and the SSRF/CRLF hardening on `redin.http` are
+defense-in-depth for the *host-configured* surface — they bound what a bug or
+a compromised remote endpoint can reach. They are **not** a boundary that
+contains hostile app code: code with `os`/`io`/`package` can ignore the
+framework entirely. Treat the `.fnl`/`.lua` you load with the same trust you'd
+give a native plugin compiled into the binary.
+
+Concretely: **do not** use redin to run third-party `.fnl`/`.lua` widgets,
+user-submitted scripts, or any code you would not run as a shell command. If
+you ever need to host untrusted UI code, the isolation must come from outside
+redin (a separate process, an OS sandbox, a container) — there is no
+in-framework setting that makes loading untrusted scripts safe.
+
 ## Cfunc registration
 
 ### `bridge.register_cfunc(name: cstring, fn: proc(L: ^Lua_State) -> i32)`

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -192,10 +192,17 @@ is_shutdown_requested :: proc(b: ^Bridge) -> bool {
 
 check_hotreload :: proc(b: ^Bridge) {
 	when !REDIN_DEV do return
-	if hotreload_check(&b.hot_reload) {
-		hotreload_execute(b)
-		b.frame_changed = true
+	trigger := hotreload_poll(&b.hot_reload)
+	if trigger == .None do return
+	ok := hotreload_execute(b)
+	// F5: a fresh-change reload that failed is likely a non-atomic editor
+	// save caught mid-write — arm one short retry. A retry that also fails
+	// (or any success) leaves the retry disarmed, so a genuinely broken file
+	// settles after two attempts instead of retrying forever.
+	if hotreload_should_arm_retry(trigger, ok) {
+		hotreload_arm_retry(&b.hot_reload)
 	}
+	b.frame_changed = true
 }
 
 // Walk the flat tree once: for each draggable with handle_off, ensure at

--- a/src/redin/bridge/hotreload.odin
+++ b/src/redin/bridge/hotreload.odin
@@ -4,11 +4,32 @@ import "core:fmt"
 import "core:os"
 import "core:time"
 
+// F5 (#204): how long after a failed reload to make one more attempt.
+// An editor that saves non-atomically (write-in-place rather than
+// write-temp-then-rename) can update a watched file's mtime while the
+// buffer is still half-written, so the mtime-triggered re-require lands on
+// a truncated module and fails with a Fennel syntax error. A single short
+// retry gives the editor time to finish the write; 50ms is far longer than
+// any in-place save and short enough to feel instant.
+HOTRELOAD_RETRY_MS :: 50.0
+
+Hotreload_Trigger :: enum {
+	None,    // nothing to do this frame
+	Changed, // a watched file's mtime advanced
+	Retry,   // a previously-armed one-shot retry came due
+}
+
 Hot_Reload :: struct {
 	watch_paths:    [dynamic]string,
 	last_mtimes:    map[string]i64,
 	frame_counter:  int,
 	check_interval: int,
+	// F5: one-shot retry after a failed reload. retry_armed is true between
+	// arming the retry and consuming it; retry_at marks when it was armed.
+	// Because it is armed only on a fresh-change failure and consumed once,
+	// a genuinely broken file fails at most twice, never in a loop.
+	retry_armed:    bool,
+	retry_at:       time.Tick,
 }
 
 hotreload_init :: proc(hr: ^Hot_Reload, source_tree: bool) {
@@ -38,9 +59,36 @@ hotreload_destroy :: proc(hr: ^Hot_Reload) {
 	delete(hr.last_mtimes)
 }
 
-hotreload_check :: proc(hr: ^Hot_Reload) -> bool {
+// Pure predicate: given a retry is armed and `elapsed_ms` have passed since
+// it was armed, is it due to fire? Factored out so the timing rule is unit-
+// testable without a real clock.
+hotreload_retry_due :: proc(armed: bool, elapsed_ms: f64) -> bool {
+	return armed && elapsed_ms >= HOTRELOAD_RETRY_MS
+}
+
+// Pure predicate: after an execute attempt, should a one-shot retry be armed?
+// Only when a *fresh* mtime change (not an already-consumed retry) failed —
+// this is what bounds a broken file to two attempts instead of a loop.
+hotreload_should_arm_retry :: proc(trigger: Hotreload_Trigger, reload_ok: bool) -> bool {
+	return trigger == .Changed && !reload_ok
+}
+
+hotreload_poll :: proc(hr: ^Hot_Reload) -> Hotreload_Trigger {
+	// A pending retry fires on its own time-based deadline, independent of
+	// the mtime-poll throttle, and is consumed here so it fires at most once.
+	// While a retry is still pending we hold off on mtime polling so the two
+	// paths can't interleave.
+	if hr.retry_armed {
+		elapsed := time.duration_milliseconds(time.tick_since(hr.retry_at))
+		if hotreload_retry_due(hr.retry_armed, elapsed) {
+			hr.retry_armed = false
+			return .Retry
+		}
+		return .None
+	}
+
 	hr.frame_counter += 1
-	if hr.frame_counter < hr.check_interval do return false
+	if hr.frame_counter < hr.check_interval do return .None
 	hr.frame_counter = 0
 
 	changed := false
@@ -51,10 +99,17 @@ hotreload_check :: proc(hr: ^Hot_Reload) -> bool {
 		}
 		hr.last_mtimes[path] = mtime
 	}
-	return changed
+	return changed ? .Changed : .None
 }
 
-hotreload_execute :: proc(b: ^Bridge) {
+// Arm a single retry to fire ~HOTRELOAD_RETRY_MS later. retry_at records
+// the moment of failure; hotreload_poll fires once that long has elapsed.
+hotreload_arm_retry :: proc(hr: ^Hot_Reload) {
+	hr.retry_armed = true
+	hr.retry_at = time.tick_now()
+}
+
+hotreload_execute :: proc(b: ^Bridge) -> (ok: bool) {
 	code := `
 		package.loaded["dataflow"] = nil
 		package.loaded["effect"]   = nil
@@ -76,9 +131,10 @@ hotreload_execute :: proc(b: ^Bridge) {
 		msg := lua_tostring_raw(b.L, -1)
 		fmt.eprintfln("Hot reload error: %s", msg)
 		lua_pop(b.L, 1)
-	} else {
-		fmt.println("Hot reload: runtime reloaded")
+		return false
 	}
+	fmt.println("Hot reload: runtime reloaded")
+	return true
 }
 
 @(private = "file")

--- a/src/redin/bridge/hotreload_retry_test.odin
+++ b/src/redin/bridge/hotreload_retry_test.odin
@@ -1,0 +1,38 @@
+package bridge
+
+// F5 (#204): a hot reload triggered by a non-atomic editor save can land on
+// a half-written file and fail. The watcher arms one short retry so the
+// editor's finished write is picked up automatically. The timing rule and
+// the arm-at-most-once rule are factored into pure predicates so they can be
+// checked without a real clock, Lua state, or filesystem.
+
+import "core:testing"
+
+@(test)
+test_hotreload_retry_due_timing :: proc(t: ^testing.T) {
+	// Not armed: never due, regardless of elapsed time.
+	testing.expect(t, !hotreload_retry_due(false, 0), "disarmed never fires")
+	testing.expect(t, !hotreload_retry_due(false, 1000), "disarmed never fires even much later")
+
+	// Armed but before the deadline: not yet.
+	testing.expect(t, !hotreload_retry_due(true, 0), "armed but no time passed")
+	testing.expect(t, !hotreload_retry_due(true, HOTRELOAD_RETRY_MS - 1), "armed but just under the deadline")
+
+	// Armed and at/after the deadline: due.
+	testing.expect(t, hotreload_retry_due(true, HOTRELOAD_RETRY_MS), "exactly at the deadline fires")
+	testing.expect(t, hotreload_retry_due(true, HOTRELOAD_RETRY_MS + 5), "past the deadline fires")
+}
+
+@(test)
+test_hotreload_should_arm_retry :: proc(t: ^testing.T) {
+	// Only a fresh mtime change that failed arms a retry.
+	testing.expect(t, hotreload_should_arm_retry(.Changed, false), "failed fresh change arms a retry")
+
+	// Everything else leaves it disarmed — crucially, a failed *retry* does
+	// not arm another, bounding a broken file to two attempts.
+	testing.expect(t, !hotreload_should_arm_retry(.Changed, true), "successful change does not arm")
+	testing.expect(t, !hotreload_should_arm_retry(.Retry, false), "failed retry does not re-arm (no loop)")
+	testing.expect(t, !hotreload_should_arm_retry(.Retry, true), "successful retry does not arm")
+	testing.expect(t, !hotreload_should_arm_retry(.None, false), "no trigger never arms")
+	testing.expect(t, !hotreload_should_arm_retry(.None, true), "no trigger never arms")
+}

--- a/src/redin/bridge/json.odin
+++ b/src/redin/bridge/json.odin
@@ -108,6 +108,13 @@ lua_value_to_json_inner :: proc(b: ^strings.Builder, L: ^Lua_State, index: i32, 
 		json_null(b)
 		return
 	}
+	// Same stack guard as the decoder. The encoder keeps a strings.Builder
+	// alive up the call stack, so on exhaustion we degrade to `null` (as the
+	// depth cap does) rather than longjmp out via luaL_error and leak it.
+	if lua_checkstack(L, 8) == 0 {
+		json_null(b)
+		return
+	}
 	abs_idx := index < 0 ? lua_gettop(L) + index + 1 : index
 	t := lua_type(L, abs_idx)
 	switch t {
@@ -229,6 +236,17 @@ json_decode_value :: proc(L: ^Lua_State, s: string, pos: ^int) -> bool {
 @(private = "file")
 json_decode_value_at :: proc(L: ^Lua_State, s: string, pos: ^int, depth: int) -> bool {
 	if depth > MAX_JSON_DEPTH do return false
+	// Defense-in-depth: guarantee room for the slots this level and its
+	// children push (table + key + value, plus headroom) before descending.
+	// MAX_JSON_DEPTH (128) keeps today's worst case far under LuaJIT's
+	// 8000-slot default, so this never trips now; it stops a future raised
+	// cap or a non-default-stack thread from turning a deep payload into an
+	// unchecked overflow instead of a catchable error. No Odin allocation is
+	// live on this recursion path, so the luaL_error longjmp leaks nothing.
+	if lua_checkstack(L, 8) == 0 {
+		luaL_error(L, "JSON nesting exhausts Lua stack")
+		return false
+	}
 	json_skip_ws(s, pos)
 	if pos^ >= len(s) do return false
 	c := s[pos^]

--- a/src/redin/bridge/json_checkstack_test.odin
+++ b/src/redin/bridge/json_checkstack_test.odin
@@ -1,0 +1,65 @@
+package bridge
+
+// F2 (#204): the JSON encoder/decoder recurse per nesting level, pushing a
+// few Lua slots each. MAX_JSON_DEPTH (128) keeps the worst case far under
+// LuaJIT's 8000-slot default, but the recursion now calls lua_checkstack
+// before descending so a future raised cap or a non-default-stack thread
+// fails cleanly instead of overflowing the stack unchecked.
+//
+// The exhaustion path itself can't be provoked deterministically at depth
+// 128, so these tests pin the two things that can regress: the binding is
+// wired (checkstack reports headroom), and the guard leaves the happy path
+// — a deep-but-valid payload — decoding correctly while the depth cap still
+// rejects past the limit.
+
+import "core:strings"
+import "core:testing"
+
+@(test)
+test_lua_checkstack_binding_reports_headroom :: proc(t: ^testing.T) {
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	// A fresh state has ample room; the guard's happy path must pass.
+	testing.expect(t, lua_checkstack(L, 8) != 0, "checkstack(8) should succeed on a fresh state")
+}
+
+// Build `[`×n + `]`×n: an array nested n levels deep with an empty array
+// at the bottom. The innermost array is decoded by json_decode_value_at at
+// depth n-1, so n stays clear of the depth cap.
+@(private = "file")
+nested_arrays :: proc(n: int) -> string {
+	b := strings.builder_make()
+	for _ in 0 ..< n do strings.write_byte(&b, '[')
+	for _ in 0 ..< n do strings.write_byte(&b, ']')
+	return strings.to_string(b)
+}
+
+@(test)
+test_decode_deep_within_cap_succeeds :: proc(t: ^testing.T) {
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	// 100 levels: deep enough to exercise the per-level checkstack guard
+	// many times, comfortably under MAX_JSON_DEPTH (128).
+	s := nested_arrays(100)
+	defer delete(s)
+	pos := 0
+	testing.expect(t, json_decode_value(L, s, &pos), "100-level nesting is within the cap and must decode")
+}
+
+@(test)
+test_decode_over_cap_rejected :: proc(t: ^testing.T) {
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	// 200 levels is well past MAX_JSON_DEPTH; the depth guard rejects it
+	// before the stack guard would ever matter.
+	s := nested_arrays(200)
+	defer delete(s)
+	pos := 0
+	testing.expect(t, !json_decode_value(L, s, &pos), "200-level nesting exceeds the depth cap and must be rejected")
+}

--- a/src/redin/bridge/lua_api.odin
+++ b/src/redin/bridge/lua_api.odin
@@ -28,6 +28,10 @@ foreign luajit {
 
 	lua_gettop    :: proc(L: ^Lua_State) -> i32 ---
 	lua_settop    :: proc(L: ^Lua_State, index: i32) ---
+	// Ensures at least `extra` free slots on the Lua stack, growing it if
+	// needed. Returns 0 (false) when the stack cannot grow. Calling a push
+	// without this guard past the available slots is an unchecked overflow.
+	lua_checkstack :: proc(L: ^Lua_State, extra: i32) -> i32 ---
 	lua_pushvalue :: proc(L: ^Lua_State, index: i32) ---
 	lua_remove    :: proc(L: ^Lua_State, index: i32) ---
 	lua_type      :: proc(L: ^Lua_State, index: i32) -> i32 ---

--- a/src/runtime/dataflow.fnl
+++ b/src/runtime/dataflow.fnl
@@ -10,6 +10,16 @@
 (var tracking nil)
 (var effect-handler nil)
 
+;; F4 (#204): cap on synchronous dispatch recursion. A handler that returns
+;; {:db db :dispatch [...]} re-enters dispatch through the effect handler; one
+;; that self-dispatches unconditionally would otherwise recurse until the Lua
+;; stack overflows with no useful diagnostic. Not a security boundary — the
+;; app author controls their handlers — but an easy footgun. 64 is far deeper
+;; than any legitimate dispatch chain.
+(local MAX-DISPATCH-DEPTH 64)
+(set M.MAX_DISPATCH_DEPTH MAX-DISPATCH-DEPTH)
+(var dispatch-depth 0)
+
 ;; ===== Path utilities =====
 
 (fn paths-overlap? [a b]
@@ -122,7 +132,7 @@
 (fn M.reg-handler [key handler-fn]
   (tset handlers key handler-fn))
 
-(fn M.dispatch [event]
+(fn do-dispatch [event]
   (let [key (. event 1)
         handler-fn (. handlers key)]
     (assert handler-fn (.. "No handler registered for: " (tostring key)))
@@ -134,6 +144,23 @@
                    (= (type result) "table") (~= (. result :db) nil))
           (when effect-handler
             (effect-handler result)))))))
+
+(fn M.dispatch [event]
+  (if (>= dispatch-depth MAX-DISPATCH-DEPTH)
+    ;; Runaway synchronous recursion — drop the event with a diagnostic
+    ;; instead of overflowing the Lua stack.
+    (print (.. "Warning: dispatch depth exceeded " MAX-DISPATCH-DEPTH
+               " (runaway :dispatch recursion?); dropping event "
+               (tostring (. event 1))))
+    (do
+      (set dispatch-depth (+ dispatch-depth 1))
+      ;; pcall so the depth counter is restored even when a handler errors;
+      ;; otherwise one errored dispatch leaves the counter elevated and
+      ;; eventually wedges all dispatching. Re-raise with level 0 to preserve
+      ;; the original message (e.g. the "No handler" assert) verbatim.
+      (let [(ok? err) (pcall do-dispatch event)]
+        (set dispatch-depth (- dispatch-depth 1))
+        (when (not ok?) (error err 0))))))
 
 ;; ===== Public API: change detection =====
 
@@ -191,7 +218,8 @@
   (set subscriptions {})
   (set changed-paths [])
   (set tracking nil)
-  (set effect-handler nil))
+  (set effect-handler nil)
+  (set dispatch-depth 0))
 
 ;; ===== Global registration =====
 

--- a/src/runtime/effect.fnl
+++ b/src/runtime/effect.fnl
@@ -3,6 +3,15 @@
 
 (local M {})
 
+;; F4 (#204): upper bound on outstanding dispatch-later timers. A handler
+;; that schedules a timer every frame grows timer-queue without bound and
+;; slowly exhausts memory with no useful diagnostic. Not a security boundary
+;; — the app author controls their handlers — but an easy footgun. At the cap
+;; we drop new timers with a warning rather than grow forever. 10,000 is far
+;; above any legitimate fan-out of pending timers.
+(local MAX-TIMER-QUEUE 10000)
+(set M.MAX_TIMER_QUEUE MAX-TIMER-QUEUE)
+
 (var executors {})
 (var timer-queue [])
 (var pending-http {})
@@ -14,6 +23,16 @@
 
 (fn M.reg-fx [key executor-fn]
   (tset executors key executor-fn))
+
+;; Enqueue a timer unless the queue is at its cap, in which case drop it
+;; with a warning. Centralised so both the single- and list-form of
+;; :dispatch-later share the bound (F4, #204).
+(fn enqueue-timer [at event]
+  (if (< (length timer-queue) MAX-TIMER-QUEUE)
+    (table.insert timer-queue {:at at :event event})
+    (print (.. "Warning: timer queue at cap (" MAX-TIMER-QUEUE
+               "); dropping dispatch-later event "
+               (tostring (and (= (type event) "table") (. event 1)))))))
 
 ;; ===== Execution =====
 
@@ -91,9 +110,9 @@
                   (* (_G.redin.now) 1000)
                   (* (os.clock) 1000))]
         (if (and (= (type params) "table") (. params :ms))
-          (table.insert timer-queue {:at (+ now params.ms) :event params.dispatch})
+          (enqueue-timer (+ now params.ms) params.dispatch)
           (each [_ timer-spec (ipairs params)]
-            (table.insert timer-queue {:at (+ now timer-spec.ms) :event timer-spec.dispatch}))))))
+            (enqueue-timer (+ now timer-spec.ms) timer-spec.dispatch))))))
   (M.reg-fx :http
     (fn [params]
       (set next-http-id (+ next-http-id 1))

--- a/test/lua/test_effect.fnl
+++ b/test/lua/test_effect.fnl
@@ -104,6 +104,46 @@
   (effect.clear-timers)
   (assert (= (effect.pending-timers) 0) "timers cleared"))
 
+;; --- F4 (#204): runaway-growth guards ---
+
+;; A handler-less `:dispatch-later` scheduled every frame grows timer-queue
+;; without bound. The cap drops new timers (with a warning) once the queue
+;; is full rather than letting it consume memory forever.
+(fn t.test-timer-queue-cap-drops-overflow []
+  (setup)
+  (let [cap effect.MAX_TIMER_QUEUE]
+    (assert (and cap (> cap 0)) "MAX_TIMER_QUEUE is exported and positive")
+    (for [_ 1 cap]
+      (effect.execute {:db nil :dispatch-later {:ms 100 :dispatch [:event/x]}}))
+    (assert (= (effect.pending-timers) cap) "queue fills exactly to the cap")
+    ;; One more past the cap must be dropped, not enqueued.
+    (effect.execute {:db nil :dispatch-later {:ms 100 :dispatch [:event/x]}})
+    (assert (= (effect.pending-timers) cap) "over-cap dispatch-later is dropped")))
+
+;; A handler that unconditionally re-dispatches itself recurses
+;; synchronously through effect.execute -> :dispatch -> dataflow.dispatch.
+;; Without a depth cap this overflows the Lua stack; with it, the chain is
+;; cut at MAX_DISPATCH_DEPTH and unwinds cleanly (no error).
+(fn t.test-dispatch-depth-cap-stops-runaway []
+  (setup)
+  (dataflow.init {:n 0})
+  (dataflow.register-globals)
+  (dataflow.set-effect-handler effect.execute)
+  (dataflow.reg-handler :event/loop
+    (fn [db _event]
+      (dataflow.update db :n #(+ (or $1 0) 1))
+      {:db db :dispatch [:event/loop]}))
+  (let [(ok err) (pcall dataflow.dispatch [:event/loop])]
+    (assert ok (.. "runaway dispatch must be capped, not error: " (tostring err))))
+  ;; Exactly MAX_DISPATCH_DEPTH handlers run before the cap drops the next.
+  (assert (= (rawget (dataflow._get-raw-db) :n) dataflow.MAX_DISPATCH_DEPTH)
+          "ran exactly MAX_DISPATCH_DEPTH handlers before hitting the cap")
+  ;; The depth counter must return to baseline so later dispatches aren't
+  ;; wrongly rejected.
+  (dataflow.dispatch [:event/loop])
+  (assert (= (rawget (dataflow._get-raw-db) :n) (* 2 dataflow.MAX_DISPATCH_DEPTH))
+          "depth counter reset between top-level dispatches"))
+
 ;; Regression test for issue #146.
 ;;
 ;; In production the host calls poll-timers with wall-clock ms

--- a/test/ui/run-all.sh
+++ b/test/ui/run-all.sh
@@ -103,12 +103,20 @@ for test_file in "$SCRIPT_DIR"/test_*.bb; do
 
   echo "=== $name ==="
 
-  # Optional sidecar: <app>_app.flags — whitespace-split extra host flags.
+  # Optional sidecar: <app>_app.flags — extra host flags, ONE PER LINE.
+  # Read line-by-line (no word-splitting, no globbing): the file contents
+  # are repo-controlled, but CI runs this script, so an unquoted `$(cat …)`
+  # expansion would let a `*_app.flags` carrying shell metacharacters run on
+  # the runner the moment a job picks it up (#204 F3). One flag per line
+  # means whitespace inside a line is preserved as part of that single arg.
+  # Blank lines are ignored; the `|| [ -n "$line" ]` tail catches a final
+  # line with no trailing newline.
   flags_file="$SCRIPT_DIR/${app_name}_app.flags"
   extra_flags=()
   if [ -f "$flags_file" ]; then
-    # shellcheck disable=SC2207
-    extra_flags=( $(cat "$flags_file") )
+    while IFS= read -r line || [ -n "$line" ]; do
+      [ -n "$line" ] && extra_flags+=( "$line" )
+    done < "$flags_file"
   fi
 
   # Start dev server in background


### PR DESCRIPTION
Closes #204.

A multi-agent audit @ `db602b4` found **no critical/high issues**. This PR lands all six low/info defense-in-depth items, each verified against source.

## Findings addressed

| ID | Sev | Area | Fix |
|----|-----|------|-----|
| **F1** | low | CI | SHA-pin the floating `actions/*` official actions (`checkout`→v6.0.3, `upload-artifact`→v7.0.1, `download-artifact`→v8.0.1) in `test.yml` + `release.yml`, matching the existing third-party pin convention. Dependabot keeps them current. |
| **F2** | low | bridge | `lua_checkstack(L, 8)` guard on the JSON encoder + decoder recursion. Decoder raises a precise Lua error; encoder degrades to `null` (avoids leaking its `strings.Builder` on a longjmp). Adds the `lua_checkstack` FFI binding. |
| **F3** | low | test harness | Read `*_app.flags` sidecars **one flag per line** instead of an unquoted `$(cat)` that word-splits + globs — closes a CI command-injection path. Drops the `SC2207` disable. |
| **F4** | info | runtime | Cap synchronous `:dispatch` recursion at **64** and the `:dispatch-later` timer queue at **10,000**, each with a drop+warn. `pcall` keeps the depth counter correct even when a handler errors. |
| **F5** | info | hot reload | On a failed reload from a fresh file change, arm one **~50ms retry** to tolerate non-atomic editor saves landing mid-write; a retry that also fails gives up (no loop). |
| **F6** | info | docs | New "Trust model" section in `native-bridge.md`: app `.fnl`/`.lua` run with full Lua stdlib as the trusted principal — redin is **not** a sandbox for untrusted code. |

## Tests added

- `json_checkstack_test.odin` — 3 tests (binding wired, deep-but-valid decodes, over-cap rejected)
- `hotreload_retry_test.odin` — 2 tests (retry timing predicate, arm-at-most-once predicate)
- `test_effect.fnl` — 2 tests (timer-queue cap drop, dispatch-depth cap stops runaway + counter resets)

F4's runtime-behavior caps are documented in `docs/app-api.md` and `docs/reference/effects.md` to keep the contract in sync.

## Verification

- Release-stripped build ✅
- `./build-dev.sh` (compiles the `REDIN_DEV` hot-reload path) ✅
- Fennel runtime: **137 passed, 0 failed**
- `odin test src/redin/bridge`: **104 passed, 0 failed**
- `bash test/ui/run-all.sh --headless`: all suites passed
- Memory: tracker active, no leaks on the JSON encode/decode path; port/token files cleaned up on shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)