### PR TITLE
fix(#225): NUL-safe shell argv and response id/error delivery (L3, L4)

### DIFF
--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -982,10 +982,13 @@ deliver_http_response :: proc(b: ^Bridge, resp: ^Http_Response) {
 	// Response data table
 	lua_createtable(L, 0, 5)
 
+	// #225 L4: id must use lua_pushlstring (explicit length) like body /
+	// stdout / stderr — clone_to_cstring + lua_pushstring truncates at the
+	// first NUL. The id is the app-controlled routing key; a NUL-truncated id
+	// no longer matches the app's pending-request slot, so the response
+	// callback silently never fires and the entry leaks.
 	if len(resp.id) > 0 {
-		cid := strings.clone_to_cstring(resp.id)
-		lua_pushstring(L, cid)
-		delete(cid)
+		lua_pushlstring(L, cstring(raw_data(transmute([]u8)resp.id)), uint(len(resp.id)))
 		lua_setfield(L, -2, "id")
 	}
 
@@ -997,10 +1000,8 @@ deliver_http_response :: proc(b: ^Bridge, resp: ^Http_Response) {
 		lua_setfield(L, -2, "body")
 	}
 
-	if len(resp.error_msg) > 0 {
-		cerr := strings.clone_to_cstring(resp.error_msg)
-		lua_pushstring(L, cerr)
-		delete(cerr)
+	if len(resp.error_msg) > 0 { // #225 L4: NUL-safe, mirrors id above
+		lua_pushlstring(L, cstring(raw_data(transmute([]u8)resp.error_msg)), uint(len(resp.error_msg)))
 		lua_setfield(L, -2, "error")
 	}
 
@@ -1030,7 +1031,10 @@ deliver_http_response :: proc(b: ^Bridge, resp: ^Http_Response) {
 // redin.shell(id, cmd_table, stdin) — queue async shell command
 // Reads a Lua sequence at `idx` into an owned []string. Returns ok=false
 // (after freeing any partial result) if any element is not a string, so
-// callers don't silently substitute "" for a non-string argv entry (#172).
+// callers don't silently substitute "" for a non-string argv entry (#172),
+// or if any element contains an embedded NUL, which os.process_start would
+// truncate at when building the C argv for execve (#225 L3) — silently
+// dropping the tail of the argument.
 // lua_isstring here is strict (type == LUA_TSTRING), so numbers/bools/tables
 // are rejected rather than coerced.
 read_string_array :: proc(L: ^Lua_State, idx: i32) -> (out: []string, ok: bool) {
@@ -1039,13 +1043,16 @@ read_string_array :: proc(L: ^Lua_State, idx: i32) -> (out: []string, ok: bool) 
 	for i in 0 ..< count {
 		lua_rawgeti(L, idx, i32(i + 1))
 		is_str := lua_isstring(L, -1)
-		if is_str do out[i] = lua_clone_string(L, -1)
+		s: string
+		if is_str do s = lua_clone_string(L, -1)
 		lua_pop(L, 1)
-		if !is_str {
-			for s in out do if len(s) > 0 do delete(s)
+		if !is_str || strings.index_byte(s, 0) >= 0 {
+			if len(s) > 0 do delete(s)
+			for x in out do if len(x) > 0 do delete(x)
 			delete(out)
 			return nil, false
 		}
+		out[i] = s
 	}
 	return out, true
 }
@@ -1062,10 +1069,11 @@ redin_shell :: proc "c" (L: ^Lua_State) -> i32 {
 	if lua_istable(L, 2) {
 		cmd, ok := read_string_array(L, 2)
 		if !ok {
-			// #172: a non-string argv element would otherwise become "",
-			// silently corrupting the command. Reject with an error result
-			// so the on-error handler fires instead.
-			shell_emit_error(&g_bridge.shell_client, req.id, "shell :cmd contains a non-string element")
+			// #172 / #225 L3: a non-string argv element would otherwise become
+			// "", and an element with an embedded NUL would be truncated at the
+			// NUL by execve — both silently corrupt the command. Reject with an
+			// error result so the on-error handler fires instead.
+			shell_emit_error(&g_bridge.shell_client, req.id, "shell :cmd contains a non-string element or an embedded NUL")
 			if len(req.id) > 0 do delete(req.id)
 			return 0
 		}
@@ -1126,10 +1134,13 @@ deliver_shell_response :: proc(b: ^Bridge, resp: ^Shell_Response) {
 	// Response data table
 	lua_createtable(L, 0, 5)
 
+	// #225 L4: id must use lua_pushlstring (explicit length) like body /
+	// stdout / stderr — clone_to_cstring + lua_pushstring truncates at the
+	// first NUL. The id is the app-controlled routing key; a NUL-truncated id
+	// no longer matches the app's pending-request slot, so the response
+	// callback silently never fires and the entry leaks.
 	if len(resp.id) > 0 {
-		cid := strings.clone_to_cstring(resp.id)
-		lua_pushstring(L, cid)
-		delete(cid)
+		lua_pushlstring(L, cstring(raw_data(transmute([]u8)resp.id)), uint(len(resp.id)))
 		lua_setfield(L, -2, "id")
 	}
 
@@ -1146,10 +1157,8 @@ deliver_shell_response :: proc(b: ^Bridge, resp: ^Shell_Response) {
 	lua_pushnumber(L, f64(resp.exit_code))
 	lua_setfield(L, -2, "exit-code")
 
-	if len(resp.error_msg) > 0 {
-		cerr := strings.clone_to_cstring(resp.error_msg)
-		lua_pushstring(L, cerr)
-		delete(cerr)
+	if len(resp.error_msg) > 0 { // #225 L4: NUL-safe, mirrors id above
+		lua_pushlstring(L, cstring(raw_data(transmute([]u8)resp.error_msg)), uint(len(resp.error_msg)))
 		lua_setfield(L, -2, "error")
 	}
 

--- a/src/redin/bridge/shell_cmd_test.odin
+++ b/src/redin/bridge/shell_cmd_test.odin
@@ -30,4 +30,51 @@ test_read_string_array_rejects_non_string :: proc(t: ^testing.T) {
 	testing.expect(t, !ok2, "a non-string element must be rejected (#172)")
 	testing.expect(t, bad == nil, "rejected result must be nil (freed)")
 	lua_pop(L, 1)
+
+	// #225 L3: an element with an embedded NUL would be truncated at the NUL
+	// by execve (os.process_start builds a C argv). Reject it, don't truncate.
+	testing.expect(t, luaL_dostring(L, "return {'echo', 'hello\\0world'}") == 0, "lua build failed")
+	nul, ok3 := read_string_array(L, lua_gettop(L))
+	testing.expect(t, !ok3, "an element with an embedded NUL must be rejected (#225 L3)")
+	testing.expect(t, nul == nil, "rejected result must be nil (freed)")
+	lua_pop(L, 1)
+
+	// A bare NUL byte at the end is still an embedded NUL and must be rejected.
+	testing.expect(t, luaL_dostring(L, "return {'ok', 'x\\0'}") == 0, "lua build failed")
+	nul2, ok4 := read_string_array(L, lua_gettop(L))
+	testing.expect(t, !ok4, "trailing NUL must be rejected")
+	testing.expect(t, nul2 == nil, "rejected result must be nil (freed)")
+	lua_pop(L, 1)
+}
+
+// #225 L4: deliver_shell_response echoed the app-controlled `id` back through
+// clone_to_cstring + lua_pushstring, truncating it at the first NUL. A
+// truncated id no longer matches the app's pending-shell slot, so the
+// response callback silently never fires. The delivery must preserve the
+// full id via lua_pushlstring (as it already does for stdout/stderr).
+@(test)
+test_deliver_shell_response_preserves_nul_id :: proc(t: ^testing.T) {
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	b: Bridge
+	b.L = L
+
+	// Capture the delivered id's length into a Lua global.
+	setup: cstring = `captured_id_len = -1
+function redin_events(evs)
+  local d = evs[1][2]
+  captured_id_len = d.id and #d.id or -1
+end`
+	testing.expect(t, luaL_dostring(L, setup) == 0, "lua setup failed")
+
+	resp: Shell_Response
+	resp.id = "a\x00b" // 3 bytes, embedded NUL
+	deliver_shell_response(&b, &resp)
+
+	lua_getglobal(L, "captured_id_len")
+	got := int(lua_tonumber(L, -1))
+	lua_pop(L, 1)
+	testing.expect_value(t, got, 3)
 }


### PR DESCRIPTION
Addresses **L3** and **L4** from the #225 audit.

**L3:** `read_string_array` cloned argv elements preserving NULs, but `os.process_start` converts each to a C string for `execve`, truncating at the first NUL — `["echo" "hello\0world"]` silently ran `echo hello`. Now rejected (like #172 rejects non-string elements) instead of truncated.

**L4:** `deliver_shell_response` echoed the app-controlled `id`/`error` back through `clone_to_cstring` + `lua_pushstring`, truncating at the first NUL. A NUL-truncated id no longer matches the app's pending-shell slot, so the response callback silently never fires and the entry leaks. Now uses `lua_pushlstring` with explicit length, as stdout/stderr already do. The HTTP delivery path had the identical bug on its app-controlled id/error — fixed the same way.

## Tests
argv-NUL-rejection cases on the `read_string_array` test + a delivery test asserting a NUL-bearing id round-trips at full length. Full bridge suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
