### PR TITLE
fix(#225): default CI workflows to read-only GITHUB_TOKEN (L8)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,12 @@ on:
         required: false
         default: ""
 
+# #225 L8: default every job to a read-only GITHUB_TOKEN. The `build` job
+# needs no write scope; only the `release` job escalates to
+# `contents: write` (at job level) to publish the GitHub release.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+# #225 L8: default the workflow's GITHUB_TOKEN to read-only instead of
+# inheriting the repo default (historically write-all). No job here needs
+# write; a compromised build step then can't escalate with the token.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Addresses **L8** from the #225 audit.

Neither workflow declared a top-level `permissions:` block, so every job inherited the repo-default `GITHUB_TOKEN` scopes (write-all was the GitHub-wide default until 2023).

## Fix
Add `permissions: contents: read` at the top of `test.yml` and `release.yml`. The `release` job keeps its explicit job-level `contents: write` escalation, so publishing still works while build/test steps can no longer be leveraged for a token-scoped compromise. Defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
