### PR TITLE
fix(#217): Low findings — ownership-checked cleanup, /state path cap, doc clarifications

### DIFF
--- a/docs/reference/dev-server.md
+++ b/docs/reference/dev-server.md
@@ -131,6 +131,8 @@ curl -H "$AUTH" http://localhost:$PORT/screenshot -o screenshot.png
 
 Returns binary PNG. Content-Type: `image/png`. Captures the current Raylib window.
 
+Capture is capped at **16 MP** (`width × height`); a larger window returns `413`. This is deliberately independent of — and smaller than — the `/resize` per-axis limit of `8192` (≈67 MP): a screenshot allocates a transient RGBA buffer plus a PNG-encoded copy (~256 MB at the maximum window), whereas a resize allocates nothing. So a window sized above 16 MP can exist and render but cannot be screenshotted. The two limits guard different resources, by design.
+
 ---
 
 ## Write endpoints
@@ -174,7 +176,7 @@ curl -X POST -H "$AUTH" -d '{"width":1280,"height":800}' \
   http://localhost:$PORT/resize
 ```
 
-Response: `{"ok": true}` on success; `400` if the body is not a JSON object or either dimension is outside `[100, 8192]`. Calls `rl.SetWindowSize`.
+Response: `{"ok": true}` on success; `400` if the body is not a JSON object or either dimension is outside `[100, 8192]`. Calls `rl.SetWindowSize`. Note: a window larger than 16 MP can be set here but cannot be captured by `/screenshot` (separate, smaller cap — see that endpoint).
 
 ### `POST /maximize` -- maximize the window
 

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -1721,6 +1721,13 @@ validate_font_path :: proc(path: string) -> bool {
 	// colon marks an absolute Windows path regardless of slash direction.
 	if len(path) >= 2 && path[1] == ':' do return false
 	if path[0] == '/' do return false
+	// #217 L2: this validator deliberately does NOT percent-decode or
+	// Unicode-normalize the path. Linux file APIs (rl.LoadFont → open) treat
+	// the bytes literally — they do not decode `%2e%2e` back to `..` — so the
+	// guard sees exactly what the OS will open. Adding a decode step would let
+	// a path the OS treats as benign get rewritten into one this check rejects
+	// (or vice versa), so it is intentionally omitted. Not exploitable.
+	//
 	// Segment-wise check so "foo..bar" (a legit filename that happens
 	// to contain two dots) doesn't trip the guard, but "../etc/passwd"
 	// does. Backslashes are already rejected above, so splitting on '/'

--- a/src/redin/bridge/cleanup_ownership_test.odin
+++ b/src/redin/bridge/cleanup_ownership_test.odin
@@ -1,0 +1,54 @@
+package bridge
+
+// #217 L1: the signal handler and the normal shutdown path previously unlinked
+// .redin-port / .redin-token unconditionally. Two redin instances sharing a
+// CWD clobber each other's files at startup, so the live owner is whoever
+// wrote last; a crashing instance must NOT remove a file a *different* live
+// instance owns. unlink_if_matches only unlinks when the on-disk content
+// equals the value we recorded at write time.
+
+import "core:os"
+import "core:strings"
+import "core:testing"
+
+@(test)
+test_unlink_if_matches_removes_on_match :: proc(t: ^testing.T) {
+	path := "test_redin_l1_match.tmp"
+	testing.expect(t, os.write_entire_file(path, "our-token-abc") == nil,
+		"setup: write temp file")
+	cpath := strings.clone_to_cstring(path, context.temp_allocator)
+
+	unlink_if_matches(cpath, transmute([]u8)string("our-token-abc"))
+
+	defer if os.exists(path) do os.remove(path)
+	testing.expect(t, !os.exists(path), "our own file must be removed on match")
+}
+
+@(test)
+test_unlink_if_matches_keeps_on_mismatch :: proc(t: ^testing.T) {
+	path := "test_redin_l1_mismatch.tmp"
+	testing.expect(t, os.write_entire_file(path, "other-instance-token") == nil,
+		"setup: write temp file")
+	defer os.remove(path)
+	cpath := strings.clone_to_cstring(path, context.temp_allocator)
+
+	unlink_if_matches(cpath, transmute([]u8)string("our-token"))
+
+	testing.expect(t, os.exists(path),
+		"a co-located live instance's file must be left intact on content mismatch")
+}
+
+@(test)
+test_unlink_if_matches_keeps_on_prefix :: proc(t: ^testing.T) {
+	// On-disk content shares a prefix with our value but is longer. A prefix
+	// match must not trigger unlink — lengths must be equal.
+	path := "test_redin_l1_prefix.tmp"
+	testing.expect(t, os.write_entire_file(path, "abc-extra") == nil,
+		"setup: write temp file")
+	defer os.remove(path)
+	cpath := strings.clone_to_cstring(path, context.temp_allocator)
+
+	unlink_if_matches(cpath, transmute([]u8)string("abc"))
+
+	testing.expect(t, os.exists(path), "prefix-only match must not unlink")
+}

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -193,10 +193,47 @@ drain_incoming_503 :: proc(ds: ^Dev_Server) {
 @(private = "file")
 g_signal_cleanup_installed: bool = false
 
+// #217 L1: exactly what this process wrote into .redin-port / .redin-token,
+// captured at write time so cleanup can prove ownership before unlinking.
+// Two redin instances sharing a CWD clobber each other's files at startup
+// (same fixed filenames), so the live owner is whoever wrote last; a crashing
+// or exiting instance must not remove a file a *different* live instance owns.
+@(private = "file") g_cleanup_port:      [16]u8
+@(private = "file") g_cleanup_port_len:  int
+@(private = "file") g_cleanup_token:     [128]u8
+@(private = "file") g_cleanup_token_len: int
+
+@(private = "file")
+record_cleanup_identity :: proc(port_str: string, token: string) {
+	g_cleanup_port_len  = copy(g_cleanup_port[:], transmute([]u8)port_str)
+	g_cleanup_token_len = copy(g_cleanup_token[:], transmute([]u8)token)
+}
+
+// unlink_if_matches removes `path` only when its current content exactly equals
+// `expect` (#217 L1). Async-signal-safe: it runs from cleanup_on_signal, so it
+// uses only raw syscalls (open/read/close/unlink) and stack memory — no
+// allocation, no Odin context. O_NOFOLLOW so a swapped-in symlink can't
+// redirect the read. A short read or any length/byte difference fails safe
+// (leaves the file) rather than risk deleting another instance's.
+unlink_if_matches :: proc "contextless" (path: cstring, expect: []u8) {
+	if len(expect) == 0 do return
+	fd, oerr := linux.open(path, {.NOFOLLOW, .CLOEXEC})
+	if oerr != .NONE do return
+	buf: [256]u8
+	n, rerr := linux.read(fd, buf[:])
+	linux.close(fd)
+	if rerr != .NONE do return
+	if int(n) != len(expect) do return
+	for i in 0 ..< len(expect) {
+		if buf[i] != expect[i] do return
+	}
+	linux.unlink(path)
+}
+
 @(private = "file")
 cleanup_on_signal :: proc "c" (sig: linux.Signal) {
-	linux.unlink(SIGNAL_PORT_FILE_C)
-	linux.unlink(SIGNAL_TOKEN_FILE_C)
+	unlink_if_matches(SIGNAL_PORT_FILE_C, g_cleanup_port[:g_cleanup_port_len])
+	unlink_if_matches(SIGNAL_TOKEN_FILE_C, g_cleanup_token[:g_cleanup_token_len])
 	// SA_RESETHAND already restored the default handler. Re-raise so
 	// the kernel runs that default disposition (e.g. core dump for
 	// SIGSEGV) on this same signal.
@@ -358,6 +395,9 @@ write_port_and_token_files :: proc(ds: ^Dev_Server, bound_port: int) -> bool {
 		ds.running = false
 		return false
 	}
+	// #217 L1: both files now hold our values — remember them so cleanup only
+	// removes files this instance still owns.
+	record_cleanup_identity(port_str, ds.auth_token)
 	return true
 }
 
@@ -423,8 +463,10 @@ devserver_destroy :: proc(ds: ^Dev_Server) {
 				free(pc)
 			}
 		}
-		os.remove(PORT_FILE)
-		os.remove(TOKEN_FILE)
+		// #217 L1: ownership-checked removal, same as the signal handler —
+		// don't unlink files a co-located live instance overwrote.
+		unlink_if_matches(SIGNAL_PORT_FILE_C, g_cleanup_port[:g_cleanup_port_len])
+		unlink_if_matches(SIGNAL_TOKEN_FILE_C, g_cleanup_token[:g_cleanup_token_len])
 	}
 	if len(ds.auth_token) > 0 do delete(ds.auth_token)
 	if len(ds.expected_host_v4) > 0 do delete(ds.expected_host_v4)
@@ -1575,6 +1617,17 @@ handle_get_state :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
 	}
 }
 
+// #217 L6: per-segment byte cap on /state/<path>. The number of segments is
+// already capped at MAX_PATH_SEGMENTS and the whole path is bounded by the
+// header buffer, so this is cheap defence-in-depth rather than a live fix.
+// Pure so it's unit-testable without a Lua state.
+MAX_PATH_SEGMENT_LEN :: 128
+
+any_segment_too_long :: proc(segments: []string) -> bool {
+	for seg in segments do if len(seg) > MAX_PATH_SEGMENT_LEN do return true
+	return false
+}
+
 handle_get_state_path :: proc(ds: ^Dev_Server, ch: ^Response_Channel, dot_path: string) {
 	L := ds.bridge.L
 	lua_getglobal(L, "redin_get_state")
@@ -1597,6 +1650,11 @@ handle_get_state_path :: proc(ds: ^Dev_Server, ch: ^Response_Channel, dot_path: 
 	if len(segments) > MAX_PATH_SEGMENTS {
 		lua_pop(L, 1)
 		respond_json_error(ch, 400, `{"error":"path too deep"}`)
+		return
+	}
+	if any_segment_too_long(segments) {
+		lua_pop(L, 1)
+		respond_json_error(ch, 400, `{"error":"path segment too long"}`)
 		return
 	}
 	for seg in segments {
@@ -2308,6 +2366,12 @@ handle_post_resize :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: string)
 
 	width := read_int(L, table_idx, "width")
 	height := read_int(L, table_idx, "height")
+	// #217 L5: this per-axis bound (8192, ≈67 MP) is intentionally larger than
+	// the /screenshot area cap (MAX_SCREENSHOT_PIXELS, 16 MP). A resize
+	// allocates nothing, so it can permit large windows; a screenshot allocates
+	// a transient RGBA + PNG buffer, so it caps area separately. A window set
+	// above 16 MP renders fine but /screenshot returns 413 — by design, not a
+	// bug. Don't "align" these caps without weakening one guard.
 	if width < 100 || height < 100 || width > 8192 || height > 8192 {
 		respond_json_error(ch, 400, `{"error":"width and height must be in [100, 8192]"}`)
 		return

--- a/src/redin/bridge/state_path_test.odin
+++ b/src/redin/bridge/state_path_test.odin
@@ -1,0 +1,31 @@
+package bridge
+
+// #217 L6: /state/<path> caps the number of dot-separated segments (32) but
+// never bounded the length of any single segment. It is safe in practice today
+// — the request path is already bounded by the header buffer — but the cap is
+// cheap defence-in-depth. any_segment_too_long is the pure predicate behind it.
+
+import "core:strings"
+import "core:testing"
+
+@(test)
+test_any_segment_too_long_flags_overlong :: proc(t: ^testing.T) {
+	long := strings.repeat("a", MAX_PATH_SEGMENT_LEN + 1, context.temp_allocator)
+	segments := []string{"form", long, "name"}
+	testing.expect(t, any_segment_too_long(segments),
+		"a segment past MAX_PATH_SEGMENT_LEN must be flagged")
+}
+
+@(test)
+test_any_segment_too_long_allows_normal :: proc(t: ^testing.T) {
+	at_cap := strings.repeat("b", MAX_PATH_SEGMENT_LEN, context.temp_allocator)
+	segments := []string{"form", "name", at_cap}
+	testing.expect(t, !any_segment_too_long(segments),
+		"segments at or under the cap must pass")
+}
+
+@(test)
+test_any_segment_too_long_empty :: proc(t: ^testing.T) {
+	testing.expect(t, !any_segment_too_long([]string{}), "no segments => nothing too long")
+	testing.expect(t, !any_segment_too_long([]string{""}), "empty segment is not too long")
+}


### PR DESCRIPTION
Follow-up to #218. Closes out the **Low / Informational** findings from the #217 security review. None were correctness- or security-critical; this is hardening + clarification.

## L1 — cleanup could delete a co-located live instance's files (real fix)
`.redin-port` / `.redin-token` were unlinked **unconditionally** by both the normal-shutdown path and the signal handler. Two redin instances in one CWD share the fixed filenames, so the live owner is whoever wrote last — a crashing/exiting instance would then remove a *different* live instance's token file (tooling can no longer authenticate).

- `record_cleanup_identity` captures exactly what we wrote (port string + token) into file-scoped buffers at write time.
- `unlink_if_matches(path, expect)` only unlinks when the on-disk content still equals ours; a length/byte difference or short read **fails safe** (leaves the file).
- The signal-handler path stays **async-signal-safe**: raw `open`/`read`/`close`/`unlink` only, no allocation, `O_NOFOLLOW` so a swapped-in symlink can't redirect the read.

## L6 — per-segment length cap on `/state/<path>` (defence-in-depth)
The segment *count* was capped (32) but not per-segment *length*. Added `MAX_PATH_SEGMENT_LEN` (128) via the pure `any_segment_too_long` predicate → `400 path segment too long`. Safe in practice already (the request path is bounded by the header buffer); this is belt-and-suspenders.

## L5 — `/resize` vs `/screenshot` cap asymmetry (documentation only)
**No behaviour change** — a behaviour change would be wrong:
- Lowering `/resize` to 16 MP breaks legitimate 8K windows (33 MP).
- Raising the `/screenshot` cap weakens its ~256 MB OOM guard.

The caps are correct per-resource; the finding was purely "confusing." Clarified with a code comment at `handle_post_resize` and notes in `docs/reference/dev-server.md` (`/screenshot` + `/resize`).

## L2 — font-path percent-encoding (documentation only)
Added a comment at `validate_font_path` explaining the decode step is deliberately omitted: Linux file APIs treat the path bytes literally, so the validator already sees exactly what the OS will open. Was already not exploitable.

## Tests
Written test-first (red → green):
- `cleanup_ownership_test.odin` — `unlink_if_matches` removes on match, keeps on content mismatch, keeps on prefix-only match (3)
- `state_path_test.odin` — `any_segment_too_long` overlong / at-cap / empty (3)

## Verification
- `odin test src/redin/bridge` — **126 passed**, no leaks
- `luajit test/lua/runner.lua test/lua/test_*.fnl` — **149 passed**
- Release, `./build-dev.sh`, and `-define:REDIN_AGENT=true` builds all clean

After this merges, all #217 findings (Critical/High: none; Medium L3+L4/M2/M1 in #218; Lows here) are addressed — #217 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)