### PR TITLE
fix(#225): isolate per-timer and per-effect errors (L7)

### DIFF
--- a/src/runtime/effect.fnl
+++ b/src/runtime/effect.fnl
@@ -41,7 +41,13 @@
     (when (~= key :db)
       (let [executor (. executors key)]
         (if executor
-          (executor value)
+          ;; #225 L7: isolate each effect. A single failing effect (e.g. a
+          ;; bad :dispatch / :dispatch-later payload) must not unwind the
+          ;; `each` and drop its sibling effects in the same fx map.
+          (let [(ok err) (pcall executor value)]
+            (when (not ok)
+              (print (.. "Warning: effect executor error for "
+                         (tostring key) ": " (tostring err)))))
           (print (.. "Warning: no effect executor for: " (tostring key))))))))
 
 ;; ===== Timer queue =====
@@ -64,7 +70,14 @@
     (let [dispatch-fn (. executors :dispatch)]
       (when dispatch-fn
         (each [_ timer (ipairs due)]
-          (dispatch-fn timer.event))))
+          ;; #225 L7: isolate each due timer. One handler that errors must
+          ;; not abort the remaining due timers scheduled for this same tick
+          ;; (dataflow.dispatch re-raises with `(error err 0)`, which would
+          ;; otherwise unwind this loop).
+          (let [(ok err) (pcall dispatch-fn timer.event)]
+            (when (not ok)
+              (print (.. "Warning: dispatch-later handler error: "
+                         (tostring err))))))))
     (length due)))
 
 (fn M.pending-timers []

--- a/test/lua/test_effect.fnl
+++ b/test/lua/test_effect.fnl
@@ -293,4 +293,34 @@
     (effect.poll-timers (+ now 1000))
     (assert (= fires 2) "re-armed timer fires on the following poll")))
 
+;; --- #225 L7: error isolation ---
+
+;; One timer handler that errors must not abort the other due timers
+;; scheduled for the same tick. Before the fix, dataflow.dispatch re-raised
+;; through the each loop and every later due timer was silently skipped.
+(fn t.test-poll-timers-isolates-handler-error []
+  (setup)
+  (dataflow.init {})
+  (dataflow.register-globals)
+  (dataflow.set-effect-handler effect.execute)
+  (var good-fired false)
+  (dataflow.reg-handler :event/boom (fn [_db _event] (error "boom")))
+  (dataflow.reg-handler :event/ok (fn [db _event] (set good-fired true) db))
+  ;; Both due at the same now-ms; the boom one is enqueued first.
+  (let [now (* (os.clock) 1000)]
+    (effect.execute {:db nil :dispatch-later {:ms 0 :dispatch [:event/boom]}})
+    (effect.execute {:db nil :dispatch-later {:ms 0 :dispatch [:event/ok]}})
+    (let [fired (effect.poll-timers (+ now 1000))]
+      (assert (= fired 2) "both due timers are accounted for")
+      (assert good-fired "the good timer must fire despite the earlier error"))))
+
+;; A failing effect must not drop its sibling effects in the same fx map.
+(fn t.test-execute-isolates-effect-error []
+  (setup)
+  (var good-ran false)
+  (effect.reg-fx :boom-fx (fn [_v] (error "boom")))
+  (effect.reg-fx :good-fx (fn [_v] (set good-ran true)))
+  (effect.execute {:db nil :boom-fx "x" :good-fx "y"})
+  (assert good-ran "the sibling effect must run despite the earlier error"))
+
 t


### PR DESCRIPTION
Addresses **L7** from the #225 audit.

`poll-timers` walked the due timers calling `dispatch-fn` per entry; one handler that errored re-raised through `dataflow.dispatch` (`(error err 0)`), unwinding the `each` and silently skipping every later due-but-not-yet-dispatched timer in the same tick. `M.execute` had the same shape: a single bad `:dispatch`/`:dispatch-later` entry dropped its siblings. The host pcall kept the process alive but the user saw silently-dropped scheduled events/effects.

## Fix
Wrap each `dispatch-fn` call in `poll-timers` and each executor call in `M.execute` with `pcall`, logging on error instead of re-raising across siblings.

## Tests
Adds tests that a boom handler/effect doesn't stop a sibling. Full Fennel suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
