### PR TITLE
fix(#217): NUL-safe Lua string clones, bound HTTP body, normalize whitelist dots

### DIFF
--- a/docs/reference/native-bridge.md
+++ b/docs/reference/native-bridge.md
@@ -167,7 +167,7 @@ Hostname and CIDR entries are **always allowed**, on top of whatever the class p
 
 **SSRF / DNS-rebinding defence (#162 M3):** the access class is enforced against the **resolved IP**, not the URL text. redin resolves the host itself, checks the resolved address against the class, then dials that exact endpoint. So a public hostname that resolves into a blocked range (`evil.example → 127.0.0.1`) is rejected under `"local"`/`"external"` — a literal-string check would miss it. An explicit hostname or CIDR entry still overrides this (the explicit opt-in is intentional).
 
-Hostname comparison is ASCII-byte case-insensitive. IDN hostnames must be passed in their punycode (`xn--...`) form — `münchen.example` is not equivalent to `xn--mnchen-3ya.example`, and the URL parser punycodes the request host before matching.
+Hostname comparison is ASCII-byte case-insensitive, and a single trailing root-label dot is insignificant on either side — `"example.com"` in the whitelist matches a request to `example.com.` and vice versa. IDN hostnames must be passed in their punycode (`xn--...`) form — `münchen.example` is not equivalent to `xn--mnchen-3ya.example`, and the URL parser punycodes the request host before matching.
 
 Rejection failure (delivered to the `:http` effect's `on-error`): `{status: 0, error: "host <name> not in http whitelist"}`.
 

--- a/src/redin/bridge/api.odin
+++ b/src/redin/bridge/api.odin
@@ -564,6 +564,17 @@ set_http_whitelist :: proc(allow: []string) {
 	}
 }
 
+// #217 M1: DNS treats a hostname carrying an explicit trailing root-label dot
+// ("example.com.") as equivalent to the dotless form ("example.com"). Strip a
+// single trailing dot so whitelist comparisons match regardless of which side
+// carries it. Only one dot is removed — a bare "." or a "..": suffix is left
+// as-is so a degenerate entry can't normalize to "" and match everything.
+@(private = "file")
+strip_trailing_dot :: proc(s: string) -> string {
+	if len(s) > 1 && s[len(s) - 1] == '.' do return s[:len(s) - 1]
+	return s
+}
+
 // http_whitelist_check reports whether an *explicit* entry (hostname
 // literal, case-insensitive, or CIDR) matches `host`, or the class is All.
 // It is the string-level check used directly by unit tests; the live
@@ -585,7 +596,7 @@ http_whitelist_check :: proc(host: string) -> (rejected: string, ok: bool) {
 			continue
 		}
 		entry_lower := strings.to_lower(entry, context.temp_allocator)
-		if host_lower == entry_lower do return "", true
+		if strip_trailing_dot(host_lower) == strip_trailing_dot(entry_lower) do return "", true
 	}
 	return host, false
 }
@@ -612,7 +623,7 @@ http_access_allowed :: proc(host: string, addr: net.Address) -> bool {
 			continue
 		}
 		entry_lower := strings.to_lower(entry, context.temp_allocator)
