### PR TITLE
Expose mouse wheel deltas and -/= keys to canvas providers

### DIFF
--- a/docs/superpowers/specs/2026-04-12-fennel-canvas-drawing-api-design.md
+++ b/docs/superpowers/specs/2026-04-12-fennel-canvas-drawing-api-design.md
@@ -101,6 +101,10 @@ All coordinates are canvas-relative. Input state is passed from Odin when invoki
 ;; Mouse inside canvas bounds
 (ctx.mouse-in?)
 
+;; Mouse wheel deltas this frame (0 when idle); gate on mouse-in? as needed
+(ctx.wheel-x)   ;; horizontal scroll delta (raw raylib; shift→horiz promotion not applied)
+(ctx.wheel-y)   ;; vertical scroll delta
+
 ;; Keyboard (when canvas has focus)
 (ctx.key-down? :space)
 (ctx.key-pressed? :enter)

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -2714,6 +2714,8 @@ string_to_key :: proc(name: string) -> rl.KeyboardKey {
 	case "7":         return .SEVEN
 	case "8":         return .EIGHT
 	case "9":         return .NINE
+	case "-":         return .MINUS
+	case "=":         return .EQUAL
 	case "shift":     return .LEFT_SHIFT
 	case "ctrl":      return .LEFT_CONTROL
 	case "alt":       return .LEFT_ALT

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -661,7 +661,7 @@ push_mouse_buttons :: proc(L: ^Lua_State, parent_idx: i32, field: cstring, query
 
 // Build a Lua table with mouse state for canvas draw functions
 push_canvas_input_state :: proc(L: ^Lua_State, rect: rl.Rectangle) {
-	lua_createtable(L, 0, 6)
+	lua_createtable(L, 0, 8)
 	input_idx := lua_gettop(L)
 
 	m := input.mouse_pos()
@@ -678,6 +678,17 @@ push_canvas_input_state :: proc(L: ^Lua_State, rect: rl.Rectangle) {
 	push_mouse_buttons(L, input_idx, "mouse-down", input.is_mouse_button_down)
 	push_mouse_buttons(L, input_idx, "mouse-pressed", input.is_mouse_button_pressed)
 	push_mouse_buttons(L, input_idx, "mouse-released", input.is_mouse_button_released)
+
+	// Raw raylib wheel deltas for this frame. GetMouseWheelMoveV is a pure
+	// read of the frame's stored value (not consume-once), so reading it
+	// here during render does not race the input poll. The shift→horizontal
+	// promotion in input.poll() is intentionally not replicated — providers
+	// gate on mouse-in? / shift themselves.
+	wheel := rl.GetMouseWheelMoveV()
+	lua_pushnumber(L, f64(wheel.x))
+	lua_setfield(L, input_idx, "wheel-x")
+	lua_pushnumber(L, f64(wheel.y))
+	lua_setfield(L, input_idx, "wheel-y")
 }
 
 // ---------------------------------------------------------------------------

--- a/src/runtime/canvas.fnl
+++ b/src/runtime/canvas.fnl
@@ -36,6 +36,8 @@
      :mouse-released? (fn [?btn]
                         (let [tbl (. input :mouse-released)]
                           (if tbl (. tbl (or ?btn :left)) false)))
+     :wheel-x (fn [] (or (. input :wheel-x) 0))
+     :wheel-y (fn [] (or (. input :wheel-y) 0))
      :key-down? (fn [key]
                   (let [redin-tbl (rawget _G :redin)]
                     (if (and redin-tbl (rawget redin-tbl :key_down))

--- a/test/lua/test_canvas.fnl
+++ b/test/lua/test_canvas.fnl
@@ -221,6 +221,28 @@
     (assert (= (length dispatched) 1) "one event dispatched")
     (assert (= (. (. dispatched 1) 1) :test-event) "event name")))
 
+;; --- wheel input queries ---
+
+(fn t.test-wheel-queries-pass-through []
+  (canvas._reset)
+  (var seen nil)
+  (canvas.register :wheel-test
+                   (fn [ctx]
+                     (set seen [(ctx.wheel-x) (ctx.wheel-y)])))
+  (canvas._draw :wheel-test 100 100 {:wheel-x 1.5 :wheel-y -2})
+  (assert (= (. seen 1) 1.5) "wheel-x passes through")
+  (assert (= (. seen 2) -2) "wheel-y passes through"))
+
+(fn t.test-wheel-queries-default-zero []
+  (canvas._reset)
+  (var seen nil)
+  (canvas.register :wheel-default
+                   (fn [ctx]
+                     (set seen [(ctx.wheel-x) (ctx.wheel-y)])))
+  (canvas._draw :wheel-default 100 100 {})
+  (assert (= (. seen 1) 0) "wheel-x defaults to 0")
+  (assert (= (. seen 2) 0) "wheel-y defaults to 0"))
+
 ;; --- init wiring ---
 
 (fn t.test-canvas-global-set-after-register-globals []


### PR DESCRIPTION
## Summary
- `push_canvas_input_state` now includes `wheel-x` / `wheel-y` from `rl.GetMouseWheelMoveV()` (raw per-frame deltas; safe to read during render since raylib stores the frame value), and `build-ctx` exposes them as `(ctx.wheel-x)` / `(ctx.wheel-y)` defaulting to 0. Closes #211.
- `string_to_key` gains `"-"` → `.MINUS` and `"="` → `.EQUAL` so canvas apps can bind zoom shortcuts.
- The shift→horizontal promotion that `input.poll()` applies to ScrollEvents is intentionally not replicated; providers gate on `(ctx.mouse-in?)` / shift themselves (documented in the canvas drawing API spec doc).

## Test Plan
- [x] `luajit test/lua/runner.lua test/lua/test_canvas.fnl` — 22 passed (2 new: wheel pass-through, default-zero)
- [x] Full Fennel suite — 149 passed, 0 failed
- [x] `odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit` — clean
- [x] Manual: wheel-zoom in a canvas app (motivating consumer: conops-ui graph view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)