### PR TITLE
fix(#225): JSON-escape node tag / id in /frames and /agent/nodes (L1)

### DIFF
--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -1193,10 +1193,9 @@ frame_value_to_json :: proc(
 
 	// Emit ["tag", attrs-with-rect, ...children-recursed]
 	strings.write_string(b, "[")
-	// tag
-	strings.write_string(b, `"`)
-	strings.write_string(b, tag)
-	strings.write_string(b, `"`)
+	// tag — #225 L1: a Lua node tag can contain `"` or control chars; emit
+	// through json_string so a hostile tag can't break the JSON structure.
+	json_string(b, tag)
 	// attrs at slot [2]
 	lua_rawgeti(L, idx, 2)
 	strings.write_string(b, ",")
@@ -1283,7 +1282,15 @@ agent_nodes_walker :: proc(b: ^strings.Builder, L: ^Lua_State, index: i32, first
 		if len(mode) > 0 && len(id) > 0 && tag != "canvas" {
 			if !first^ do strings.write_string(b, ",")
 			first^ = false
-			fmt.sbprintf(b, `{{"id":"%s","mode":"%s","type":"%s"}}`, id, mode, tag)
+			// #225 L1: id and tag are app-controlled; escape via json_string
+			// so a `"` in either can't inject a key into the agent-nodes JSON.
+			strings.write_string(b, `{"id":`)
+			json_string(b, id)
+			strings.write_string(b, `,"mode":`)
+			json_string(b, mode)
+			strings.write_string(b, `,"type":`)
+			json_string(b, tag)
+			strings.write_string(b, "}")
 		}
 	}
 	lua_pop(L, 1)

--- a/src/redin/bridge/devserver_json_escape_test.odin
+++ b/src/redin/bridge/devserver_json_escape_test.odin
@@ -1,0 +1,60 @@
+package bridge
+
+import "core:strings"
+import "core:testing"
+import rl "vendor:raylib"
+
+// #225 L1: /frames and /agent/nodes emitted the node `tag` / `id` raw, so a
+// Lua node whose tag or :id contains a `"` produced structurally broken JSON
+// (and could inject an extra key an agent consumer would trust). Both must
+// route through json_string.
+
+@(test)
+test_frame_tag_is_json_escaped :: proc(t: ^testing.T) {
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	// A node whose tag carries a quote + injection attempt.
+	testing.expect(t, luaL_dostring(L, `return {'ev"il', {}}`) == 0, "lua build failed")
+
+	b := strings.builder_make()
+	defer strings.builder_destroy(&b)
+	skips := make(map[i32]i32)
+	defer delete(skips)
+	dfs := 0
+	frame_value_to_json(&b, L, lua_gettop(L), []rl.Rectangle{}, skips, &dfs)
+	out := strings.to_string(b)
+
+	testing.expectf(t, strings.contains(out, `\"`), "quote in tag must be escaped: %s", out)
+	testing.expectf(t, strings.contains(out, `"ev\"il"`), "tag must be a single escaped string: %s", out)
+	// The raw, unescaped `ev"il"` (a broken close) must not appear.
+	testing.expectf(t, !strings.contains(out, `ev"il"`), "tag must not close the JSON string early: %s", out)
+}
+
+// agent_nodes_walker is compiled only in REDIN_AGENT builds, so this test
+// is too. Run it with: odin test src/redin/bridge ... -define:REDIN_AGENT=true
+when REDIN_AGENT {
+@(test)
+test_agent_nodes_id_is_json_escaped :: proc(t: ^testing.T) {
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	testing.expect(
+		t,
+		luaL_dostring(L, `return {'text', {agent='edit', id='a"b'}}`) == 0,
+		"lua build failed",
+	)
+
+	b := strings.builder_make()
+	defer strings.builder_destroy(&b)
+	first := true
+	agent_nodes_walker(&b, L, lua_gettop(L), &first)
+	out := strings.to_string(b)
+
+	testing.expectf(t, strings.contains(out, `"id":"a\"b"`), "id quote must be escaped: %s", out)
+	testing.expectf(t, strings.contains(out, `"mode":"edit"`), "mode present: %s", out)
+	testing.expectf(t, strings.contains(out, `"type":"text"`), "type present: %s", out)
+}
+} // when REDIN_AGENT


### PR DESCRIPTION
Addresses **L1** from the #225 audit.

`frame_value_to_json` wrote the node `tag` between raw quotes, and `agent_nodes_walker` built its object with `sbprintf("%s")` for `id`/`tag`. A Lua node whose tag is `ev"il` or whose `:id` contains a `"` produced structurally broken JSON — and could inject an extra key an LLM-side agent consuming `/agent/nodes` would trust.

## Fix
Route both through `json_string`, which already handles quotes, control chars, and UTF-8.

## Tests
Frame-tag escaping test (default build) + an agent-nodes id escaping test gated on `REDIN_AGENT` (matching the code it covers, verified locally with `-define:REDIN_AGENT=true`). Full bridge suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
