### PR TITLE
fix(shell): run shell workers under the caller's context allocator

### DIFF
--- a/.claude/skills/redin-maintenance/SKILL.md
+++ b/.claude/skills/redin-maintenance/SKILL.md
@@ -72,7 +72,7 @@ Every non-OPTIONS request to the dev server needs `Authorization: Bearer <token>
 
 ### Available test suites
 
-`smoke`, `input`, `button`, `canvas`, `drag`, `image`, `line_height`, `modal`, `multiline`, `popout`, `resize`, `scroll`, `scroll_x`, `shadow`, `text_select`, `viewport`, `animate`, `devserver_pool`
+`agent`, `animate`, `button`, `canvas`, `canvas_override_press`, `devserver_pool`, `drag`, `hover_active`, `image`, `input`, `input_parsing`, `json_limits`, `line_height`, `markdown`, `modal`, `multiline`, `nested_click`, `popout`, `profile`, `resize`, `scroll`, `scroll_clip`, `scroll_x`, `scrollbar_drag`, `scrollbar_padded`, `shadow`, `shell`, `smoke`, `text_select`, `viewport`
 
 ### Drag tests and the mouse-takeover pipeline
 

--- a/src/redin/bridge/shell.odin
+++ b/src/redin/bridge/shell.odin
@@ -138,7 +138,14 @@ shell_client_request :: proc(sc: ^Shell_Client, req: Shell_Request) {
 	// Count this worker before it starts so shell_client_destroy can wait
 	// for it (#166). The worker decrements last, after its final access.
 	sync.atomic_add(&sc.workers_alive, 1)
-	thread.create_and_start_with_data(data, shell_thread_proc, self_cleanup = true)
+	// Pass the caller's context so the worker allocates Shell_Response
+	// strings (and frees the request + thread data) with the same allocator
+	// the main thread uses on its side of the handoff. Without this, the
+	// worker runs under `runtime.default_context()` (heap), and the main
+	// thread's tracking allocator (REDIN_TRACK_MEM) hits a bad-free
+	// assertion -> SIGILL when it frees the response (#214). Mirrors
+	// Http_Client; core:thread swaps in a per-thread temp allocator.
+	thread.create_and_start_with_data(data, shell_thread_proc, init_context = context, self_cleanup = true)
 }
 
 shell_client_poll :: proc(sc: ^Shell_Client, results: ^[dynamic]Shell_Response) {

--- a/src/redin/bridge/shell_allocator_test.odin
+++ b/src/redin/bridge/shell_allocator_test.odin
@@ -1,0 +1,87 @@
+package bridge
+
+// Regression test for #214: shell worker threads ran under
+// runtime.default_context(), so Shell_Response strings were allocated with
+// the plain heap allocator while the main thread freed them with whatever
+// context.allocator it runs under — the tracking allocator in
+// REDIN_TRACK_MEM builds, which trapped on the mismatched free (SIGILL)
+// the moment the first :shell result was delivered. shell_client_request
+// now hands the caller's context to the worker (mirroring Http_Client), so
+// every allocation that crosses the thread boundary — response strings,
+// the request strings freed worker-side, the Shell_Thread_Data box, the
+// results array's backing — goes through one allocator.
+
+import "core:mem"
+import "core:strings"
+import "core:sync"
+import "core:testing"
+import "core:time"
+
+@(test)
+test_shell_worker_uses_caller_allocator :: proc(t: ^testing.T) {
+	// Mirror REDIN_TRACK_MEM: wrap this test's allocator in a tracking
+	// allocator. Record bad frees instead of panicking (the default
+	// callback traps -> SIGILL) so a regression fails with a message.
+	track: mem.Tracking_Allocator
+	mem.tracking_allocator_init(&track, context.allocator)
+	defer mem.tracking_allocator_destroy(&track)
+	track.bad_free_callback = mem.tracking_allocator_bad_free_callback_add_to_array
+	context.allocator = mem.tracking_allocator(&track)
+
+	sc: Shell_Client
+	shell_client_init(&sc)
+
+	// Absolute path: the env allowlist is deny-by-default, so the child
+	// has no PATH to resolve against (see shell_test.odin).
+	cmd := make([]string, 2)
+	cmd[0] = strings.clone("/bin/echo")
+	cmd[1] = strings.clone("cross-thread")
+	req := Shell_Request {
+		id    = strings.clone("track-1"),
+		cmd   = cmd,
+		stdin = strings.clone(""),
+	}
+	// The worker owns req from here (shell_thread_proc frees it).
+	shell_client_request(&sc, req)
+
+	// Drain like bridge.poll_shell does: copy results out, then free each
+	// response on this thread — the exact free that trapped pre-fix.
+	results: [dynamic]Shell_Response
+	deadline := time.time_add(time.now(), 5 * time.Second)
+	for time.diff(time.now(), deadline) > 0 {
+		shell_client_poll(&sc, &results)
+		if len(results) > 0 do break
+		time.sleep(20 * time.Millisecond)
+	}
+
+	testing.expect(t, len(results) == 1, "expected one shell result")
+	if len(results) == 1 {
+		testing.expectf(t, strings.has_prefix(results[0].stdout, "cross-thread"),
+			"unexpected stdout %q", results[0].stdout)
+	}
+	for &r in results do shell_response_destroy(&r)
+	delete(results)
+
+	shell_client_destroy(&sc)
+
+	// The worker's Thread struct was also allocated under the tracking
+	// allocator and is self-freed shortly after the worker proc returns
+	// (after workers_alive hits 0), so give the books a moment to balance.
+	outstanding := -1
+	balance_deadline := time.time_add(time.now(), 2 * time.Second)
+	for time.diff(time.now(), balance_deadline) > 0 {
+		sync.lock(&track.mutex)
+		outstanding = len(track.allocation_map)
+		sync.unlock(&track.mutex)
+		if outstanding == 0 do break
+		time.sleep(10 * time.Millisecond)
+	}
+
+	for bf in track.bad_free_array {
+		testing.expectf(t, false,
+			"bad free of %p at %v — worker and main thread disagree on the allocator (#214)",
+			bf.memory, bf.location)
+	}
+	testing.expectf(t, outstanding == 0,
+		"%d allocation(s) never freed through the caller's allocator (#214)", outstanding)
+}

--- a/test/ui/shell_app.fnl
+++ b/test/ui/shell_app.fnl
@@ -1,0 +1,52 @@
+;; Minimal app exercising the :shell effect.
+;; Regression coverage for issue #214: REDIN_TRACK_MEM builds (what
+;; build-dev.sh produces, and what this suite runs against) crashed with
+;; SIGILL when the first shell result was delivered.
+(local dataflow (require :dataflow))
+(local theme-mod (require :theme))
+
+(theme-mod.set-theme
+  {:body {:font-size 14 :color [216 222 233]}})
+
+(dataflow.init {:out "" :exit "" :runs 0})
+
+;; Expose state to dev server (GET /state endpoint)
+(global redin_get_state (. dataflow :_get-raw-db))
+
+;; Absolute paths in :cmd — the shell env allowlist is deny-by-default,
+;; so children get no PATH to resolve against.
+(reg-handler :shell/run
+  (fn [db event]
+    {:db db
+     :shell {:cmd ["/bin/echo" "-n" (. event 2)]
+             :on-success :shell/ok
+             :on-error :shell/fail}}))
+
+(reg-handler :shell/run-fail
+  (fn [db event]
+    {:db db
+     :shell {:cmd ["/bin/false"]
+             :on-success :shell/ok
+             :on-error :shell/fail}}))
+
+(reg-handler :shell/ok
+  (fn [db event]
+    (let [resp (. event 2)]
+      (update (assoc db :out (or (. resp :stdout) ""))
+              :runs #(+ $1 1)))))
+
+;; exit-code arrives as a Lua number; store it as a string so the test
+;; isn't comparing JSON doubles to integers.
+(reg-handler :shell/fail
+  (fn [db event]
+    (let [resp (. event 2)]
+      (update (assoc db :exit (tostring (. resp :exit-code)))
+              :runs #(+ $1 1)))))
+
+(reg-sub :sub/out (fn [db] (get db :out)))
+
+(global main_view
+  (fn []
+    (let [out (subscribe :sub/out)]
+      [:vbox {}
+       [:text {:id :out :aspect :body} (tostring out)]])))

--- a/test/ui/test_shell.bb
+++ b/test/ui/test_shell.bb
@@ -1,0 +1,24 @@
+(require '[redin-test :refer :all])
+
+;; Issue #214: the shell worker thread allocated Shell_Response strings
+;; under the thread-default heap allocator while the main thread freed
+;; them under the tracking allocator (REDIN_TRACK_MEM, the build-dev.sh
+;; default this suite runs against). The first delivered result tripped
+;; the tracker's bad-free assertion -> SIGILL. These tests fail hard if
+;; that regresses: the app dies on the first delivery and every wait-for
+;; below times out.
+
+(deftest shell-success-delivers-stdout
+  (dispatch ["shell/run" "tracked"])
+  (wait-for (state= "out" "tracked") {:timeout 5000}))
+
+(deftest shell-error-delivers-exit-code
+  (dispatch ["shell/run-fail"])
+  (wait-for (state= "exit" "1") {:timeout 5000}))
+
+;; A second success proves the app survived freeing the earlier
+;; responses (each delivery is one alloc/free cycle across threads).
+(deftest shell-survives-repeated-deliveries
+  (dispatch ["shell/run" "again"])
+  (wait-for (state= "out" "again") {:timeout 5000})
+  (assert-state "runs" #(= % 3)))


### PR DESCRIPTION
Fixes #214 — `REDIN_TRACK_MEM` dev builds crashed with SIGILL when the `:shell` effect fired.

## Root cause

`shell_client_request` spawned its worker without `init_context`, so the worker ran under `runtime.default_context()`:

- The worker cloned `Shell_Response` strings with the plain heap allocator; the main thread freed them under its `context.allocator` — the tracking allocator in `REDIN_TRACK_MEM` builds. `mem.Tracking_Allocator`'s default bad-free callback is `runtime.trap()` → SIGILL on the first delivered result (`shell_response_destroy`, shell.odin:108).
- The inverse mismatch was silent: the worker freed the tracking-allocated request strings and `Shell_Thread_Data` with the heap allocator, leaving stale tracker entries (false leak reports).

## Fix

One line: pass `init_context = context` in `shell_client_request`, mirroring the established `Http_Client` pattern (`http_client.odin`). `core:thread` swaps in a per-thread temp allocator for the worker, and `mem.Tracking_Allocator` is mutex-guarded, so sharing the caller's context across the thread boundary is safe. Nothing in the shell worker path touches `context.temp_allocator` (modern `core:os` uses its own thread-local arenas with a registered thread-exit cleaner), so no temp-arena cleanup is needed in the worker.

## Tests (both red-green verified against the unfixed code)

- **Odin unit test** `shell_allocator_test.odin`: runs the full `shell_client_request` → worker → `shell_client_poll` → destroy cycle under a test-local tracking allocator (bad frees recorded, not trapped) and asserts zero bad frees and zero unfreed allocations. Crashes with `free(): invalid pointer` on the unfixed code.
- **UI suite** `test/ui/shell_app.fnl` + `test/ui/test_shell.bb` (the `:shell` effect had no UI test): success, error, and repeated-delivery paths against the dev build, where the tracker is baked in. On the unfixed code the app dies with `Tracking allocator error: Bad free of pointer …` + SIGILL on the first result.

Also synced the stale "Available test suites" list in `redin-maintenance/SKILL.md` (now generated from the actual `test/ui/test_*.bb` files, including the new `shell` suite).

## Verification

- `odin test src/redin/bridge` — 109/109 pass
- `luajit test/lua/runner.lua test/lua/test_*.fnl` — 149/149 pass
- `bash test/ui/run-all.sh --headless` — all suites pass, no tracker leaks or bad frees on shutdown
- Release build (`odin build src/cmd/redin …`) — OK

## Note for a follow-up

While verifying the pattern I noticed the http worker has the same `init_context` setup but *does* allocate from `context.temp_allocator` (`strings.to_lower`, http_client.odin:486); with `init_context` set, `core:thread` skips destroying the thread's default temp arena, so each http worker leaks its temp arena (invisible to the tracker — arena backing doesn't go through `context.allocator`). Pre-existing and out of scope here; I can file an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)