### PR TITLE
fix(#221): NUL-safe markdown copy source (M1) + CI submodule-SHA assertion (L1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,21 @@ jobs:
         with:
           submodules: recursive
 
+      # Assert the resolved odin-http submodule matches the reviewed pin.
+      # `submodules: recursive` resolves the gitlink SHA, but nothing else
+      # here fails if that pointer is moved — by a PR bumping the gitlink or a
+      # history-rewrite at the pinned SHA — the same trust-without-assertion
+      # gap the third-party-action SHA pins close. Bump `expected` to match the
+      # gitlink whenever odin-http is intentionally rolled forward (#221 L1).
+      - name: Verify odin-http submodule SHA
+        run: |
+          expected=9f50972ec8a7f4e31bd050f245b79f63733f31f8
+          actual=$(git -C lib/odin-http rev-parse HEAD)
+          [ "$actual" = "$expected" ] || {
+            echo "::error::odin-http submodule SHA mismatch (got $actual, expected $expected)"
+            exit 1
+          }
+
       # Validate the workflow input before using it anywhere. Without this,
       # a maintainer typo like `v1.0.0; rm -rf /` flows verbatim into the
       # release name and tag (#136 L2). The trigger is workflow_dispatch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,21 @@ jobs:
         with:
           submodules: recursive
 
+      # Assert the resolved odin-http submodule matches the reviewed pin.
+      # `submodules: recursive` resolves the gitlink SHA, but nothing else
+      # here fails if that pointer is moved — by a PR bumping the gitlink or a
+      # history-rewrite at the pinned SHA — the same trust-without-assertion
+      # gap the third-party-action SHA pins close. Bump `expected` to match the
+      # gitlink whenever odin-http is intentionally rolled forward (#221 L1).
+      - name: Verify odin-http submodule SHA
+        run: |
+          expected=9f50972ec8a7f4e31bd050f245b79f63733f31f8
+          actual=$(git -C lib/odin-http rev-parse HEAD)
+          [ "$actual" = "$expected" ] || {
+            echo "::error::odin-http submodule SHA mismatch (got $actual, expected $expected)"
+            exit 1
+          }
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -68,6 +83,21 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           submodules: recursive
+
+      # Assert the resolved odin-http submodule matches the reviewed pin.
+      # `submodules: recursive` resolves the gitlink SHA, but nothing else
+      # here fails if that pointer is moved — by a PR bumping the gitlink or a
+      # history-rewrite at the pinned SHA — the same trust-without-assertion
+      # gap the third-party-action SHA pins close. Bump `expected` to match the
+      # gitlink whenever odin-http is intentionally rolled forward (#221 L1).
+      - name: Verify odin-http submodule SHA
+        run: |
+          expected=9f50972ec8a7f4e31bd050f245b79f63733f31f8
+          actual=$(git -C lib/odin-http rev-parse HEAD)
+          [ "$actual" = "$expected" ] || {
+            echo "::error::odin-http submodule SHA mismatch (got $actual, expected $expected)"
+            exit 1
+          }
 
       - name: Install system dependencies
         run: |

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -408,7 +408,9 @@ clear_frame :: proc(b: ^Bridge) {
 // ---------------------------------------------------------------------------
 
 // lua_clone_string clones a Lua string at `index` into an owned Odin string
-// using the context allocator (same ownership as strings.clone_from_cstring).
+// using `allocator` (the context allocator by default, same ownership as
+// strings.clone_from_cstring; callers that want a frame-scoped clone pass
+// context.temp_allocator).
 //
 // #217 L3/L4: it reads the *length-carrying* value via lua_tolstring rather
 // than treating the pointer as a C string. Lua strings may contain embedded
@@ -417,10 +419,10 @@ clear_frame :: proc(b: ^Bridge) {
 // header_safe. Caller must guarantee the value at `index` is a string/number
 // (every call site checks lua_isstring first), so lua_tolstring won't return
 // nil. Mirrors json.odin's lua_tostring_len.
-lua_clone_string :: proc(L: ^Lua_State, index: i32) -> string {
+lua_clone_string :: proc(L: ^Lua_State, index: i32, allocator := context.allocator) -> string {
 	n: uint
 	p := lua_tolstring(L, index, &n)
-	return strings.clone(string(([^]u8)(p)[:n]))
+	return strings.clone(string(([^]u8)(p)[:n]), allocator)
 }
 
 redin_log :: proc "c" (L: ^Lua_State) -> i32 {
@@ -1364,11 +1366,16 @@ lua_flatten_node :: proc(L: ^Lua_State, index: i32, cur: ^[dynamic]u8, b: ^Bridg
 			lua_pop(L, 1)
 		}
 
-		// Position 3 — source string.
+		// Position 3 — source string. Clone NUL-safely (length-carrying
+		// lua_tolstring) into the temp arena: a strlen-based read truncated
+		// markdown bodies at the first NUL and silently dropped the post-NUL
+		// bytes from the #112 copy-button's verbatim source (#221 M1). The
+		// clone lives in temp_allocator alongside the parse/lower output and is
+		// deep-copied into permanent storage by flatten_subtree's slot pass.
 		source: string
 		lua_rawgeti(L, abs_idx, 3)
 		if lua_isstring(L, -1) {
-			source = string(lua_tostring_raw(L, -1))
+			source = lua_clone_string(L, -1, context.temp_allocator)
 		}
 		lua_pop(L, 1)
 

--- a/src/redin/bridge/markdown_source_nul_test.odin
+++ b/src/redin/bridge/markdown_source_nul_test.odin
@@ -1,0 +1,61 @@
+package bridge
+
+import "core:sync"
+import "core:testing"
+
+import "../types"
+
+// #221 M1: the markdown branch of lua_flatten_node read its `source` (the
+// verbatim text behind a `[:markdown {...} "source"]` node) with
+// `string(lua_tostring_raw(...))`, a strlen-based read that truncates at the
+// first NUL. The truncated source then flows into markdown.lower's
+// copy_text — the #112 Copy button's "copy verbatim source" payload — so a
+// source carrying an embedded NUL (e.g. markdown built from redin.shell
+// stdout) silently lost every byte after the NUL, both on screen and on the
+// clipboard. The fix routes the read through lua_clone_string, which is
+// length-carrying (lua_tolstring), the same NUL-safe pattern #217 standardised
+// across the other 23 sites.
+@(test)
+test_markdown_source_preserves_embedded_nul :: proc(t: ^testing.T) {
+	sync.lock(&g_test_bridge_global_mutex)
+	defer sync.unlock(&g_test_bridge_global_mutex)
+
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	b: Bridge
+	b.L = L
+	saved := g_bridge
+	g_bridge = &b
+	defer g_bridge = saved
+	// clear_frame only clear()s markdown_skips (keeps backing for reuse); free
+	// it too so the test's leak tracker stays clean. LIFO: clear_frame runs
+	// first, then delete frees the now-empty map.
+	defer delete(b.markdown_skips)
+	defer clear_frame(&b)
+
+	// {"markdown", {copyable = true}, "foo\0bar"} — string.char keeps the
+	// embedded NUL unambiguous. strlen would stop at "foo" (3 bytes).
+	code: cstring = `return {"markdown", {copyable = true},
+		string.char(102, 111, 111, 0, 98, 97, 114)}`
+	rc := luaL_dostring(L, code)
+	testing.expectf(t, rc == 0, "failed to build markdown table (rc=%d)", rc)
+
+	cur: [dynamic]u8
+	defer delete(cur)
+	lua_flatten_node(L, lua_gettop(L), &cur, &b, -1)
+
+	// The copyable wrapper lowers to a copy-bar > copy-button whose copy_text
+	// is the verbatim source. Find it and assert the full byte range survived.
+	found := false
+	for node in b.nodes {
+		btn, ok := node.(types.NodeButton)
+		if !ok || len(btn.copy_text) == 0 do continue
+		found = true
+		testing.expect_value(t, len(btn.copy_text), 7)
+		testing.expect(t, btn.copy_text == "foo\x00bar",
+			"copy_text must keep bytes after the embedded NUL (#221 M1)")
+	}
+	testing.expect(t, found, "expected a copy button with copy_text")
+}


### PR DESCRIPTION
Addresses both findings from the #221 vulnerability audit.

## M1 (medium) — NUL truncation in the #112 markdown copy path

`src/redin/bridge/bridge.odin` read the markdown `source` (the verbatim
text behind `[:markdown {...} "source"]`) with
`string(lua_tostring_raw(...))`, a strlen-based read that truncates at the
first NUL. That truncated source flows into `markdown.lower`'s `copy_text`,
so a markdown body carrying an embedded NUL (e.g. built from `redin.shell`
stdout) silently lost every byte after the NUL — both on screen and on the
#112 Copy button's "copy verbatim source" clipboard payload. This site
shipped via #112 and missed the #217 NUL-safety migration that standardised
the other 23 sites on `lua_clone_string`.

**Fix:** route the read through `lua_clone_string` (length-carrying
`lua_tolstring`), cloning into the temp arena so the clone lives alongside
the parse/lower output and is deep-copied into permanent storage by
`flatten_subtree`'s slot pass. `lua_clone_string` gains an optional
allocator parameter defaulting to `context.allocator`, so existing callers
are unchanged.

Regression test (`markdown_source_nul_test.odin`) asserts a `"foo\x00bar"`
source round-trips through `copy_text` with the post-NUL bytes intact.

## L1 (low) — CI doesn't assert the odin-http submodule SHA

`test.yml` (both jobs) and `release.yml` check out `lib/odin-http` with
`submodules: recursive` but never asserted the resolved SHA against a
reviewed constant — the one trust-without-assertion gap among otherwise
SHA-pinned-and-verified third-party dependencies.

**Fix:** a post-checkout "Verify odin-http submodule SHA" step at each
submodule-checkout site fails CI unless `git -C lib/odin-http rev-parse
HEAD` equals the hardcoded pin (`9f50972…`). Intentional roll-forwards now
require bumping `expected` in the same reviewed change as the gitlink.

## Verification

- M1 regression test: RED (`copy_text` was 3 bytes) → GREEN, clean leak tracker
- Full bridge suite: 127/127 pass
- Release build + dev/agent build: OK
- L1: both workflows pass YAML lint; verification logic tested locally (passes on match, exits 1 on mismatch)

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)