-		if host_lower == entry_lower do return true
+		if strip_trailing_dot(host_lower) == strip_trailing_dot(entry_lower) do return true
 	}
 
 	switch a in addr {

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -407,6 +407,22 @@ clear_frame :: proc(b: ^Bridge) {
 // Host functions (Lua C callbacks)
 // ---------------------------------------------------------------------------
 
+// lua_clone_string clones a Lua string at `index` into an owned Odin string
+// using the context allocator (same ownership as strings.clone_from_cstring).
+//
+// #217 L3/L4: it reads the *length-carrying* value via lua_tolstring rather
+// than treating the pointer as a C string. Lua strings may contain embedded
+// NUL bytes; a strlen-based read truncates at the first one, silently dropping
+// shell-stdin payload and hiding control bytes from downstream guards like
+// header_safe. Caller must guarantee the value at `index` is a string/number
+// (every call site checks lua_isstring first), so lua_tolstring won't return
+// nil. Mirrors json.odin's lua_tostring_len.
+lua_clone_string :: proc(L: ^Lua_State, index: i32) -> string {
+	n: uint
+	p := lua_tolstring(L, index, &n)
+	return strings.clone(string(([^]u8)(p)[:n]))
+}
+
 redin_log :: proc "c" (L: ^Lua_State) -> i32 {
 	context = g_context
 	n := lua_gettop(L)
@@ -509,10 +525,10 @@ redin_http :: proc "c" (L: ^Lua_State) -> i32 {
 	req: Http_Request
 	req.headers = make(map[string]string)
 
-	if lua_isstring(L, 1) do req.id = strings.clone_from_cstring(lua_tostring_raw(L, 1))
-	if lua_isstring(L, 2) do req.url = strings.clone_from_cstring(lua_tostring_raw(L, 2))
+	if lua_isstring(L, 1) do req.id = lua_clone_string(L, 1)
+	if lua_isstring(L, 2) do req.url = lua_clone_string(L, 2)
 	if lua_isstring(L, 3) {
-		req.method = strings.clone_from_cstring(lua_tostring_raw(L, 3))
+		req.method = lua_clone_string(L, 3)
 	} else {
 		req.method = strings.clone("GET")
 	}
@@ -521,15 +537,15 @@ redin_http :: proc "c" (L: ^Lua_State) -> i32 {
 		lua_pushnil(L)
 		for lua_next(L, headers_idx) != 0 {
 			if lua_isstring(L, -2) && lua_isstring(L, -1) {
-				k := strings.clone_from_cstring(lua_tostring_raw(L, -2))
-				v := strings.clone_from_cstring(lua_tostring_raw(L, -1))
+				k := lua_clone_string(L, -2)
+				v := lua_clone_string(L, -1)
 				req.headers[k] = v
 			}
 			lua_pop(L, 1)
 		}
 	}
 	if lua_isstring(L, 5) {
-		req.body = strings.clone_from_cstring(lua_tostring_raw(L, 5))
+		req.body = lua_clone_string(L, 5)
 	} else {
 		req.body = strings.clone("")
 	}
@@ -1021,7 +1037,7 @@ read_string_array :: proc(L: ^Lua_State, idx: i32) -> (out: []string, ok: bool) 
 	for i in 0 ..< count {
 		lua_rawgeti(L, idx, i32(i + 1))
 		is_str := lua_isstring(L, -1)
-		if is_str do out[i] = strings.clone_from_cstring(lua_tostring_raw(L, -1))
+		if is_str do out[i] = lua_clone_string(L, -1)
 		lua_pop(L, 1)
 		if !is_str {
 			for s in out do if len(s) > 0 do delete(s)
@@ -1038,7 +1054,7 @@ redin_shell :: proc "c" (L: ^Lua_State) -> i32 {
 
 	req: Shell_Request
 
-	if lua_isstring(L, 1) do req.id = strings.clone_from_cstring(lua_tostring_raw(L, 1))
+	if lua_isstring(L, 1) do req.id = lua_clone_string(L, 1)
 
 	// Read cmd table (sequential array of strings).
 	if lua_istable(L, 2) {
@@ -1055,7 +1071,7 @@ redin_shell :: proc "c" (L: ^Lua_State) -> i32 {
 	}
 
 	if lua_isstring(L, 3) {
-		req.stdin = strings.clone_from_cstring(lua_tostring_raw(L, 3))
+		req.stdin = lua_clone_string(L, 3)
 	} else {
 		req.stdin = strings.clone("")
 	}
@@ -1166,7 +1182,7 @@ parse_animate_attr :: proc(L: ^Lua_State, attrs_idx: i32) -> (types.Animate_Deco
 	provider: string
 	lua_getfield(L, a_idx, "provider")
 	if lua_isstring(L, -1) {
-		provider = strings.clone_from_cstring(lua_tostring_raw(L, -1))
+		provider = lua_clone_string(L, -1)
 	}
 	lua_pop(L, 1)
 	if len(provider) == 0 {
@@ -1400,7 +1416,7 @@ lua_flatten_node :: proc(L: ^Lua_State, index: i32, cur: ^[dynamic]u8, b: ^Bridg
 	text_content: string
 	lua_rawgeti(L, abs_idx, 3)
 	if lua_isstring(L, -1) {
-		text_content = strings.clone_from_cstring(lua_tostring_raw(L, -1))
+		text_content = lua_clone_string(L, -1)
 	}
 	lua_pop(L, 1)
 
@@ -1764,7 +1780,7 @@ lua_to_theme :: proc(L: ^Lua_State, index: i32) -> map[string]types.Theme {
 	lua_pushnil(L)
 	for lua_next(L, abs_idx) != 0 {
 		if lua_isstring(L, -2) && lua_istable(L, -1) {
-			key := strings.clone_from_cstring(lua_tostring_raw(L, -2))
+			key := lua_clone_string(L, -2)
 			if key == "font-face" {
 				delete(key)
 				lua_pop(L, 1)
@@ -2261,7 +2277,7 @@ lua_get_string_field :: proc(L: ^Lua_State, index: i32, field: cstring) -> strin
 	lua_getfield(L, index, field)
 	defer lua_pop(L, 1)
 	if lua_isstring(L, -1) {
-		return strings.clone_from_cstring(lua_tostring_raw(L, -1))
+		return lua_clone_string(L, -1)
 	}
 	return ""
 }
@@ -2272,13 +2288,13 @@ lua_get_event_name :: proc(L: ^Lua_State, index: i32, field: cstring) -> string 
 	lua_getfield(L, index, field)
 	defer lua_pop(L, 1)
 	if lua_isstring(L, -1) {
-		return strings.clone_from_cstring(lua_tostring_raw(L, -1))
+		return lua_clone_string(L, -1)
 	}
 	if lua_istable(L, -1) {
 		lua_rawgeti(L, -1, 1)
 		defer lua_pop(L, 1)
 		if lua_isstring(L, -1) {
-			return strings.clone_from_cstring(lua_tostring_raw(L, -1))
+			return lua_clone_string(L, -1)
 		}
 	}
 	return ""
@@ -2341,7 +2357,7 @@ lua_read_tags :: proc(L: ^Lua_State, tbl_idx: i32, slot_idx: i32) -> []string {
 
     if lua_isstring(L, -1) {
         out := make([]string, 1)
-        out[0] = strings.clone_from_cstring(lua_tostring_raw(L, -1))
+        out[0] = lua_clone_string(L, -1)
         return out
     }
 
@@ -2354,7 +2370,7 @@ lua_read_tags :: proc(L: ^Lua_State, tbl_idx: i32, slot_idx: i32) -> []string {
         for i in 1..=n {
             lua_rawgeti(L, list_idx, i32(i))
             if lua_isstring(L, -1) {
-                append(&tmp, strings.clone_from_cstring(lua_tostring_raw(L, -1)))
+                append(&tmp, lua_clone_string(L, -1))
             }
             lua_pop(L, 1)
         }
@@ -2400,7 +2416,7 @@ lua_read_draggable :: proc(L: ^Lua_State, attrs_idx: i32) -> Maybe(types.Draggab
 	// :event (required)
 	lua_getfield(L, opts, "event")
 	if lua_isstring(L, -1) {
-		out.event = strings.clone_from_cstring(lua_tostring_raw(L, -1))
+		out.event = lua_clone_string(L, -1)
 	}
 	lua_pop(L, 1)
 	if len(out.event) == 0 {
@@ -2426,7 +2442,7 @@ lua_read_draggable :: proc(L: ^Lua_State, attrs_idx: i32) -> Maybe(types.Draggab
 	// :aspect (optional)
 	lua_getfield(L, opts, "aspect")
 	if lua_isstring(L, -1) {
-		out.aspect = strings.clone_from_cstring(lua_tostring_raw(L, -1))
+		out.aspect = lua_clone_string(L, -1)
 	}
 	lua_pop(L, 1)
 
@@ -2486,7 +2502,7 @@ lua_read_dropable :: proc(L: ^Lua_State, attrs_idx: i32) -> Maybe(types.Dropable
 
 	lua_getfield(L, opts, "event")
 	if lua_isstring(L, -1) {
-		out.event = strings.clone_from_cstring(lua_tostring_raw(L, -1))
+		out.event = lua_clone_string(L, -1)
 	}
 	lua_pop(L, 1)
 	if len(out.event) == 0 {
@@ -2499,7 +2515,7 @@ lua_read_dropable :: proc(L: ^Lua_State, attrs_idx: i32) -> Maybe(types.Dropable
 
 	lua_getfield(L, opts, "aspect")
 	if lua_isstring(L, -1) {
-		out.aspect = strings.clone_from_cstring(lua_tostring_raw(L, -1))
+		out.aspect = lua_clone_string(L, -1)
 	}
 	lua_pop(L, 1)
 
@@ -2548,13 +2564,13 @@ lua_read_drag_over :: proc(L: ^Lua_State, attrs_idx: i32) -> Maybe(types.Drag_Ov
 	// :event is OPTIONAL on :drag-over (visual-only zones don't need a handler)
 	lua_getfield(L, opts, "event")
 	if lua_isstring(L, -1) {
-		out.event = strings.clone_from_cstring(lua_tostring_raw(L, -1))
+		out.event = lua_clone_string(L, -1)
 	}
 	lua_pop(L, 1)
 
 	lua_getfield(L, opts, "aspect")
 	if lua_isstring(L, -1) {
-		out.aspect = strings.clone_from_cstring(lua_tostring_raw(L, -1))
+		out.aspect = lua_clone_string(L, -1)
 	}
 	lua_pop(L, 1)
 

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -528,6 +528,13 @@ handle_one_connection :: proc(ds: ^Dev_Server, client: net.TCP_Socket, stack_buf
 		if total >= 4 {
 			req_str := string(buf[:total])
 			if header_end := strings.index(req_str, "\r\n\r\n"); header_end >= 0 {
+				// #217 M2: two Content-Length headers are ambiguous (a
+				// request-smuggling vector); find_content_length only sees the
+				// first. Reject outright rather than guess.
+				if header_count(req_str[:header_end], "content-length") > 1 {
+					bad_request = true
+					break
+				}
 				// Check Content-Length for body
 				cl := find_content_length(req_str[:header_end])
 				body_start := header_end + 4
@@ -622,14 +629,12 @@ handle_one_connection :: proc(ds: ^Dev_Server, client: net.TCP_Socket, stack_buf
 	// header lookup works with any leading line, and the second
 	// line onward are real headers.
 	headers := req_str
-	body := ""
 	if header_end := strings.index(req_str, "\r\n\r\n"); header_end >= 0 {
 		headers = req_str[:header_end]
-		body_start := header_end + 4
-		if body_start < total {
-			body = req_str[body_start:]
-		}
 	}
+	// #217 M2: bound the body to the declared Content-Length so bytes past it
+	// (a pipelined request that overshot into the buffer) never reach handlers.
+	body := extract_body(req_str)
 
 	// DNS-rebinding defence: require Host: localhost:<port> or
 	// 127.0.0.1:<port>. A malicious site resolving an attacker
@@ -834,6 +839,54 @@ find_content_length :: proc(headers: string) -> int {
 		}
 	}
 	return n
+}
+
+// extract_body returns the request body bounded by the declared
+// Content-Length. #217 M2: the read loop can leave `total` bytes exceeding
+// header_end+4+Content-Length — recv fills whatever buffer space remains, so a
+// pipelined byte that arrives with the headers overshoots into the slack of
+// the stack buffer. Slicing req_str[body_start:] would then leak those trailing
+// bytes into the body handed to handlers. Bound the slice to exactly the
+// announced length, and never past what actually arrived.
+extract_body :: proc(req_str: string) -> string {
+	header_end := strings.index(req_str, "\r\n\r\n")
+	if header_end < 0 do return ""
+	body_start := header_end + 4
+	if body_start >= len(req_str) do return ""
+	cl := find_content_length(req_str[:header_end])
+	if cl <= 0 do return ""
+	body_end := body_start + cl
+	if body_end > len(req_str) do body_end = len(req_str)
+	return req_str[body_start:body_end]
+}
+
+// header_count returns how many real header lines (anchored at a line start,
+// past the request line) begin with `name_lower:`. #217 M2: two Content-Length
+// headers are ambiguous (a request-smuggling vector); find_header_value only
+// ever returns the first, so the caller rejects when this is > 1 rather than
+// silently trusting it. Anchoring mirrors find_header_value so a needle inside
+// the request-line URL/query is not counted.
+header_count :: proc(headers: string, name_lower: string) -> int {
+	lower := ascii_lower(headers, context.temp_allocator)
+	needle := strings.concatenate({name_lower, ":"}, context.temp_allocator)
+
+	start := 0
+	if rl_end := strings.index(lower, "\r\n"); rl_end >= 0 {
+		start = rl_end + 2
+	}
+
+	count := 0
+	pos := start
+	for pos < len(lower) {
+		rel := strings.index(lower[pos:], needle)
+		if rel < 0 do break
+		idx := pos + rel
+		if idx == start || lower[idx - 1] == '\n' {
+			count += 1
+		}
+		pos = idx + len(needle)
+	}
+	return count
 }
 
 status_text :: proc(code: int) -> string {

--- a/src/redin/bridge/devserver_body_test.odin
+++ b/src/redin/bridge/devserver_body_test.odin
@@ -1,0 +1,62 @@
+package bridge
+
+// #217 M2: the request body delivered to handlers was sliced as
+// req_str[body_start:] — bounded by what was read into the buffer, not by the
+// declared Content-Length. A recv that overshoots into the stack buffer (e.g.
+// a pipelined byte) would leak trailing bytes into the "body". And a request
+// with two Content-Length headers is ambiguous (request-smuggling vector);
+// find_header_value only sees the first. These tests pin the body bound and
+// the duplicate-header rejection.
+
+import "core:testing"
+
+@(test)
+test_extract_body_bounds_to_content_length :: proc(t: ^testing.T) {
+	// 10 bytes follow the headers but Content-Length announces 5. The body
+	// must be exactly the announced 5 bytes — the trailing "EXTRA" is not part
+	// of this request and must never reach a handler.
+	req := "POST /events HTTP/1.1\r\nContent-Length: 5\r\n\r\nhelloEXTRA"
+	testing.expect_value(t, extract_body(req), "hello")
+}
+
+@(test)
+test_extract_body_caps_at_available :: proc(t: ^testing.T) {
+	// Declared 100 but only 3 bytes arrived (short read). extract_body must
+	// not slice past what is actually present.
+	req := "POST /x HTTP/1.1\r\nContent-Length: 100\r\n\r\nabc"
+	testing.expect_value(t, extract_body(req), "abc")
+}
+
+@(test)
+test_extract_body_zero_length :: proc(t: ^testing.T) {
+	// Content-Length: 0 with bytes still in the buffer behind it — the classic
+	// M2 repro. The body must be empty, not the smuggled bytes.
+	req := "POST /events HTTP/1.1\r\nContent-Length: 0\r\n\r\n[\"x\"]"
+	testing.expect_value(t, extract_body(req), "")
+}
+
+@(test)
+test_extract_body_no_content_length :: proc(t: ^testing.T) {
+	req := "GET /state HTTP/1.1\r\nHost: localhost:8800\r\n\r\n"
+	testing.expect_value(t, extract_body(req), "")
+}
+
+@(test)
+test_header_count_detects_duplicate_content_length :: proc(t: ^testing.T) {
+	headers := "POST /x HTTP/1.1\r\nContent-Length: 0\r\nContent-Length: 100\r\nHost: localhost:8800"
+	testing.expect_value(t, header_count(headers, "content-length"), 2)
+}
+
+@(test)
+test_header_count_single :: proc(t: ^testing.T) {
+	headers := "POST /x HTTP/1.1\r\nContent-Length: 5\r\nHost: localhost:8800"
+	testing.expect_value(t, header_count(headers, "content-length"), 1)
+}
+
+@(test)
+test_header_count_ignores_request_line :: proc(t: ^testing.T) {
+	// "content-length:" in the request-line URL must not count — only real
+	// header lines, anchored at a line start, do (mirrors find_header_value).
+	headers := "GET /state/content-length:5 HTTP/1.1\r\nHost: localhost:8800"
+	testing.expect_value(t, header_count(headers, "content-length"), 0)
+}

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -506,6 +506,39 @@ test_http_whitelist_hostname_case_insensitive :: proc(t: ^testing.T) {
 }
 
 @(test)
+test_http_whitelist_host_trailing_dot :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+
+	// #217 M1: DNS treats "example.com" and the fully-qualified "example.com."
+	// (with the explicit root label) as the same name. A whitelist entry
+	// written without the trailing dot must still match a URL host that
+	// carries one — otherwise a user sees a confusing denial and is tempted
+	// to widen the whitelist to work around it.
+	set_http_whitelist([]string{"example.com"})
+	defer set_http_whitelist(nil)
+
+	rejected, ok := http_whitelist_check("example.com.")
+	testing.expect(t, ok, "fully-qualified host should match dotless whitelist entry")
+	testing.expect_value(t, rejected, "")
+}
+
+@(test)
+test_http_whitelist_entry_trailing_dot :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+
+	// Symmetric case: the root dot is on the whitelist entry instead of the
+	// host. Normalization must strip it from both sides before comparing.
+	set_http_whitelist([]string{"example.com."})
+	defer set_http_whitelist(nil)
+
+	rejected, ok := http_whitelist_check("example.com")
+	testing.expect(t, ok, "dotless host should match trailing-dot whitelist entry")
+	testing.expect_value(t, rejected, "")
+}
+
+@(test)
 test_http_whitelist_cidr_match :: proc(t: ^testing.T) {
 	resp := "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
 	m := mock_start(resp)

--- a/src/redin/bridge/lua_clone_string_test.odin
+++ b/src/redin/bridge/lua_clone_string_test.odin
@@ -1,0 +1,45 @@
+package bridge
+
+import "core:strings"
+import "core:testing"
+
+// #217 L3/L4: Lua strings carry an explicit length and may contain embedded
+// NUL bytes. The bridge read them with strings.clone_from_cstring(
+// lua_tostring_raw(...)), which is strlen-based and truncates at the first
+// NUL. That silently dropped shell-stdin payload past the NUL (L4) and
+// defeated header_safe on the URL, which never saw the NUL it was meant to
+// reject (L3). lua_clone_string must read the length-carrying value and keep
+// the full byte range so the bytes after a NUL survive.
+@(test)
+test_lua_clone_string_preserves_embedded_nul :: proc(t: ^testing.T) {
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	// "a" + NUL + "b" — 3 bytes. strlen would stop at index 1, yielding "a".
+	buf := [3]u8{'a', 0, 'b'}
+	lua_pushlstring(L, cstring(raw_data(buf[:])), 3)
+
+	got := lua_clone_string(L, lua_gettop(L))
+	defer delete(got)
+
+	testing.expect_value(t, len(got), 3)
+	testing.expect(t, got == "a\x00b",
+		"byte range after embedded NUL must survive the clone (#217 L3/L4)")
+}
+
+// An ordinary NUL-free string must clone identically — the length-carrying
+// read is a strict superset of the old behaviour, not a change for the common
+// case.
+@(test)
+test_lua_clone_string_plain :: proc(t: ^testing.T) {
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	lua_pushlstring(L, "hello", 5)
+	got := lua_clone_string(L, lua_gettop(L))
+	defer delete(got)
+
+	testing.expect(t, got == "hello", "plain string clones unchanged")
+}


### PR DESCRIPTION
Addresses the actionable findings from the #217 security review (the **Recommended set**: L3+L4, M2, M1). The informational Lows (L1/L2/L5/L6) are left as noted follow-ups.

## L3 + L4 — NUL truncation at the Lua→Odin boundary
`bridge.odin` read Lua strings with `strings.clone_from_cstring(lua_tostring_raw(...))`, which is `strlen`-based and truncates at the first embedded NUL.

- Added **`lua_clone_string(L, idx)`** — a length-carrying clone via `lua_tolstring` (mirrors json.odin's `lua_tostring_len`), same context-allocator ownership as before.
- Migrated **all 23** call sites in `bridge.odin`.
- Effect: shell-stdin payload past a NUL now survives (L4); a NUL in a URL reaches the existing `header_safe` guard, which rejects it before any dial (L3) — reusing the tested guard rather than adding a parallel up-front check.

## M2 — HTTP body bounded by Content-Length (`devserver.odin`)
The body was sliced `req_str[body_start:]` — bounded by what landed in the buffer, not the declared length.

- **`extract_body`** bounds the body to exactly `Content-Length`, capped at the bytes actually read, so a pipelined/overshoot byte never leaks into a handler's body.
- **`header_count`** + a read-loop check rejects ambiguous **duplicate `Content-Length`** headers with `400` (request-smuggling defense).

## M1 — whitelist trailing-dot normalization (`api.odin`, docs)
- **`strip_trailing_dot`** removes a single root-label dot on both sides of the hostname comparison in `http_whitelist_check` and `http_access_allowed`, so `example.com` matches `example.com.` and vice versa.
- Documented the rule in `docs/reference/native-bridge.md`.

## Tests
Written test-first (red → green) for each finding:
- `lua_clone_string_test.odin` — embedded-NUL preservation (2)
- `devserver_body_test.odin` — body bound + duplicate-CL detection (7)
- `http_client_test.odin` — two trailing-dot whitelist cases

## Verification
- `odin test src/redin/bridge` — **120 passed**, no leaks (memory tracking on)
- `luajit test/lua/runner.lua test/lua/test_*.fnl` — **149 passed**
- Release, `./build-dev.sh`, and `-define:REDIN_AGENT=true` builds all compile clean

> Note: `lib/odin-http` had been checked out on `fix/leaks-176-177` (lacking `Certificate_Verification_Failed`), which broke the build; this branch builds against main's pinned `9f50972`. No submodule pointer change is included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)