### PR TITLE
fix(#225): clamp non-finite/huge theme numerics at host boundary (M1)

### DIFF
--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -1807,12 +1807,20 @@ lua_to_theme :: proc(L: ^Lua_State, index: i32) -> map[string]types.Theme {
 			t.color = lua_get_rgb_field(L, props_idx, "color")
 			t.border = lua_get_rgb_field(L, props_idx, "border")
 			t.padding = lua_get_padding_field(L, props_idx, "padding")
-			t.border_width = u8(lua_get_number_field(L, props_idx, "border-width"))
-			t.radius = u8(lua_get_number_field(L, props_idx, "radius"))
-			t.font_size = f16(lua_get_number_field(L, props_idx, "font-size"))
-			t.line_height = lua_get_number_field(L, props_idx, "line-height")
+			// #225 M1: theme numerics can arrive non-finite or absurdly large
+			// — most reachably via `PUT /aspects`, which stores the theme
+			// verbatim and never runs the Fennel validator. An unclamped
+			// +Inf/NaN flows straight into Raylib rectangle / scissor / shadow
+			// math (font_size * line_height, total-height, DrawRectangleRounded)
+			// and crashes or corrupts the render loop. Clamp every numeric to a
+			// finite, sane range here, at the host boundary, so both the app
+			// path and the dev-server path are covered.
+			t.border_width = u8(clamp_theme(lua_get_number_field(L, props_idx, "border-width"), 0, 255))
+			t.radius = u8(clamp_theme(lua_get_number_field(L, props_idx, "radius"), 0, 255))
+			t.font_size = f16(clamp_theme(lua_get_number_field(L, props_idx, "font-size"), 0, 1024))
+			t.line_height = clamp_theme(lua_get_number_field(L, props_idx, "line-height"), 0, 16)
 			t.font = lua_get_string_field(L, props_idx, "font")
-			t.opacity = lua_get_number_field(L, props_idx, "opacity")
+			t.opacity = clamp_theme(lua_get_number_field(L, props_idx, "opacity"), 0, 1)
 			t.shadow = lua_get_shadow_field(L, props_idx, "shadow")
 			t.selection = lua_get_rgba_field(L, props_idx, "selection")
 
@@ -1883,14 +1891,17 @@ lua_get_shadow_field :: proc(L: ^Lua_State, index: i32, field: cstring) -> types
 	if !lua_istable(L, -1) do return {}
 	abs := lua_gettop(L)
 	s: types.Shadow
+	// #225 M1: offsets may be negative but must stay finite; blur must be
+	// non-negative and bounded (draw_shadow only guards on blur <= 0, so
+	// +Inf blur produced 8 passes of DrawRectangleRounded on an infinite rect).
 	lua_rawgeti(L, abs, 1)
-	s.x = f32(lua_tonumber(L, -1))
+	s.x = clamp_theme(f32(lua_tonumber(L, -1)), -4096, 4096)
 	lua_pop(L, 1)
 	lua_rawgeti(L, abs, 2)
-	s.y = f32(lua_tonumber(L, -1))
+	s.y = clamp_theme(f32(lua_tonumber(L, -1)), -4096, 4096)
 	lua_pop(L, 1)
 	lua_rawgeti(L, abs, 3)
-	s.blur = f32(lua_tonumber(L, -1))
+	s.blur = clamp_theme(f32(lua_tonumber(L, -1)), 0, 256)
 	lua_pop(L, 1)
 	lua_rawgeti(L, abs, 4)
 	if lua_istable(L, -1) {
@@ -2357,6 +2368,17 @@ lua_get_number_field :: proc(L: ^Lua_State, index: i32, field: cstring) -> f32 {
 		return f32(lua_tonumber(L, -1))
 	}
 	return 0
+}
+
+// #225 M1: coerce a theme numeric into a finite [lo, hi] range before it
+// reaches Raylib. NaN maps to 0 clamped into range; ±Inf saturate to the
+// range ends (clamp's comparisons already do this: +Inf > hi -> hi,
+// -Inf < lo -> lo). The NaN branch is explicit because every comparison
+// with NaN is false, so a bare clamp would pass NaN straight through — and
+// a NaN width/roundness is exactly what corrupts the render loop.
+clamp_theme :: proc(v: f32, lo: f32, hi: f32) -> f32 {
+	if v != v do return clamp(f32(0), lo, hi) // NaN
+	return clamp(v, lo, hi)
 }
 
 // Reads slot at `slot_idx` of the table at `tbl_idx` as a tag list:

--- a/src/redin/bridge/theme_sanitize_test.odin
+++ b/src/redin/bridge/theme_sanitize_test.odin
@@ -1,0 +1,70 @@
+package bridge
+
+import "core:math"
+import "core:sync"
+import "core:testing"
+
+// #225 M1: `PUT /aspects` stores the theme verbatim and never runs the
+// Fennel validator, so non-finite / absurdly large numerics reach the
+// host reader. Unclamped, font_size * line_height, total-height, and
+// shadow blur overflow to +Inf/NaN and flow into Raylib rectangle,
+// scissor, and DrawRectangleRounded math — a session-DoS on the render
+// loop. lua_to_theme must clamp every numeric to a finite, sane range.
+
+@(test)
+test_clamp_theme_finite_and_bounded :: proc(t: ^testing.T) {
+	inf := math.inf_f32(1)
+	nan := math.nan_f32()
+	testing.expect_value(t, clamp_theme(5, 0, 16), 5)      // in range, untouched
+	testing.expect_value(t, clamp_theme(inf, 0, 16), 16)   // +Inf saturates to hi
+	testing.expect_value(t, clamp_theme(-inf, 0, 16), 0)   // -Inf saturates to lo
+	testing.expect_value(t, clamp_theme(1e30, 0, 1024), 1024)
+	testing.expect_value(t, clamp_theme(-5, 0, 255), 0)    // negative -> lo
+	testing.expect_value(t, clamp_theme(-inf, -4096, 4096), -4096) // signed range
+	// NaN must not slip through — a bare clamp would return NaN.
+	got := clamp_theme(nan, 0, 16)
+	testing.expect(t, got == got, "NaN must be mapped to a finite value")
+	testing.expect_value(t, got, 0)
+}
+
+@(test)
+test_lua_to_theme_clamps_hostile_numerics :: proc(t: ^testing.T) {
+	sync.lock(&g_test_bridge_global_mutex)
+	defer sync.unlock(&g_test_bridge_global_mutex)
+
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	// A theme like the PUT /aspects repro in #225: huge line-height and an
+	// infinite shadow blur, plus a NaN font-size.
+	code: cstring = `return {
+		text = {["line-height"] = 1e30, ["font-size"] = 0/0},
+		button = {shadow = {0, 0, math.huge, {0, 0, 0, 128}}},
+	}`
+	rc := luaL_dostring(L, code)
+	testing.expectf(t, rc == 0, "failed to build theme table (rc=%d)", rc)
+
+	theme := lua_to_theme(L, lua_gettop(L))
+	defer {
+		// Themes own heap key + font strings (see bridge destroy).
+		for k, v in theme {
+			delete(k)
+			if len(v.font) > 0 do delete(v.font)
+		}
+		delete(theme)
+	}
+
+	txt := theme["text"]
+	lh := f32(txt.line_height)
+	testing.expect(t, lh == lh, "line-height must be finite (not NaN)")
+	testing.expect(t, lh <= 16, "line-height must be clamped to <= 16")
+	fs := f32(txt.font_size)
+	testing.expect(t, fs == fs, "font-size must be finite (not NaN)")
+	testing.expect(t, fs >= 0 && fs <= 1024, "font-size must be clamped into [0,1024]")
+
+	btn := theme["button"]
+	blur := btn.shadow.blur
+	testing.expect(t, blur == blur, "shadow blur must be finite (not NaN)")
+	testing.expect(t, blur <= 256, "shadow blur must be clamped to <= 256")
+}


### PR DESCRIPTION
Addresses **M1** from the #225 audit.

`PUT /aspects` (and `set-theme`) store the theme verbatim and never run the Fennel validator, so an app or a token-holding tool can push non-finite or absurdly large numerics. Unclamped they reach Raylib: `font_size * line_height` and total-height overflow to `+Inf`, and `draw_shadow` only guards on `blur <= 0`, so a `+Inf` blur runs eight passes of `DrawRectangleRounded` on a `{+Inf,+Inf,+Inf,+Inf}` rect with NaN roundness every frame — a session-DoS on the render loop. The `f32->u8`/`->f16` casts on `+Inf`/`NaN` are themselves implementation-defined.

## Fix
Clamp every numeric theme field to a finite, sane range in `lua_to_theme` (the host boundary), covering both the app path and the dev-server path: border-width/radius ≤ 255, font-size ≤ 1024, line-height ≤ 16, opacity ∈ [0,1], shadow offsets ∈ [-4096,4096], blur ≤ 256. NaN maps to 0; ±Inf saturate.

## Tests
`clamp_theme` unit test + an end-to-end `lua_to_theme` test with hostile numerics (`1e30`, `0/0`, `math.huge`). Full bridge suite green, no leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
