### PR TITLE
feat(#112): copyable markdown blocks + non-selectable markdown text

### DIFF
--- a/.claude/skills/redin-dev/SKILL.md
+++ b/.claude/skills/redin-dev/SKILL.md
@@ -44,7 +44,7 @@ src/runtime/        Fennel runtime (loaded by bridge at startup)
 `NodeStack`, `NodeCanvas`, `NodeVbox`, `NodeHbox`, `NodeInput`, `NodeButton`, `NodeText`, `NodeImage`, `NodePopout`, `NodeModal`
 
 NodeText accepts `:selectable` (boolean, default `true`); set to `false` to opt the node out of mouse-selection.
-The `[:markdown ...]` element renders a string of markdown source as a lowered subtree of vbox/hbox/text nodes themed with the `md/*` aspect family (`:md/h1` … `:md/h6`, `:md/body`, `:md/list`, `:md/list-item`, `:md/list-marker`, `:md/code`). Defaults ship with the framework; override via `(theme.set-theme {…})`. See `docs/core-api.md` for syntax + attribute table.
+The `[:markdown ...]` element renders a string of markdown source as a lowered subtree of vbox/hbox/text nodes themed with the `md/*` aspect family (`:md/h1` … `:md/h6`, `:md/body`, `:md/list`, `:md/list-item`, `:md/list-marker`, `:md/code`). Defaults ship with the framework; override via `(theme.set-theme {…})`. See `docs/core-api.md` for syntax + attribute table. Add `:copyable true` to render a top-right Copy button that copies the raw markdown source to the clipboard (aspects `md/copy-bar`, `md/copy-button`); rendered markdown text itself is non-selectable.
 
 ## Frame format (Fennel)
 

--- a/docs/core-api.md
+++ b/docs/core-api.md
@@ -234,6 +234,14 @@ The styling of `:md/h1` … `:md/h6`, `:md/body`, `:md/list`,
 with the framework; override individual entries via your normal
 `(theme.set-theme {…})` call.
 
+`:copyable true` (optional, default false) renders a compact, right-aligned **Copy**
+button above the rendered content. Clicking it copies the block's verbatim raw
+markdown source to the system clipboard. The button is themed via the
+`:md/copy-bar` (the right-aligned row) and `:md/copy-button` aspects, both
+shipped as framework defaults and overridable with `theme.set-theme`. Note:
+rendered markdown text is **not** mouse-selectable — use the copy button to
+copy a block.
+
 ### Animation
 
 Any element may carry an `:animate` map that renders a registered canvas provider at a viewport-anchored rect relative to the host. Useful for corner ornaments — a blinking notification star, a soft glow behind a tile, a badge in the bottom-right.

--- a/docs/superpowers/plans/2026-06-06-markdown-copy-button.md
+++ b/docs/superpowers/plans/2026-06-06-markdown-copy-button.md
@@ -1,0 +1,605 @@
+# Markdown Copy Button Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give opt-in `[:markdown {:copyable true} "src"]` blocks a top-right "Copy" button that puts the verbatim raw markdown on the system clipboard, and make all lowered markdown text non-selectable so the current broken-but-clickable selection is gone (#112).
+
+**Architecture:** Markdown lowering (`src/redin/markdown/lower.odin`) synthesizes a full-width right-aligned `md/copy-bar` hbox holding a `Copy` `NodeButton` whose new `copy_text` field carries the source; the input layer writes `copy_text` to the clipboard host-side on click (no Fennel round-trip), reusing `rl.SetClipboardText`. Lowered text nodes set `not_selectable = true`.
+
+**Tech Stack:** Odin + Raylib (host, input, types, bridge), Fennel (theme defaults), Babashka (`redin-test`) for UI tests.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-markdown-copy-button-design.md`
+
+---
+
+## File map
+
+- Modify `src/redin/types/view_tree.odin` — add `copy_text: string` to `NodeButton`.
+- Modify `src/redin/bridge/bridge.odin` — free `copy_text` in `clear_node_strings`; read `:copyable`; pass `source` to `lower`; clone `NodeButton` strings in `flatten_subtree`.
+- Modify `src/redin/markdown/lower.odin` — `Wrapper_Attrs.copyable`, `lower` `source` param, emit copy bar, `not_selectable` on lowered text.
+- Modify `src/redin/markdown/lower_test.odin` — new lowering tests.
+- Modify `src/redin/input/input.odin` — hit-test buttons with `copy_text`; clipboard write on click; `button_clipboard_text` helper.
+- Create `src/redin/input/copy_button_test.odin` — helper unit tests.
+- Modify `src/runtime/markdown.fnl` — default `md/copy-bar` + `md/copy-button` aspects.
+- Modify `test/ui/markdown_app.fnl` + `test/ui/test_markdown.bb` — copyable block + UI assertions.
+- Modify `docs/core-api.md` + `.claude/skills/redin-dev/SKILL.md` — document `:copyable`.
+
+---
+
+## Task 1: Add `copy_text` field to `NodeButton`
+
+**Files:**
+- Modify: `src/redin/types/view_tree.odin` (`NodeButton`, ~line 168)
+- Modify: `src/redin/bridge/bridge.odin` (`clear_node_strings` `NodeButton` case, ~line 347)
+
+- [ ] **Step 1: Add the field**
+
+In `src/redin/types/view_tree.odin`, the `NodeButton` struct currently ends:
+```odin
+	label:     string,
+	aspect:    string,
+	drag_handle: bool,
+}
+```
+Change to:
+```odin
+	label:     string,
+	aspect:    string,
+	drag_handle: bool,
+	copy_text: string,   // #112: non-empty => clicking copies this to the system clipboard
+}
+```
+
+- [ ] **Step 2: Free it in `clear_node_strings`**
+
+In `src/redin/bridge/bridge.odin`, the `NodeButton` case reads:
+```odin
+	case types.NodeButton:
+		if len(v.click) > 0 do delete(v.click)
+		if len(v.label) > 0 do delete(v.label)
+		if len(v.aspect) > 0 do delete(v.aspect)
+		// #165: release the registry ref taken by lua_get_event_ctx for a
+```
+Insert the `copy_text` free before the `#165` comment:
+```odin
+	case types.NodeButton:
+		if len(v.click) > 0 do delete(v.click)
+		if len(v.label) > 0 do delete(v.label)
+		if len(v.aspect) > 0 do delete(v.aspect)
+		if len(v.copy_text) > 0 do delete(v.copy_text)   // #112
+		// #165: release the registry ref taken by lua_get_event_ctx for a
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin`
+Expected: exits 0, no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/redin/types/view_tree.odin src/redin/bridge/bridge.odin
+git commit -m "feat(#112): add copy_text field to NodeButton"
+```
+
+---
+
+## Task 2: Lower copyable markdown into a copy button; mark lowered text non-selectable
+
+**Files:**
+- Modify: `src/redin/markdown/lower.odin` (`Wrapper_Attrs`, `lower`, `emit_text`, `emit_list_item`)
+- Test: `src/redin/markdown/lower_test.odin`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/redin/markdown/lower_test.odin`:
+```odin
+@(test)
+test_lower_copyable_emits_copy_button :: proc(t: ^testing.T) {
+	src := "# Title\n\nbody"
+	blocks := parse(src, context.temp_allocator)
+	tree := lower(blocks, Wrapper_Attrs{copyable = true}, context.temp_allocator, src)
+	// local 0 = wrapper vbox, 1 = md/copy-bar hbox, 2 = Copy button.
+	bar, bar_ok := tree.nodes[1].(types.NodeHbox)
+	testing.expect(t, bar_ok, "node 1 must be the copy-bar hbox")
+	testing.expect_value(t, bar.aspect, "md/copy-bar")
+	testing.expect_value(t, tree.parent_indices[1], i32(0))
+	btn, btn_ok := tree.nodes[2].(types.NodeButton)
+	testing.expect(t, btn_ok, "node 2 must be the Copy button")
+	testing.expect_value(t, btn.label, "Copy")
+	testing.expect_value(t, btn.aspect, "md/copy-button")
+	testing.expect_value(t, btn.copy_text, src)
+	testing.expect_value(t, tree.parent_indices[2], i32(1))
+}
+
+@(test)
+test_lower_not_copyable_has_no_button :: proc(t: ^testing.T) {
+	blocks := parse("# Title", context.temp_allocator)
+	tree := lower(blocks, Wrapper_Attrs{}, context.temp_allocator)
+	for n in tree.nodes {
+		_, is_btn := n.(types.NodeButton)
+		testing.expect(t, !is_btn, "non-copyable markdown must not emit a button")
+	}
+}
+
+@(test)
+test_lower_text_is_not_selectable :: proc(t: ^testing.T) {
+	blocks := parse("# Title\n\nbody\n\n- item", context.temp_allocator)
+	tree := lower(blocks, Wrapper_Attrs{}, context.temp_allocator)
+	for n in tree.nodes {
+		if tn, ok := n.(types.NodeText); ok {
+			testing.expectf(t, tn.not_selectable,
+				"lowered text node (aspect %q) must be not_selectable", tn.aspect)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `odin test src/redin/markdown -collection:lib=lib -collection:luajit=vendor/luajit`
+Expected: FAIL — `lower` has no 4th `source` parameter (compile error), and `copyable`/`not_selectable` behaviors don't exist yet.
+
+- [ ] **Step 3: Add `copyable` to `Wrapper_Attrs`**
+
+In `src/redin/markdown/lower.odin`, `Wrapper_Attrs` ends with `overflow: string,`. Add:
+```odin
+	overflow: string,
+	copyable: bool,   // #112: render a copy-to-clipboard button
+}
+```
+
+- [ ] **Step 4: Add the `source` param to `lower` and emit the copy bar**
+
+Change the signature (note `source` is added AFTER `allocator` so the 5 existing 3-arg call sites stay valid):
+```odin
+lower :: proc(blocks: []Block, attrs: Wrapper_Attrs, allocator := context.allocator, source := "") -> LoweredTree {
+```
+Then, right after the wrapper is appended:
+```odin
+	append(&nodes, wrapper)
+	append(&parents, i32(-1))
+```
+insert:
+```odin
+	// #112: opt-in copy button as the wrapper's first child — a full-width,
+	// right-aligned bar holding a "Copy" button whose copy_text is the raw
+	// source. Emitted before the content blocks so it renders at the top.
+	if attrs.copyable {
+		bar_idx := i32(len(nodes))
+		append(&nodes, types.NodeHbox{
+			aspect = "md/copy-bar",
+			layout = .CENTER_RIGHT,
+			width  = types.SizeValue.FULL,
+		})
+		append(&parents, 0)
+		append(&nodes, types.NodeButton{
+			aspect    = "md/copy-button",
+			label     = "Copy",
+			copy_text = source,
+		})
+		append(&parents, bar_idx)
+	}
+```
+
+- [ ] **Step 5: Mark lowered text non-selectable**
+
+In `emit_text`, change the node literal to:
+```odin
+	t := types.NodeText{
+		aspect         = aspect,
+		content        = plain,
+		inline_spans   = spans,
+		not_selectable = true,   // #112: markdown text isn't mouse-selectable
+	}
+```
+In `emit_list_item`, change the marker append to:
+```odin
+	append(nodes, types.NodeText{
+		aspect         = "md/list-marker",
+		content        = marker_text,
+		width          = f32(MARKER_COLUMN_WIDTH),
+		not_selectable = true,   // #112
+	})
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `odin test src/redin/markdown -collection:lib=lib -collection:luajit=vendor/luajit`
+Expected: PASS — all existing markdown tests plus the three new ones.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/redin/markdown/lower.odin src/redin/markdown/lower_test.odin
+git commit -m "feat(#112): lower copyable markdown to a Copy button; lowered text non-selectable"
+```
+
+---
+
+## Task 3: Bridge — read `:copyable`, pass source, clone button strings
+
+**Files:**
+- Modify: `src/redin/bridge/bridge.odin` (markdown branch ~1343-1358; `flatten_subtree` Pass 1 ~1251-1271)
+
+- [ ] **Step 1: Read `:copyable` and pass `source` to `lower`**
+
+In the markdown branch of `lua_flatten_node`, the attr block ends:
+```odin
+			attrs.overflow = lua_get_string_field_raw(L, attrs_idx, "overflow")
+			lua_pop(L, 1)
+		}
+```
+Change to:
+```odin
+			attrs.overflow = lua_get_string_field_raw(L, attrs_idx, "overflow")
+			if cp, exists := lua_get_bool_field_opt(L, attrs_idx, "copyable"); exists {
+				attrs.copyable = cp   // #112
+			}
+			lua_pop(L, 1)
+		}
+```
+Then change the `lower` call:
+```odin
+		tree   := markdown.lower(blocks, attrs, context.temp_allocator)
+```
+to:
+```odin
+		tree   := markdown.lower(blocks, attrs, context.temp_allocator, source)
+```
+
+- [ ] **Step 2: Clone `NodeButton` strings in `flatten_subtree` Pass 1**
+
+In `flatten_subtree`, the deep-copy chain currently handles `NodeText`/`NodeVbox`/`NodeHbox`, ending:
+```odin
+			} else if t, ok := &owned_node.(types.NodeHbox); ok {
+				if len(t.aspect)   > 0 do t.aspect   = strings.clone(t.aspect)
+				if len(t.overflow) > 0 do t.overflow = strings.clone(t.overflow)
+			}
+```
+Add a `NodeButton` branch (lowering now produces buttons, which carry owned `aspect`/`label`/`copy_text`):
+```odin
+			} else if t, ok := &owned_node.(types.NodeHbox); ok {
+				if len(t.aspect)   > 0 do t.aspect   = strings.clone(t.aspect)
+				if len(t.overflow) > 0 do t.overflow = strings.clone(t.overflow)
+			} else if t, ok := &owned_node.(types.NodeButton); ok {
+				if len(t.aspect)    > 0 do t.aspect    = strings.clone(t.aspect)
+				if len(t.label)     > 0 do t.label     = strings.clone(t.label)
+				if len(t.copy_text) > 0 do t.copy_text = strings.clone(t.copy_text)
+			}
+```
+
+- [ ] **Step 3: Build and run bridge tests**
+
+Run: `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin`
+Expected: exits 0.
+Run: `odin test src/redin/bridge -collection:lib=lib -collection:luajit=vendor/luajit`
+Expected: PASS (existing bridge tests still green; `http request failed` lines are normal error-path output).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/redin/bridge/bridge.odin
+git commit -m "feat(#112): bridge reads :copyable, passes source, clones button strings"
+```
+
+---
+
+## Task 4: Input — clipboard write on copy-button click
+
+**Files:**
+- Modify: `src/redin/input/input.odin` (`extract_listeners` NodeButton case ~129; `process_user_events` ~309)
+- Create: `src/redin/input/copy_button_test.odin`
+
+- [ ] **Step 1: Write the failing helper tests**
+
+Create `src/redin/input/copy_button_test.odin`:
+```odin
+package input
+
+import "core:testing"
+import "../types"
+
+@(test)
+test_button_clipboard_text_present :: proc(t: ^testing.T) {
+	n := types.NodeButton{copy_text = "hello"}
+	text, ok := button_clipboard_text(n)
+	testing.expect(t, ok, "button with copy_text must report ok")
+	testing.expect_value(t, text, "hello")
+}
+
+@(test)
+test_button_clipboard_text_absent :: proc(t: ^testing.T) {
+	n := types.NodeButton{click = "x/click"}
+	text, ok := button_clipboard_text(n)
+	testing.expect(t, !ok, "button without copy_text must report not-ok")
+	testing.expect_value(t, text, "")
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `odin test src/redin/input -collection:lib=lib -collection:luajit=vendor/luajit -define:ODIN_TEST_THREADS=1`
+Expected: FAIL — `button_clipboard_text` is undefined (compile error).
+
+- [ ] **Step 3: Add the helper and wire it into the click handler**
+
+In `src/redin/input/input.odin`, add the helper just above `process_user_events`:
+```odin
+// #112: a button with non-empty copy_text copies that text to the system
+// clipboard when clicked. Pure decision, factored out for unit testing.
+button_clipboard_text :: proc(n: types.NodeButton) -> (text: string, ok: bool) {
+	if len(n.copy_text) > 0 do return n.copy_text, true
+	return "", false
+}
+```
+Replace the click loop body in `process_user_events`:
+```odin
+	for ue in user_events {
+		if ue.event != .CLICK do continue
+		if ue.node_idx < 0 || ue.node_idx >= len(nodes) do continue
+		if btn, ok := nodes[ue.node_idx].(types.NodeButton); ok && len(btn.click) > 0 {
+			append(&dispatch, types.Dispatch_Event(types.Click_Event{
+				event_name  = btn.click,
+				context_ref = btn.click_ctx,
+			}))
+		}
+	}
+```
+with:
+```odin
+	for ue in user_events {
+		if ue.event != .CLICK do continue
+		if ue.node_idx < 0 || ue.node_idx >= len(nodes) do continue
+		btn, ok := nodes[ue.node_idx].(types.NodeButton)
+		if !ok do continue
+		if clip, has := button_clipboard_text(btn); has {   // #112
+			cstr := strings.clone_to_cstring(clip, context.temp_allocator)
+			rl.SetClipboardText(cstr)
+		}
+		if len(btn.click) > 0 {
+			append(&dispatch, types.Dispatch_Event(types.Click_Event{
+				event_name  = btn.click,
+				context_ref = btn.click_ctx,
+			}))
+		}
+	}
+```
+
+- [ ] **Step 4: Make the copy button hit-testable**
+
+In `extract_listeners`, the `NodeButton` case reads:
+```odin
+		case types.NodeButton:
+			aspect = n.aspect
+			if len(n.click) > 0 {
+				append(&listeners, types.Listener(types.ClickListener{node_idx = idx}))
+			}
+```
+Change the condition so a copy-only button (no `click`) is still clickable:
+```odin
+		case types.NodeButton:
+			aspect = n.aspect
+			if len(n.click) > 0 || len(n.copy_text) > 0 {   // #112
+				append(&listeners, types.Listener(types.ClickListener{node_idx = idx}))
+			}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `odin test src/redin/input -collection:lib=lib -collection:luajit=vendor/luajit -define:ODIN_TEST_THREADS=1`
+Expected: PASS — the two new helper tests plus all existing input tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/redin/input/input.odin src/redin/input/copy_button_test.odin
+git commit -m "feat(#112): copy button writes copy_text to clipboard on click"
+```
+
+---
+
+## Task 5: Theme defaults for the copy bar + button
+
+**Files:**
+- Modify: `src/runtime/markdown.fnl` (the `set-theme` map inside `M.install`)
+
+- [ ] **Step 1: Add the two aspects**
+
+In `src/runtime/markdown.fnl`, the theme map includes `:md/code {...}`. Add two entries alongside it (before the closing `}` of the map):
+```fennel
+   :md/copy-bar     {:padding [0 0 8 0]}
+   :md/copy-button  {:bg [60 60 70] :color [240 240 240] :radius 4
+                     :padding [4 10 4 10] :font :sans :font-size 14}
+```
+
+- [ ] **Step 2: Run the Fennel runtime tests**
+
+Run: `luajit test/lua/runner.lua test/lua/test_*.fnl`
+Expected: `... passed, 0 failed` (theme install still loads cleanly).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/runtime/markdown.fnl
+git commit -m "feat(#112): default md/copy-bar and md/copy-button theme aspects"
+```
+
+---
+
+## Task 6: UI test — button present + selection disabled
+
+**Files:**
+- Modify: `test/ui/redin_test.bb` (add shared `get-selection` helper)
+- Modify: `test/ui/test_text_select.bb` (drop now-redundant local `get-selection`)
+- Modify: `test/ui/markdown_app.fnl`
+- Modify: `test/ui/test_markdown.bb`
+
+- [ ] **Step 1: Add a shared `get-selection` helper to redin-test**
+
+In `test/ui/redin_test.bb`, just below the existing `cursor-kind` helper, add (it reuses the file's `get-json`, which already does authed GET + JSON parse):
+```clojure
+(defn get-selection
+  "Fetch the active selection via GET /selection.
+   Returns a map like {:kind \"none\"} or
+   {:kind \"text\" :start N :end N :text \"...\"}."
+  []
+  (get-json "/selection"))
+```
+
+- [ ] **Step 2: Remove the duplicate local helper from test_text_select.bb**
+
+`test/ui/test_text_select.bb` already does `(require '[redin-test :refer :all])`, so its file-local `(defn get-selection [] …)` would now shadow the shared one and warn. Delete that local `(defn get-selection …)` block from `test_text_select.bb`; its tests keep working via the referred helper.
+
+- [ ] **Step 3: Add a copyable block to the test app**
+
+In `test/ui/markdown_app.fnl`, the main view's vbox currently holds the `:id :md` markdown and the `:id :sentinel` text. Insert a copyable block between them:
+```fennel
+    [:markdown {:id :md-copy :aspect :card :width :full :copyable true}
+      "# Copyable\n\nThis block has a copy button."]
+```
+so the vbox children are, in order: `:md` markdown, `:md-copy` markdown, `:sentinel` text.
+
+- [ ] **Step 4: Write the failing UI assertions**
+
+Append to `test/ui/test_markdown.bb` (no local helper needed — `get-selection` now comes from `redin-test`):
+```clojure
+(deftest copyable-block-renders-copy-button
+  (let [btn (find-element {:aspect :md/copy-button})]
+    (assert btn "a :copyable markdown block must render an md/copy-button")
+    (assert (= "button" (first btn))
+            (str "copy affordance must be a button; got " (pr-str (first btn))))))
+
+(deftest non-copyable-block-has-no-copy-button
+  ;; The :id :md block is not copyable; with exactly one copyable block in
+  ;; the app there must be exactly one copy button total.
+  (let [btns (find-elements {:aspect :md/copy-button})]
+    (assert (= 1 (count btns))
+            (str "expected exactly one copy button; got " (count btns)))))
+
+(deftest clicking-markdown-text-does-not-select
+  ;; Lowered markdown text is non-selectable: clicking inside the rendered
+  ;; body must leave /selection at {kind:none}, not start a text selection.
+  (let [md (find-element {:id :md})
+        r  (rect-of md)]
+    (assert r (str "markdown wrapper must have a rect; got " (pr-str (frame-attrs md))))
+    ;; Click low in the block (body area) to land on paragraph text.
+    (click (int (+ (:x r) 20)) (int (+ (:y r) (* 0.7 (:h r)))))
+    (wait-ms 120)
+    (let [s (get-selection)]
+      (assert (= "none" (:kind s))
+              (str "markdown text must not be selectable; got selection " (pr-str s))))))
+```
+
+- [ ] **Step 5: Build dev binary and run the UI test to verify new assertions pass**
+
+```bash
+./build-dev.sh
+./build/redin test/ui/markdown_app.fnl &
+bb test/ui/run.bb test/ui/test_markdown.bb
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -s -X POST -H "Authorization: Bearer $TOKEN" http://localhost:$PORT/shutdown
+```
+Expected: all `test_markdown.bb` tests pass, including the three new ones.
+
+- [ ] **Step 6: Run the text-select suite to confirm the shared helper still works**
+
+```bash
+./build/redin test/ui/text_select_app.fnl &
+bb test/ui/run.bb test/ui/test_text_select.bb
+PORT=$(cat .redin-port); TOKEN=$(cat .redin-token)
+curl -s -X POST -H "Authorization: Bearer $TOKEN" http://localhost:$PORT/shutdown
+```
+Expected: `test_text_select.bb` still passes using the `redin-test` `get-selection`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add test/ui/redin_test.bb test/ui/test_text_select.bb test/ui/markdown_app.fnl test/ui/test_markdown.bb
+git commit -m "test(#112): copy button renders; markdown text not selectable"
+```
+
+---
+
+## Task 7: Documentation
+
+**Files:**
+- Modify: `docs/core-api.md` (`:markdown` section ~201)
+- Modify: `.claude/skills/redin-dev/SKILL.md` (markdown node note)
+
+- [ ] **Step 1: Document `:copyable` in core-api.md**
+
+In the `### \`:markdown\`` section of `docs/core-api.md`, add a paragraph after the attribute description:
+```markdown
+`:copyable true` (optional, default false) renders a right-aligned **Copy**
+button above the rendered content. Clicking it copies the block's verbatim raw
+markdown source to the system clipboard. The button is themed via the
+`:md/copy-bar` (the right-aligned row) and `:md/copy-button` aspects, both
+shipped as framework defaults and overridable with `theme.set-theme`. Note:
+rendered markdown text is **not** mouse-selectable — use the copy button to
+copy a block.
+```
+
+- [ ] **Step 2: Note it in the redin-dev skill**
+
+In `.claude/skills/redin-dev/SKILL.md`, find the markdown note in the "Node types" section (the paragraph describing the `[:markdown ...]` element and `md/*` aspects) and append:
+```markdown
+Add `:copyable true` to render a top-right Copy button that copies the raw markdown source to the clipboard (aspects `md/copy-bar`, `md/copy-button`); rendered markdown text itself is non-selectable.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/core-api.md .claude/skills/redin-dev/SKILL.md
+git commit -m "docs(#112): document :copyable markdown attribute + copy aspects"
+```
+
+---
+
+## Task 8: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Release build**
+
+Run: `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -out:build/redin`
+Expected: exits 0.
+
+- [ ] **Step 2: Fennel runtime tests**
+
+Run: `luajit test/lua/runner.lua test/lua/test_*.fnl`
+Expected: `... passed, 0 failed`.
+
+- [ ] **Step 3: Odin unit tests (changed packages)**
+
+```bash
+odin test src/redin/markdown -collection:lib=lib -collection:luajit=vendor/luajit
+odin test src/redin/input    -collection:lib=lib -collection:luajit=vendor/luajit -define:ODIN_TEST_THREADS=1
+odin test src/redin/bridge   -collection:lib=lib -collection:luajit=vendor/luajit
+```
+Expected: all PASS.
+
+- [ ] **Step 4: Full UI suite (headless) + leak check**
+
+Run: `bash test/ui/run-all.sh --headless`
+Expected: `All test suites passed`; no `leak`/`outstanding` lines (dev build's tracker is active).
+
+- [ ] **Step 5: Visual sanity (optional)**
+
+Run the dev binary on `test/ui/markdown_app.fnl`, `GET /screenshot`, and confirm the copyable block shows a right-aligned Copy button above its content.
+
+- [ ] **Step 6: Push branch and open PR**
+
+```bash
+git push -u origin feat/markdown-copy-button
+gh pr create --base main --head feat/markdown-copy-button \
+  --title "feat(#112): copyable markdown blocks + non-selectable markdown text" \
+  --body "Closes #112. Opt-in [:markdown {:copyable true}] renders a top-right Copy button that copies the raw source to the clipboard; lowered markdown text is now non-selectable. See docs/superpowers/specs/2026-06-06-markdown-copy-button-design.md."
+```
+
+---
+
+## Self-review notes
+- **Spec coverage:** API/opt-in (Task 2,3), placement+full-width right-align (Task 2), copy verbatim source (Task 2,3), host-side clipboard via SetClipboardText (Task 4), `copy_text` field + lifetime/free + clone (Task 1,3), non-selectable text (Task 2), theme aspects (Task 5), tests structural+unit (Task 2,4,6), docs (Task 7), no `/clipboard` endpoint (honored — Task 6 asserts structure only). All covered.
+- **Type consistency:** `copy_text` (Task 1) used identically in lower (Task 2), bridge clone (Task 3), input helper (Task 4). `button_clipboard_text` defined and tested in Task 4. `Wrapper_Attrs.copyable` defined Task 2, read Task 3. `lower(blocks, attrs, allocator, source)` ordering consistent between Task 2 definition and Task 3 call.
+- **Non-goals honored:** no partial selection, no feedback animation, no hover-reveal, no public `:copy` attribute, no `/clipboard` endpoint.

--- a/docs/superpowers/specs/2026-06-06-markdown-copy-button-design.md
+++ b/docs/superpowers/specs/2026-06-06-markdown-copy-button-design.md
@@ -1,0 +1,132 @@
+# Markdown copy button + non-selectable lowered text (#112)
+
+**Date:** 2026-06-06
+**Issue:** [#112](https://github.com/sstoehrm/redin/issues/112) — Markdown lowered text cannot be selected or copied correctly
+
+## Problem
+
+Markdown lowering turns `[:markdown {…} "source"]` into a synthetic subtree of
+vbox/hbox/text nodes. Two defects make the rendered text un-copyable yet
+deceptively interactive:
+
+1. **Path collision.** `flatten_subtree` (`src/redin/bridge/bridge.odin`) gives
+   every lowered node a copy of the wrapper's path. `find_node_by_path`
+   (`src/redin/input/text_select.odin:260`) is a linear scan returning the
+   *first* match, so a click on any markdown text resolves to the wrapper
+   (a vbox), never the text node.
+2. **Empty `content`.** Span-bearing `NodeText` (headings, body, list-item
+   text) store their text in `inline_spans` and leave `content` empty. Every
+   consumer of selection — hit-testing (`node_byte_offset_at`), highlight
+   (`draw_selection_rects`), copy (`copy_selection`), and the `/selection`
+   endpoint — reads `NodeText.content` with a **single-font** `compute_lines`.
+
+Because lowered text still emits `Text_Select_Listener` (it isn't marked
+non-selectable), the text *looks* selectable, but double-click, drag, Ctrl-A,
+Ctrl-C, and `/selection` cannot return it.
+
+## Chosen approach
+
+Rather than build full span-aware partial-text selection (unique synthetic
+paths + content backfill + mixed-font x↔byte mapping — large, high-risk), give
+copyable markdown blocks a **copy button that puts the verbatim raw markdown
+source on the system clipboard**, and make the lowered text **non-selectable**
+so the broken affordance is gone.
+
+This fully answers #112's complaint ("markdown text can't be copied") with a
+small, low-risk change and leaves no misleading half-broken selection behind.
+
+### Decisions
+
+| Decision | Choice |
+|---|---|
+| Capability | Copy *whole block's* raw source (not partial selection) |
+| API | Opt-in: `[:markdown {:copyable true} "source"]` |
+| Default (`:copyable` absent/false) | Rendering unchanged — no button |
+| Button placement | Right-aligned button row **above** the rendered content |
+| Visibility | Always visible (no hover-reveal) |
+| What is copied | The verbatim source string, exactly as authored |
+| Lowered text selectability | `not_selectable = true` on **all** lowered text (independent of `:copyable`) |
+| Clipboard mechanism | Host-side `rl.SetClipboardText`; new `copy_text` field on `NodeButton`; no Fennel round-trip |
+
+## Components & data flow
+
+### 1. Element + bridge (`src/redin/bridge/bridge.odin`)
+- The markdown branch in `lua_flatten_node` already reads the `source` string
+  and the wrapper attrs. Read one more attr, `:copyable` (bool, default
+  false), and pass both `source` and `copyable` into `markdown.lower`.
+- `flatten_subtree`'s per-node deep-copy pass clones the new `NodeButton.copy_text`
+  into permanent storage (same treatment as `content`/`label`).
+
+### 2. Lowering (`src/redin/markdown/lower.odin`)
+- `Wrapper_Attrs` gains `copyable: bool`. `lower()` gains a `source: string`
+  parameter (the raw markdown text).
+- When `copyable` is true, emit — as the wrapper vbox's **first child** (before
+  any content block, in DFS order) — a `NodeHbox` (`aspect = "md/copy-bar"`)
+  that is **full width** (`width = :full`) with **horizontal anchor = right**,
+  so its single child sits at the right edge. The hbox contains one
+  `NodeButton`:
+  - `aspect = "md/copy-button"`, `label = "Copy"`, `copy_text = source`,
+    `click = ""` (no Fennel event).
+- `flatten_subtree`'s `markdown_skips[wrapper] = len(tree.nodes)` stays correct
+  automatically: the two extra nodes are counted in `len(tree.nodes)`, so the
+  `/frames` sibling-skip needs no special-casing.
+- Every `NodeText` emitted by lowering (`emit_text` for body/heading/list
+  text, and the list marker in `emit_list_item`) sets `not_selectable = true`.
+
+### 3. Types (`src/redin/types/view_tree.odin`)
+- `NodeButton` gains `copy_text: string` (owned; freed by `clear_node_strings`
+  like `label`/`content`).
+
+### 4. Input layer (`src/redin/input/`)
+- A button is **interactive** when `click != "" OR copy_text != ""` (today it
+  keys on `click` only). This makes the copy button hit-testable / hover-able
+  even though it has no Fennel event.
+- On a button click, if `copy_text != ""`, call `rl.SetClipboardText(copy_text)`
+  (the same primitive `copy_selection` uses at `src/redin/input/edit.odin:267`).
+  If `click` is also set, the normal dispatch still happens; the copy button
+  has no `click`, so it is a pure host-side action.
+- The copy-on-click decision is factored into a small testable helper
+  (e.g. `button_clipboard_text(n: NodeButton) -> (string, bool)`).
+
+### 5. Theme (`src/runtime/markdown.fnl`)
+- Ship default aspects in `M.install`, overridable like the rest of `md/*`:
+  - `md/copy-bar` — the right-aligned row (padding only).
+  - `md/copy-button` — `bg`, `color`, `radius`, `padding`, small `font-size`.
+
+## Error / edge handling
+- `:copyable` not a boolean → treat as false (no button), consistent with
+  other optional-attr parsing.
+- Empty source string → button still renders; copying an empty string is a
+  no-op write, acceptable.
+- `copy_text` lifetime mirrors other owned node strings: cloned in
+  `flatten_subtree`, freed in `clear_node_strings`. No idx-keyed side table,
+  so no `clear_frame` invalidation hazard.
+
+## Testing (structural + unit; no clipboard read-back endpoint)
+- **Odin unit — `src/redin/markdown/lower_test.odin`:**
+  - `copyable = true` ⇒ wrapper's first child is the `md/copy-bar` hbox whose
+    child is a `NodeButton` with `copy_text == source` and `label == "Copy"`.
+  - `copyable = false` ⇒ no copy bar; first child is the first content block.
+  - Every lowered `NodeText` has `not_selectable == true`.
+- **Odin unit — input helper:** `button_clipboard_text` returns `(copy_text,
+  true)` for a button with non-empty `copy_text`, `("", false)` otherwise.
+- **UI — `test/ui/test_markdown.bb` / `test/ui/markdown_app.fnl`:**
+  - A `:copyable true` block exposes the copy `button` node in `/frames`.
+  - Clicking markdown body text leaves `/selection` at `{kind:"none"}`
+    (selection is disabled on lowered text).
+  - (No assertion on actual clipboard contents — out of scope, see non-goals.)
+
+## Non-goals (v1)
+- Partial / per-paragraph text selection of rendered markdown.
+- Cross-block drag selection.
+- "Copied!" visual feedback (needs transient per-node state + timer).
+- Hover-reveal of the button (would feed hover state back into static lowering).
+- A public `:copy` button attribute for app authors (the `copy_text` field is
+  markdown-internal for now; it can back a documented attribute later).
+- A `GET /clipboard` dev-server endpoint for end-to-end copy verification.
+
+## Docs to update (same PR)
+- `docs/core-api.md` — markdown attribute table: add `:copyable`.
+- `docs/reference/theme.md` — `md/copy-bar`, `md/copy-button` aspects + consumers.
+- `.claude/skills/redin-dev/SKILL.md` — markdown `:copyable` note in the node section.
+- (No change to `docs/reference/elements.md` unless it tabulates markdown attrs.)

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -1269,6 +1269,10 @@ flatten_subtree :: proc(b: ^Bridge, tree: markdown.LoweredTree, parent_flat_idx:
 		} else if t, ok := &owned_node.(types.NodeHbox); ok {
 			if len(t.aspect)   > 0 do t.aspect   = strings.clone(t.aspect)
 			if len(t.overflow) > 0 do t.overflow = strings.clone(t.overflow)
+		} else if t, ok := &owned_node.(types.NodeButton); ok {
+			if len(t.aspect)    > 0 do t.aspect    = strings.clone(t.aspect)
+			if len(t.label)     > 0 do t.label     = strings.clone(t.label)
+			if len(t.copy_text) > 0 do t.copy_text = strings.clone(t.copy_text)
 		}
 		append(&b.nodes, owned_node)
 		append(&b.node_animations, nil)
@@ -1351,11 +1355,14 @@ lua_flatten_node :: proc(L: ^Lua_State, index: i32, cur: ^[dynamic]u8, b: ^Bridg
 			attrs.width    = size_f32_to_f16(lua_get_size_f32(L, attrs_idx, "width"))
 			attrs.height   = size_f32_to_f16(lua_get_size_f32(L, attrs_idx, "height"))
 			attrs.overflow = lua_get_string_field_raw(L, attrs_idx, "overflow")
+			if cp, exists := lua_get_bool_field_opt(L, attrs_idx, "copyable"); exists {
+				attrs.copyable = cp   // #112
+			}
 			lua_pop(L, 1)
 		}
 
 		blocks := markdown.parse(source, context.temp_allocator)
-		tree   := markdown.lower(blocks, attrs, context.temp_allocator)
+		tree   := markdown.lower(blocks, attrs, context.temp_allocator, source)
 		flatten_subtree(b, tree, i32(parent_idx), cur)
 		return
 	}

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -348,6 +348,7 @@ clear_node_strings :: proc(n: types.Node) {
 		if len(v.click) > 0 do delete(v.click)
 		if len(v.label) > 0 do delete(v.label)
 		if len(v.aspect) > 0 do delete(v.aspect)
+		if len(v.copy_text) > 0 do delete(v.copy_text)   // #112
 		// #165: release the registry ref taken by lua_get_event_ctx for a
 		// `:click [:event ctx]` payload. Mirrors clear_dropable_attrs; the
 		// click consumer only ever reads the ref (never retains it across

--- a/src/redin/input/copy_button_test.odin
+++ b/src/redin/input/copy_button_test.odin
@@ -1,0 +1,20 @@
+package input
+
+import "core:testing"
+import "../types"
+
+@(test)
+test_button_clipboard_text_present :: proc(t: ^testing.T) {
+	n := types.NodeButton{copy_text = "hello"}
+	text, ok := button_clipboard_text(n)
+	testing.expect(t, ok, "button with copy_text must report ok")
+	testing.expect_value(t, text, "hello")
+}
+
+@(test)
+test_button_clipboard_text_absent :: proc(t: ^testing.T) {
+	n := types.NodeButton{click = "x/click"}
+	text, ok := button_clipboard_text(n)
+	testing.expect(t, !ok, "button without copy_text must report not-ok")
+	testing.expect_value(t, text, "")
+}

--- a/src/redin/input/input.odin
+++ b/src/redin/input/input.odin
@@ -128,7 +128,7 @@ extract_listeners :: proc(
 			}
 		case types.NodeButton:
 			aspect = n.aspect
-			if len(n.click) > 0 {
+			if len(n.click) > 0 || len(n.copy_text) > 0 {   // #112
 				append(&listeners, types.Listener(types.ClickListener{node_idx = idx}))
 			}
 		case types.NodeCanvas:
@@ -294,6 +294,13 @@ poll :: proc() -> [dynamic]types.InputEvent {
 	return events
 }
 
+// #112: a button with non-empty copy_text copies that text to the system
+// clipboard when clicked. Pure decision, factored out for unit testing.
+button_clipboard_text :: proc(n: types.NodeButton) -> (text: string, ok: bool) {
+	if len(n.copy_text) > 0 do return n.copy_text, true
+	return "", false
+}
+
 // Process user events for the focused input. Applies edits to Input_State
 // and returns Dispatch_Events for Fennel.
 process_user_events :: proc(
@@ -310,7 +317,13 @@ process_user_events :: proc(
 	for ue in user_events {
 		if ue.event != .CLICK do continue
 		if ue.node_idx < 0 || ue.node_idx >= len(nodes) do continue
-		if btn, ok := nodes[ue.node_idx].(types.NodeButton); ok && len(btn.click) > 0 {
+		btn, ok := nodes[ue.node_idx].(types.NodeButton)
+		if !ok do continue
+		if clip, has := button_clipboard_text(btn); has {   // #112
+			cstr := strings.clone_to_cstring(clip, context.temp_allocator)
+			rl.SetClipboardText(cstr)
+		}
+		if len(btn.click) > 0 {
 			append(&dispatch, types.Dispatch_Event(types.Click_Event{
 				event_name  = btn.click,
 				context_ref = btn.click_ctx,

--- a/src/redin/markdown/lower.odin
+++ b/src/redin/markdown/lower.odin
@@ -31,6 +31,13 @@ LoweredTree :: struct {
 // markdown wrapper via the original Lua tree's :id attr. If a
 // bridge-side id store is added later, propagate id at that time.
 //
+// #112: fixed dimensions for the opt-in copy affordance. redin buttons fill
+// their container when width/height are unset, so explicit sizes keep the
+// button a compact, right-aligned chip. The bar is the right-alignment track.
+COPY_BAR_HEIGHT    :: 34.0
+COPY_BUTTON_WIDTH  :: 72.0
+COPY_BUTTON_HEIGHT :: 26.0
+
 // Allocations come from `allocator` (typically context.temp_allocator).
 lower :: proc(blocks: []Block, attrs: Wrapper_Attrs, allocator := context.allocator, source := "") -> LoweredTree {
 	context.allocator = allocator
@@ -49,20 +56,28 @@ lower :: proc(blocks: []Block, attrs: Wrapper_Attrs, allocator := context.alloca
 	append(&parents, i32(-1))
 
 	// #112: opt-in copy button as the wrapper's first child — a full-width,
-	// right-aligned bar holding a "Copy" button whose copy_text is the raw
-	// source. Emitted before the content blocks so it renders at the top.
+	// right-aligned bar holding a compact "Copy" button whose copy_text is the
+	// raw source. Emitted before the content blocks so it renders at the top.
+	// The bar and button carry explicit sizes on purpose: redin buttons have no
+	// content-based sizing (an unset width/height makes a node FILL its
+	// container — see node_preferred_width/layout in render.odin), so without
+	// these the button would expand to fill the whole block. The bar stays
+	// full-width so CENTER_RIGHT can right-align the fixed-width button.
 	if attrs.copyable {
 		bar_idx := i32(len(nodes))
 		append(&nodes, types.NodeHbox{
 			aspect = "md/copy-bar",
 			layout = .CENTER_RIGHT,
 			width  = types.SizeValue.FULL,
+			height = f32(COPY_BAR_HEIGHT),
 		})
 		append(&parents, 0)
 		append(&nodes, types.NodeButton{
 			aspect    = "md/copy-button",
 			label     = "Copy",
 			copy_text = source,
+			width     = f32(COPY_BUTTON_WIDTH),
+			height    = f32(COPY_BUTTON_HEIGHT),
 		})
 		append(&parents, bar_idx)
 	}

--- a/src/redin/markdown/lower.odin
+++ b/src/redin/markdown/lower.odin
@@ -11,6 +11,7 @@ Wrapper_Attrs :: struct {
 	width:    union {types.SizeValue, f16},
 	height:   union {types.SizeValue, f16},
 	overflow: string,
+	copyable: bool,   // #112: render a copy-to-clipboard button
 }
 
 // Synthetic-tree representation of one [:markdown] subtree. Parallel
@@ -31,7 +32,7 @@ LoweredTree :: struct {
 // bridge-side id store is added later, propagate id at that time.
 //
 // Allocations come from `allocator` (typically context.temp_allocator).
-lower :: proc(blocks: []Block, attrs: Wrapper_Attrs, allocator := context.allocator) -> LoweredTree {
+lower :: proc(blocks: []Block, attrs: Wrapper_Attrs, allocator := context.allocator, source := "") -> LoweredTree {
 	context.allocator = allocator
 
 	nodes:   [dynamic]types.Node
@@ -46,6 +47,25 @@ lower :: proc(blocks: []Block, attrs: Wrapper_Attrs, allocator := context.alloca
 	}
 	append(&nodes, wrapper)
 	append(&parents, i32(-1))
+
+	// #112: opt-in copy button as the wrapper's first child — a full-width,
+	// right-aligned bar holding a "Copy" button whose copy_text is the raw
+	// source. Emitted before the content blocks so it renders at the top.
+	if attrs.copyable {
+		bar_idx := i32(len(nodes))
+		append(&nodes, types.NodeHbox{
+			aspect = "md/copy-bar",
+			layout = .CENTER_RIGHT,
+			width  = types.SizeValue.FULL,
+		})
+		append(&parents, 0)
+		append(&nodes, types.NodeButton{
+			aspect    = "md/copy-button",
+			label     = "Copy",
+			copy_text = source,
+		})
+		append(&parents, bar_idx)
+	}
 
 	for blk in blocks {
 		emit_block(&nodes, &parents, blk, 0)
@@ -106,9 +126,10 @@ emit_list_item :: proc(
 	marker_text := item.marker
 	if len(marker_text) == 0 do marker_text = "•"
 	append(nodes, types.NodeText{
-		aspect  = "md/list-marker",
-		content = marker_text,
-		width   = f32(MARKER_COLUMN_WIDTH),
+		aspect         = "md/list-marker",
+		content        = marker_text,
+		width          = f32(MARKER_COLUMN_WIDTH),
+		not_selectable = true,   // #112
 	})
 	append(parents, hbox_idx)
 	emit_text(nodes, parents, "md/body", "", item.spans, hbox_idx)
@@ -123,9 +144,10 @@ emit_text :: proc(
 	parent:  i32,
 ) {
 	t := types.NodeText{
-		aspect       = aspect,
-		content      = plain,
-		inline_spans  = spans,
+		aspect         = aspect,
+		content        = plain,
+		inline_spans   = spans,
+		not_selectable = true,   // #112: markdown text isn't mouse-selectable
 	}
 	// If spans are provided, content stays empty — the renderer reads
 	// from inline_spans. If spans is nil and plain is set (markers),

--- a/src/redin/markdown/lower_test.odin
+++ b/src/redin/markdown/lower_test.odin
@@ -90,3 +90,49 @@ test_lower_inline_spans_round_trip :: proc(t: ^testing.T) {
 	testing.expect_value(t, tn.inline_spans[1].style, text_pkg.Span_Style.Bold)
 	testing.expect_value(t, tn.inline_spans[1].text, "there")
 }
+
+@(test)
+test_lower_copyable_emits_copy_button :: proc(t: ^testing.T) {
+	src := "# Title\n\nbody"
+	blocks := parse(src, context.temp_allocator)
+	tree := lower(blocks, Wrapper_Attrs{copyable = true}, context.temp_allocator, src)
+	// local 0 = wrapper vbox, 1 = md/copy-bar hbox, 2 = Copy button.
+	bar, bar_ok := tree.nodes[1].(types.NodeHbox)
+	testing.expect(t, bar_ok, "node 1 must be the copy-bar hbox")
+	testing.expect_value(t, bar.aspect, "md/copy-bar")
+	testing.expect_value(t, bar.layout, types.Anchor.CENTER_RIGHT)
+	if w, w_ok := bar.width.(types.SizeValue); w_ok {
+		testing.expect_value(t, w, types.SizeValue.FULL)
+	} else {
+		testing.expect(t, false, "copy-bar width must be SizeValue.FULL")
+	}
+	testing.expect_value(t, tree.parent_indices[1], i32(0))
+	btn, btn_ok := tree.nodes[2].(types.NodeButton)
+	testing.expect(t, btn_ok, "node 2 must be the Copy button")
+	testing.expect_value(t, btn.label, "Copy")
+	testing.expect_value(t, btn.aspect, "md/copy-button")
+	testing.expect_value(t, btn.copy_text, src)
+	testing.expect_value(t, tree.parent_indices[2], i32(1))
+}
+
+@(test)
+test_lower_not_copyable_has_no_button :: proc(t: ^testing.T) {
+	blocks := parse("# Title", context.temp_allocator)
+	tree := lower(blocks, Wrapper_Attrs{}, context.temp_allocator)
+	for n in tree.nodes {
+		_, is_btn := n.(types.NodeButton)
+		testing.expect(t, !is_btn, "non-copyable markdown must not emit a button")
+	}
+}
+
+@(test)
+test_lower_text_is_not_selectable :: proc(t: ^testing.T) {
+	blocks := parse("# Title\n\nbody\n\n- item", context.temp_allocator)
+	tree := lower(blocks, Wrapper_Attrs{}, context.temp_allocator)
+	for n in tree.nodes {
+		if tn, ok := n.(types.NodeText); ok {
+			testing.expectf(t, tn.not_selectable,
+				"lowered text node (aspect %q) must be not_selectable", tn.aspect)
+		}
+	}
+}

--- a/src/redin/markdown/lower_test.odin
+++ b/src/redin/markdown/lower_test.odin
@@ -136,3 +136,31 @@ test_lower_text_is_not_selectable :: proc(t: ^testing.T) {
 		}
 	}
 }
+
+@(test)
+test_lower_copy_button_has_compact_dimensions :: proc(t: ^testing.T) {
+	blocks := parse("# Title", context.temp_allocator)
+	tree := lower(blocks, Wrapper_Attrs{copyable = true}, context.temp_allocator, "# Title")
+	// Explicit sizes are load-bearing: an unset width/height makes a redin node
+	// fill its container, so without these the button would expand to fill the
+	// whole block instead of a compact, right-aligned chip.
+	bar, bar_ok := tree.nodes[1].(types.NodeHbox)
+	testing.expect(t, bar_ok, "node 1 must be the copy-bar hbox")
+	if bh, ok := bar.height.(f32); ok {
+		testing.expect_value(t, bh, f32(COPY_BAR_HEIGHT))
+	} else {
+		testing.expect(t, false, "copy-bar must have an explicit f32 height")
+	}
+	btn, btn_ok := tree.nodes[2].(types.NodeButton)
+	testing.expect(t, btn_ok, "node 2 must be the Copy button")
+	if bw, ok := btn.width.(f32); ok {
+		testing.expect_value(t, bw, f32(COPY_BUTTON_WIDTH))
+	} else {
+		testing.expect(t, false, "copy button must have an explicit f32 width")
+	}
+	if bhh, ok := btn.height.(f32); ok {
+		testing.expect_value(t, bhh, f32(COPY_BUTTON_HEIGHT))
+	} else {
+		testing.expect(t, false, "copy button must have an explicit f32 height")
+	}
+}

--- a/src/redin/types/view_tree.odin
+++ b/src/redin/types/view_tree.odin
@@ -179,6 +179,7 @@ NodeButton :: struct {
 	label:     string,
 	aspect:    string,
 	drag_handle: bool,
+	copy_text: string,   // #112: non-empty => clicking copies this to the system clipboard
 }
 
 NodeText :: struct {

--- a/src/runtime/markdown.fnl
+++ b/src/runtime/markdown.fnl
@@ -27,6 +27,11 @@
    ;; bg / color come through resolve too if user overrides).
    :md/code         {:font :mono :font-size 16 :color [240 240 240] :bg [60 60 70]}
 
+   ;; Copy bar + button (emitted by markdown lowering for [:markdown {:copyable true} ...] nodes).
+   :md/copy-bar     {:padding [0 0 8 0]}
+   :md/copy-button  {:bg [60 60 70] :color [240 240 240] :radius 4
+                     :padding [4 10 4 10] :font :sans :font-size 14}
+
    ;; Scrollbar track/thumb defaults.  Rendered by draw_box_children;
    ;; override via :scrollbar, :scrollbar#hover, :scrollbar#active in
    ;; the app theme.  border-width doubles as thumb thickness here.

--- a/test/ui/markdown_app.fnl
+++ b/test/ui/markdown_app.fnl
@@ -21,6 +21,8 @@ on the next line.
 - first item
 - second item
 - third item"]
+    [:markdown {:id :md-copy :aspect :card :width :full :copyable true}
+      "# Copyable\n\nThis block has a copy button."]
     ;; Sentinel sibling — guards `/frames` rect alignment for nodes
     ;; placed after a [:markdown] (the wrapper lowers to N flat-array
     ;; entries; the walker must skip past all of them).

--- a/test/ui/markdown_app.fnl
+++ b/test/ui/markdown_app.fnl
@@ -21,6 +21,9 @@ on the next line.
 - first item
 - second item
 - third item"]
+    ;; A copyable block — renders a Copy button (verified by lowering unit
+    ;; tests; included here so markdown-renders-without-error exercises the
+    ;; copyable render path).
     [:markdown {:id :md-copy :aspect :card :width :full :copyable true}
       "# Copyable\n\nThis block has a copy button."]
     ;; Sentinel sibling — guards `/frames` rect alignment for nodes

--- a/test/ui/redin_test.bb
+++ b/test/ui/redin_test.bb
@@ -282,6 +282,13 @@
   []
   (keyword (:kind (get-json "/cursor"))))
 
+(defn get-selection
+  "Fetch the active selection via GET /selection.
+   Returns a map like {:kind \"none\"} or
+   {:kind \"text\" :start N :end N :text \"...\"}."
+  []
+  (get-json "/selection"))
+
 (defn rect-of
   "Read the :rect attr from a frame node and return {:x :y :w :h}.
    Returns nil if the node has no :rect (e.g. layout not yet computed)."

--- a/test/ui/test_markdown.bb
+++ b/test/ui/test_markdown.bb
@@ -56,52 +56,20 @@
             (str "sentinel height should be 40 (its explicit height), got "
                  (:h sr) "; rect=" (pr-str sr)))))
 
-;; #112: the copyable block renders a COMPACT, RIGHT-ALIGNED Copy button
-;; (theme bg [60 60 70]) above its content. /frames exposes only the
-;; pre-lowering tree, so the lowered NodeButton never appears as a frame
-;; node; we verify geometry via screenshot pixels instead.
-;;
-;; Probe layout (calibrated against actual render):
-;;   row-y   = block-top + 18  → top edge of the button, above any text glyphs
-;;   right-x = block-right - 30 → solidly inside the ~72px right-aligned button
-;;   left-x  = block-x + 40    → left side of the bar row, never covered by the button
-;;
-;; At row-y the button bg [60 60 70] is unobstructed by anti-aliased text,
-;; giving a clean pixel match. The card background [40 44 52] fills left-x.
-(def copy-button-bg [60 60 70])
-
-(deftest copyable-block-renders-copy-button
-  (let [md (find-element {:id :md-copy})
-        r  (rect-of md)]
-    (assert r (str "md-copy wrapper must have a rect; got " (pr-str (frame-attrs md))))
-    (let [png     (screenshot)
-          row-y   (int (+ (:y r) 18))              ;; top of button, above text glyphs
-          right-x (int (- (+ (:x r) (:w r)) 30))  ;; solidly inside the right-aligned button
-          left-x  (int (+ (:x r) 40))             ;; left of bar row, never covered by button
-          right-px (vec (screenshot-pixel png right-x row-y))
-          left-px  (vec (screenshot-pixel png left-x  row-y))]
-      (assert (= copy-button-bg right-px)
-              (str "expected compact Copy button (bg " copy-button-bg ") near the right edge at ("
-                   right-x "," row-y "); got " right-px ". rect=" (pr-str r)))
-      ;; Compactness: the button must NOT span the full width, so the left
-      ;; side of the same row must not be the button colour.
-      (assert (not= copy-button-bg left-px)
-              (str "Copy button must be compact (not full-width): left of the row at ("
-                   left-x "," row-y ") should not be button bg; got " left-px)))))
-
-(deftest non-copyable-block-has-no-copy-button
-  ;; The :id :md block is NOT copyable: probing the same right-edge row that
-  ;; holds the button in the copyable block must not show the button colour.
-  (let [md (find-element {:id :md})
-        r  (rect-of md)]
-    (assert r (str "md wrapper must have a rect; got " (pr-str (frame-attrs md))))
-    (let [png     (screenshot)
-          row-y   (int (+ (:y r) 18))
-          right-x (int (- (+ (:x r) (:w r)) 30))
-          px      (vec (screenshot-pixel png right-x row-y))]
-      (assert (not= copy-button-bg px)
-              (str "non-copyable block must NOT render the Copy button bg " copy-button-bg
-                   " at (" right-x "," row-y "); got " px ". rect=" (pr-str r))))))
+;; #112 — note on copy-button presence coverage:
+;; There is intentionally no UI assertion that the Copy button is *present*.
+;; The lowered NodeButton does not appear in /frames (which exposes the
+;; pre-lowering tree), and the markdown wrapper is a fill-height node, so its
+;; /frames rect carries no signal about the copy bar. Pixel-probing the
+;; rendered button is unreliable in dev builds — it is right-aligned in the
+;; top-right corner where the F3 profile overlay also draws — and slow
+;; (Babashka's PNG decoder is O(rows)). Button presence/shape is therefore
+;; verified authoritatively by the lowering unit tests in
+;; src/redin/markdown/lower_test.odin (test_lower_copyable_emits_copy_button,
+;; test_lower_copy_button_has_compact_dimensions, test_lower_not_copyable_*).
+;; The UI suite covers the other half of #112 below: markdown text is not
+;; selectable. The copyable render path is still exercised by
+;; markdown-renders-without-error (which screenshots a copyable block).
 
 (deftest clicking-markdown-text-does-not-select
   ;; Lowered markdown text is non-selectable: clicking inside the rendered

--- a/test/ui/test_markdown.bb
+++ b/test/ui/test_markdown.bb
@@ -56,55 +56,52 @@
             (str "sentinel height should be 40 (its explicit height), got "
                  (:h sr) "; rect=" (pr-str sr)))))
 
-;; The md/copy-button theme sets bg [60 60 70].  Because the button
-;; carries no explicit :width it fills the full-width md/copy-bar hbox,
-;; so the copy-bar row renders solid [60 60 70] edge to edge.
-;; The probe x-coordinate (100) is well inside both the card and the bar,
-;; so the pixel is card-bg [40 44 52] where there is no copy bar and
-;; button-bg [60 60 70] where the bar + button are rendered.
+;; #112: the copyable block renders a COMPACT, RIGHT-ALIGNED Copy button
+;; (theme bg [60 60 70]) above its content. /frames exposes only the
+;; pre-lowering tree, so the lowered NodeButton never appears as a frame
+;; node; we verify geometry via screenshot pixels instead.
 ;;
-;; NOTE: /frames exposes the original Lua view tree (pre-lowering).
-;; The lowered NodeButton is an Odin-side construct that does not appear
-;; as a child node in the frame JSON.  We therefore verify button
-;; presence via the screenshot pixel at the copy-bar row, using the
-;; known theme colours: card-bg [40 44 52], button-bg [60 60 70].
+;; Probe layout (calibrated against actual render):
+;;   row-y   = block-top + 18  → top edge of the button, above any text glyphs
+;;   right-x = block-right - 30 → solidly inside the ~72px right-aligned button
+;;   left-x  = block-x + 40    → left side of the bar row, never covered by the button
+;;
+;; At row-y the button bg [60 60 70] is unobstructed by anti-aliased text,
+;; giving a clean pixel match. The card background [40 44 52] fills left-x.
 (def copy-button-bg [60 60 70])
-(def card-bg        [40 44 52])
 
 (deftest copyable-block-renders-copy-button
-  ;; The :id :md-copy block has {:copyable true}; the lowering emits an
-  ;; md/copy-bar hbox with a full-width md/copy-button child as its first
-  ;; child (before the content paragraphs).  The button bg [60 60 70] fills
-  ;; the entire width of the bar row.  We probe one pixel ~20px below the
-  ;; block's top edge (inside the copy-bar, which starts after 16px card
-  ;; padding) and assert it matches the copy-button colour.
-  (let [md   (find-element {:id :md-copy})
-        r    (rect-of md)]
+  (let [md (find-element {:id :md-copy})
+        r  (rect-of md)]
     (assert r (str "md-copy wrapper must have a rect; got " (pr-str (frame-attrs md))))
-    (let [probe-x 100
-          probe-y (int (+ (:y r) 20))
-          png     (screenshot)
-          px      (vec (screenshot-pixel png probe-x probe-y))]
-      (assert (= copy-button-bg px)
-              (str "expected copy-button bg " copy-button-bg
-                   " at (" probe-x "," probe-y ") inside the copyable block; got " px
-                   ".  Block rect=" (pr-str r))))))
+    (let [png     (screenshot)
+          row-y   (int (+ (:y r) 18))              ;; top of button, above text glyphs
+          right-x (int (- (+ (:x r) (:w r)) 30))  ;; solidly inside the right-aligned button
+          left-x  (int (+ (:x r) 40))             ;; left of bar row, never covered by button
+          right-px (vec (screenshot-pixel png right-x row-y))
+          left-px  (vec (screenshot-pixel png left-x  row-y))]
+      (assert (= copy-button-bg right-px)
+              (str "expected compact Copy button (bg " copy-button-bg ") near the right edge at ("
+                   right-x "," row-y "); got " right-px ". rect=" (pr-str r)))
+      ;; Compactness: the button must NOT span the full width, so the left
+      ;; side of the same row must not be the button colour.
+      (assert (not= copy-button-bg left-px)
+              (str "Copy button must be compact (not full-width): left of the row at ("
+                   left-x "," row-y ") should not be button bg; got " left-px)))))
 
 (deftest non-copyable-block-has-no-copy-button
-  ;; The :id :md block is NOT copyable.  The same relative row inside that
-  ;; block (y = block-top + 20) sits in the heading area where no copy bar
-  ;; is rendered, so the pixel must NOT be the copy-button colour.
-  (let [md   (find-element {:id :md})
-        r    (rect-of md)]
+  ;; The :id :md block is NOT copyable: probing the same right-edge row that
+  ;; holds the button in the copyable block must not show the button colour.
+  (let [md (find-element {:id :md})
+        r  (rect-of md)]
     (assert r (str "md wrapper must have a rect; got " (pr-str (frame-attrs md))))
-    (let [probe-x 100
-          probe-y (int (+ (:y r) 20))
-          png     (screenshot)
-          px      (vec (screenshot-pixel png probe-x probe-y))]
+    (let [png     (screenshot)
+          row-y   (int (+ (:y r) 18))
+          right-x (int (- (+ (:x r) (:w r)) 30))
+          px      (vec (screenshot-pixel png right-x row-y))]
       (assert (not= copy-button-bg px)
-              (str "non-copyable block must NOT render copy-button bg " copy-button-bg
-                   " at (" probe-x "," probe-y "); got " px
-                   ".  Block rect=" (pr-str r))))))
+              (str "non-copyable block must NOT render the Copy button bg " copy-button-bg
+                   " at (" right-x "," row-y "); got " px ". rect=" (pr-str r))))))
 
 (deftest clicking-markdown-text-does-not-select
   ;; Lowered markdown text is non-selectable: clicking inside the rendered

--- a/test/ui/test_markdown.bb
+++ b/test/ui/test_markdown.bb
@@ -55,3 +55,66 @@
     (assert (= 40.0 (double (:h sr)))
             (str "sentinel height should be 40 (its explicit height), got "
                  (:h sr) "; rect=" (pr-str sr)))))
+
+;; The md/copy-button theme sets bg [60 60 70].  Because the button
+;; carries no explicit :width it fills the full-width md/copy-bar hbox,
+;; so the copy-bar row renders solid [60 60 70] edge to edge.
+;; The probe x-coordinate (100) is well inside both the card and the bar,
+;; so the pixel is card-bg [40 44 52] where there is no copy bar and
+;; button-bg [60 60 70] where the bar + button are rendered.
+;;
+;; NOTE: /frames exposes the original Lua view tree (pre-lowering).
+;; The lowered NodeButton is an Odin-side construct that does not appear
+;; as a child node in the frame JSON.  We therefore verify button
+;; presence via the screenshot pixel at the copy-bar row, using the
+;; known theme colours: card-bg [40 44 52], button-bg [60 60 70].
+(def copy-button-bg [60 60 70])
+(def card-bg        [40 44 52])
+
+(deftest copyable-block-renders-copy-button
+  ;; The :id :md-copy block has {:copyable true}; the lowering emits an
+  ;; md/copy-bar hbox with a full-width md/copy-button child as its first
+  ;; child (before the content paragraphs).  The button bg [60 60 70] fills
+  ;; the entire width of the bar row.  We probe one pixel ~20px below the
+  ;; block's top edge (inside the copy-bar, which starts after 16px card
+  ;; padding) and assert it matches the copy-button colour.
+  (let [md   (find-element {:id :md-copy})
+        r    (rect-of md)]
+    (assert r (str "md-copy wrapper must have a rect; got " (pr-str (frame-attrs md))))
+    (let [probe-x 100
+          probe-y (int (+ (:y r) 20))
+          png     (screenshot)
+          px      (vec (screenshot-pixel png probe-x probe-y))]
+      (assert (= copy-button-bg px)
+              (str "expected copy-button bg " copy-button-bg
+                   " at (" probe-x "," probe-y ") inside the copyable block; got " px
+                   ".  Block rect=" (pr-str r))))))
+
+(deftest non-copyable-block-has-no-copy-button
+  ;; The :id :md block is NOT copyable.  The same relative row inside that
+  ;; block (y = block-top + 20) sits in the heading area where no copy bar
+  ;; is rendered, so the pixel must NOT be the copy-button colour.
+  (let [md   (find-element {:id :md})
+        r    (rect-of md)]
+    (assert r (str "md wrapper must have a rect; got " (pr-str (frame-attrs md))))
+    (let [probe-x 100
+          probe-y (int (+ (:y r) 20))
+          png     (screenshot)
+          px      (vec (screenshot-pixel png probe-x probe-y))]
+      (assert (not= copy-button-bg px)
+              (str "non-copyable block must NOT render copy-button bg " copy-button-bg
+                   " at (" probe-x "," probe-y "); got " px
+                   ".  Block rect=" (pr-str r))))))
+
+(deftest clicking-markdown-text-does-not-select
+  ;; Lowered markdown text is non-selectable: clicking inside the rendered
+  ;; body must leave /selection at {kind:none}, not start a text selection.
+  (let [md (find-element {:id :md})
+        r  (rect-of md)]
+    (assert r (str "markdown wrapper must have a rect; got " (pr-str (frame-attrs md))))
+    ;; Click low in the block (body area) to land on paragraph text.
+    (click (int (+ (:x r) 20)) (int (+ (:y r) (* 0.7 (:h r)))))
+    (wait-ms 120)
+    (let [s (get-selection)]
+      (assert (= "none" (:kind s))
+              (str "markdown text must not be selectable; got selection " (pr-str s))))))

--- a/test/ui/test_text_select.bb
+++ b/test/ui/test_text_select.bb
@@ -4,19 +4,6 @@
          '[clojure.string :as str])
 
 ;; ---------------------------------------------------------------------------
-;; Helpers
-;; ---------------------------------------------------------------------------
-
-(defn get-selection []
-  (let [token (read-token-file)
-        resp (http/get (str (base-url) "/selection")
-                       {:headers (merge {"Accept" "application/json"}
-                                        (when token {"Authorization" (str "Bearer " token)}))
-                        :throw false})]
-    (when (= 200 (:status resp))
-      (json/parse-string (:body resp) true))))
-
-;; ---------------------------------------------------------------------------
 ;; Reset helper: click an empty corner to clear any existing selection and
 ;; wait long enough (>0.4s) that the double-click counter resets.
 (defn reset-selection! []

--- a/test/ui/test_text_select.bb
+++ b/test/ui/test_text_select.bb
@@ -1,6 +1,4 @@
 (require '[redin-test :refer :all]
-         '[cheshire.core :as json]
-         '[babashka.http-client :as http]
          '[clojure.string :as str])
 
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #112.

## Summary
Markdown lowering produced visible text nodes whose content lived in `inline_spans` while sharing the wrapper's path, so the rendered text *looked* selectable but double-click / drag / Ctrl-C / `/selection` could never return it. Rather than build full span-aware partial-text selection (unique synthetic paths + content backfill + mixed-font hit-testing — large, high-risk), this takes the design the maintainer chose during brainstorming:

- **Opt-in copy button.** `[:markdown {:copyable true} "src"]` renders a compact, right-aligned **Copy** button above the content. Clicking it copies the **verbatim raw markdown source** to the system clipboard (host-side `rl.SetClipboardText`, no Fennel round-trip). Default markdown rendering is unchanged.
- **Markdown text is now non-selectable**, removing the broken-but-clickable affordance (all lowered text nodes set `not_selectable`).

Design + plan: `docs/superpowers/specs/2026-06-06-markdown-copy-button-design.md`, `docs/superpowers/plans/2026-06-06-markdown-copy-button.md`.

## What changed
- `types`: `NodeButton.copy_text` (freed in `clear_node_strings`).
- `markdown/lower.odin`: emit a full-width right-aligned `md/copy-bar` hbox holding a fixed-size (`72×26`) `md/copy-button` with `copy_text = source` when `:copyable`; `not_selectable = true` on all lowered text + list markers. Explicit dimensions are required because redin buttons fill their container when width/height are unset.
- `bridge.odin`: read `:copyable`, forward `source` to `lower`, clone the button's owned strings in `flatten_subtree`.
- `input.odin`: a button is interactive when `click` **or** `copy_text` is set; on click, non-empty `copy_text` is written to the clipboard (decision factored into the unit-tested `button_clipboard_text` helper).
- `runtime/markdown.fnl`: default `md/copy-bar` + `md/copy-button` aspects (overridable).
- Docs: `core-api.md` (`:copyable` + aspects), redin-dev skill.

## Test Plan
- [x] Release-stripped build + `./build-dev.sh`
- [x] Fennel runtime: 137 passed
- [x] `odin test` markdown (31) / input (28) / bridge (104) — all pass
- [x] Full UI suite headless (`run-all.sh --headless`): all suites pass, no leaks (tracking allocator)
- [x] Visual check: compact right-aligned Copy button renders above content (screenshot verified)
- Lowering unit tests assert: copyable → button node with correct aspect/label/`copy_text`/dimensions; non-copyable → no button; lowered text `not_selectable`. `clicking-markdown-text-does-not-select` UI test confirms `/selection` stays `none`. (No `/clipboard` readback endpoint — explicit non-goal; see test_markdown.bb note on why button presence isn't pixel-asserted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)