### PR TITLE
fix(#216): free http worker's thread-local temp arena (init_context leak)

### DIFF
--- a/src/redin/bridge/http_client.odin
+++ b/src/redin/bridge/http_client.odin
@@ -1,5 +1,6 @@
 package bridge
 
+import "base:runtime"
 import "core:bytes"
 import "core:fmt"
 import "core:log"
@@ -404,8 +405,30 @@ http_client_poll :: proc(hc: ^Http_Client, results: ^[dynamic]Http_Response) {
 	clear(&hc.results)
 }
 
+// destroy_thread_temp_arena frees THIS thread's default temp arena. #216: http
+// workers are spawned with init_context set (see http_client_request), and
+// core:thread's _maybe_destroy_default_temp_allocator returns early whenever
+// init_context != nil — it leaves custom-context cleanup to the thread proc.
+// _select_context_for_thread still gave the worker its own thread-local arena
+// (global_default_temp_allocator_data), and the worker allocates from it (the
+// scheme lowercase here + the whitelist host compare in http_access_allowed),
+// so we must free it ourselves at exit. This replicates exactly what the
+// nil-init_context path would have done. The leak bypasses context.allocator,
+// so REDIN_TRACK_MEM never sees it; it is a real RSS leak, one arena per
+// request thread. The guard makes it a no-op under -DODIN_DEFAULT_TO_NIL_ALLOCATOR
+// (where the default temp allocator is the nil allocator).
+destroy_thread_temp_arena :: proc() {
+	if context.temp_allocator.procedure == runtime.default_temp_allocator_proc {
+		runtime.default_temp_allocator_destroy(auto_cast context.temp_allocator.data)
+	}
+}
+
 @(private = "file")
 http_thread_proc :: proc(raw_data_ptr: rawptr) {
+	// #216: free our thread-local temp arena on every exit path. Runs last
+	// (only proc-scope defer), after all temp allocations are done.
+	defer destroy_thread_temp_arena()
+
 	data := cast(^Http_Thread_Data)raw_data_ptr
 	response := execute_http_request(data.request, data.client)
 

--- a/src/redin/bridge/http_temp_arena_test.odin
+++ b/src/redin/bridge/http_temp_arena_test.odin
@@ -1,0 +1,56 @@
+package bridge
+
+// #216: http workers are spawned with init_context set (http_client.odin), so
+// core:thread's teardown skips _maybe_destroy_default_temp_allocator — it
+// leaves custom-context cleanup to the thread proc. _select_context_for_thread
+// still hands the worker its OWN thread-local default temp arena, and the
+// worker path allocates from it (scheme lowercasing + the whitelist host
+// compare), so without an explicit destroy each request leaks one arena. The
+// leak is invisible to REDIN_TRACK_MEM (the arena bypasses context.allocator),
+// so this test observes the runtime arena state directly: a live block exists
+// after a temp alloc, and must be gone after the worker's cleanup runs.
+
+import "base:runtime"
+import "core:strings"
+import "core:sync"
+import "core:testing"
+import "core:thread"
+
+@(private = "file")
+Arena_Probe :: struct {
+	block_after_alloc:   bool,
+	block_after_cleanup: bool,
+}
+
+@(private = "file")
+arena_probe_proc :: proc(raw: rawptr) {
+	p := cast(^Arena_Probe)raw
+
+	// Allocate from the thread-local default temp arena, exactly like
+	// execute_http_request's strings.to_lower(..., context.temp_allocator).
+	_ = strings.to_lower("ABC", context.temp_allocator)
+	p.block_after_alloc = runtime.global_default_temp_allocator_data.arena.curr_block != nil
+
+	// The fix under test: free this thread's temp arena before it exits.
+	destroy_thread_temp_arena()
+	p.block_after_cleanup = runtime.global_default_temp_allocator_data.arena.curr_block != nil
+}
+
+@(test)
+test_http_worker_frees_thread_temp_arena :: proc(t: ^testing.T) {
+	probe := new(Arena_Probe)
+	defer free(probe)
+
+	// Mirror http_client_request: spawn with init_context set (the condition
+	// that makes the runtime skip its own temp-arena cleanup).
+	worker_ctx := context
+	th := thread.create_and_start_with_data(probe, arena_probe_proc,
+		init_context = worker_ctx, self_cleanup = false)
+	thread.join(th)
+	thread.destroy(th)
+
+	testing.expect(t, probe.block_after_alloc,
+		"a temp alloc must initialize the thread-local arena (test precondition)")
+	testing.expect(t, !probe.block_after_cleanup,
+		"#216: the worker must free its thread-local temp arena before exit")
+}


### PR DESCRIPTION
Closes #216

## The leak
`http_client_request` spawns workers with `init_context` set. Per `core:thread`'s contract, `_maybe_destroy_default_temp_allocator` **returns early whenever `init_context != nil`** — it leaves custom-context cleanup to the thread proc:

```odin
_maybe_destroy_default_temp_allocator :: proc(init_context: Maybe(runtime.Context)) {
    if init_context != nil { return }   // <-- our case: skipped
    ...
}
```

But `_select_context_for_thread` still repoints the worker to its **own** thread-local arena (`global_default_temp_allocator_data`), and the worker path allocates from it in two places:
- `strings.to_lower(req.url[:colon], context.temp_allocator)` (scheme guard), and
- the whitelist host compare in `http_access_allowed` (`strings.to_lower`, `net.address_to_string`).

So each request leaked one arena. It bypasses `context.allocator`, so **`REDIN_TRACK_MEM` never saw it** — a real RSS leak, bounded per request thread.

## The fix
`destroy_thread_temp_arena()` replicates exactly what the nil-`init_context` path would have done — a guarded `default_temp_allocator_destroy` — `defer`red at the top of `http_thread_proc` so it runs **last on every exit path**.

Chose the issue's **option 1** over option 2 (dropping the single temp use): the whitelist check *also* allocates from temp, so dropping line 486 alone would have left the arena initialized and still leaking. Freeing the arena covers all temp uses, present and future.

## Test
The leak is invisible to the tracking allocator, so the test observes the runtime arena **directly**: a thread spawned with `init_context` (mirroring the real worker) shows a live `arena.curr_block` after a temp alloc and **none after cleanup**. Red→green verified (no-op stub fails the post-cleanup assertion).

## Verification
- `odin test src/redin/bridge` — **127 passed**, no leaks (real http worker threads exercised by the existing `http_client_test` suite)
- `luajit test/lua/runner.lua test/lua/test_*.fnl` — **149 passed**
- Release, `./build-dev.sh`, and `-define:REDIN_AGENT=true` builds all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)