### PR TITLE
fix(#225): block IPv4-in-IPv6 SSRF transition addresses (M3)

### DIFF
--- a/src/redin/bridge/api.odin
+++ b/src/redin/bridge/api.odin
@@ -498,7 +498,30 @@ ip6_is_private_or_local :: proc(a: net.IP6_Address) -> bool {
 	case b[0] == 0xfe && (b[1] & 0xc0) == 0x80: return true // fe80::/10 link-local
 	case (b[0] & 0xfe) == 0xfc:                 return true // fc00::/7 ULA
 	}
+	// #225 M3: IPv4-in-IPv6 transition spaces dial an internal v4 target on a
+	// dual-stack host, bypassing the v6-only checks above. Extract the embedded
+	// v4 and classify it with the (hardened) v4 policy.
+	//
+	// IPv4-mapped  ::ffff:0:0/96  — bytes 0-9 zero, 10-11 == ff:ff, 12-15 = v4.
+	if bytes_are_zero(b[0:10]) && b[10] == 0xff && b[11] == 0xff {
+		return ip4_is_private_or_local(net.IP4_Address{b[12], b[13], b[14], b[15]})
+	}
+	// 6to4  2002::/16  — bytes 2-5 embed the v4.
+	if b[0] == 0x20 && b[1] == 0x02 {
+		return ip4_is_private_or_local(net.IP4_Address{b[2], b[3], b[4], b[5]})
+	}
+	// NAT64  64:ff9b::/96  — bytes 12-15 embed the v4.
+	if b[0] == 0x00 && b[1] == 0x64 && b[2] == 0xff && b[3] == 0x9b && bytes_are_zero(b[4:12]) {
+		return ip4_is_private_or_local(net.IP4_Address{b[12], b[13], b[14], b[15]})
+	}
+	// Unspecified  ::  — never a legitimate dial target.
+	if bytes_are_zero(b[:]) do return true
 	return false
+}
+
+bytes_are_zero :: proc(s: []u8) -> bool {
+	for x in s do if x != 0 do return false
+	return true
 }
 
 // access_decide_ip4 / _ip6: does `class` permit dialing this resolved IP,

--- a/src/redin/bridge/http_access_test.odin
+++ b/src/redin/bridge/http_access_test.odin
@@ -44,12 +44,29 @@ test_ip4_is_private :: proc(t: ^testing.T) {
 
 @(test)
 test_ip6_is_private :: proc(t: ^testing.T) {
-	for s in ([]string{"::1", "fe80::1", "fc00::1", "fd12:3456::1"}) {
+	for s in ([]string{
+		"::1", "fe80::1", "fc00::1", "fd12:3456::1",
+		// #225 M3: IPv4-in-IPv6 transition spaces that dial to an internal
+		// v4 target on a dual-stack host. IPv4-mapped (::ffff:0:0/96) of a
+		// private/loopback/metadata v4; 6to4 (2002::/16) embedding one;
+		// NAT64 (64:ff9b::/96); and the unspecified address.
+		"::ffff:127.0.0.1", "::ffff:10.0.0.1", "::ffff:169.254.169.254",
+		"::ffff:192.168.1.1",
+		"2002:7f00:0001::",       // 6to4 of 127.0.0.1
+		"2002:0a00:0001::",       // 6to4 of 10.0.0.1
+		"64:ff9b::7f00:1",        // NAT64 of 127.0.0.1
+		"::",                     // unspecified
+	}) {
 		a, ok := net.parse_ip6_address(s)
 		testing.expect(t, ok, "parse")
 		testing.expectf(t, ip6_is_private_or_local(a), "%s should classify as private/local", s)
 	}
-	for s in ([]string{"2001:4860:4860::8888", "2606:4700::1111"}) {
+	for s in ([]string{
+		"2001:4860:4860::8888", "2606:4700::1111",
+		"::ffff:8.8.8.8",         // IPv4-mapped public stays external
+		"2002:0808:0808::",       // 6to4 of 8.8.8.8 stays external
+		"64:ff9b::0808:0808",     // NAT64 of 8.8.8.8 stays external
+	}) {
 		a, ok := net.parse_ip6_address(s)
 		testing.expect(t, ok, "parse")
 		testing.expectf(t, !ip6_is_private_or_local(a), "%s should classify as external", s)


### PR DESCRIPTION
Addresses **M3** from the #225 audit.

`ip6_is_private_or_local` only matched `::1`, `fe80::/10`, and `fc00::/7`, so IPv4-in-IPv6 transition addresses slipped past the `external` access class. On a dual-stack host, dialing `::ffff:127.0.0.1` (IPv4-mapped), `2002:7f00:1::` (6to4), or `64:ff9b::7f00:1` (NAT64) opens an actual IPv4 connection to the embedded internal target — an attacker-controlled AAAA record turns `set_http_whitelist(["external"])` into internal-network reach, defeating the DNS-rebinding defence.

## Fix
Extract the embedded v4 from each transition space and classify it with the already-hardened `ip4_is_private_or_local` policy; reject the unspecified address `::` outright. Public v4s (`::ffff:8.8.8.8`) still classify as external.

## Tests
Extends `test_ip6_is_private` with mapped / 6to4 / NAT64 / unspecified private cases and public-v4 transition cases. Full `src/redin/bridge` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
