### PR TITLE
chore: migrate to Odin dev-2026-07 and raylib 6

### DIFF
--- a/.claude/skills/redin-maintenance/SKILL.md
+++ b/.claude/skills/redin-maintenance/SKILL.md
@@ -15,7 +15,7 @@ odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -o
 
 `src/cmd/redin/` is the thin CLI entry point (`package main`, arg parsing + memory tracking + `redin.run` call). The framework itself lives in `src/redin/` (`package redin`).
 
-Requires: `libssl-dev`, `libraylib-dev`, and the `lib/odin-http` git submodule (`git submodule update --init`).
+Requires: Odin dev-2026-07 or newer (raylib 6 ships in `vendor:raylib`), `libssl-dev`, the X11/GL dev libs (`libgl1-mesa-dev libx11-dev libxrandr-dev libxi-dev libxcursor-dev libxinerama-dev`), and the `lib/odin-http` git submodule (`git submodule update --init`).
 
 ## Fennel runtime tests
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,11 +47,12 @@ jobs:
         uses: laytan/setup-odin@8536d8fa450ec6f1bd9ddc84bbaaf16296c0051d  # v2.12.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # Pin the Odin release: the default tracks master, which broke
-          # core:sys/linux (Sig_Action) between dev-2026-04 and -06 and
-          # turned CI red repo-wide. dev-2026-04 is the line the tree
-          # builds and tests clean on. Bump deliberately, not silently.
-          release: dev-2026-04
+          # Pin the Odin release: the default tracks master, which can
+          # break core:sys APIs mid-cycle and turn CI red repo-wide.
+          # dev-2026-07 is the line the tree builds and tests clean on
+          # (non-parametric Sig_Action, vendored raylib 6). Bump
+          # deliberately, not silently.
+          release: dev-2026-07
 
       - name: Run Fennel tests
         run: luajit test/lua/runner.lua test/lua/test_*.fnl
@@ -134,11 +135,12 @@ jobs:
         uses: laytan/setup-odin@8536d8fa450ec6f1bd9ddc84bbaaf16296c0051d  # v2.12.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # Pin the Odin release: the default tracks master, which broke
-          # core:sys/linux (Sig_Action) between dev-2026-04 and -06 and
-          # turned CI red repo-wide. dev-2026-04 is the line the tree
-          # builds and tests clean on. Bump deliberately, not silently.
-          release: dev-2026-04
+          # Pin the Odin release: the default tracks master, which can
+          # break core:sys APIs mid-cycle and turn CI red repo-wide.
+          # dev-2026-07 is the line the tree builds and tests clean on
+          # (non-parametric Sig_Action, vendored raylib 6). Bump
+          # deliberately, not silently.
+          release: dev-2026-07
 
       - name: Run Fennel tests
         run: luajit test/lua/runner.lua test/lua/test_*.fnl

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -o
 
 | Dependency | Purpose | Required |
 |-----------|---------|----------|
-| **Odin** (nightly) | Compiles the host/renderer | Yes |
-| **Raylib** | Bundled with Odin | -- |
+| **Odin** (dev-2026-07 or newer) | Compiles the host/renderer | Yes |
+| **Raylib** (6.0) | Bundled with Odin (`vendor:raylib`) | -- |
 | **LuaJIT** (`luajit`) | Runs tests, AOT compiles Fennel; the C library is statically linked from `vendor/luajit/` so `libluajit-5.1-dev` is not required | Yes |
 | **OpenSSL** (`libssl-dev`) | HTTPS support via odin-http | Yes |
 | **OpenGL + X11 dev headers** (Linux only — `libgl1-mesa-dev`, `libx11-dev`, `libxrandr-dev`, `libxi-dev`, `libxcursor-dev`, `libxinerama-dev`) | Required by Odin's bundled Raylib at link time | Yes (Linux) |

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -245,10 +245,9 @@ install_signal_cleanup :: proc() {
 	if g_signal_cleanup_installed do return
 	g_signal_cleanup_installed = true
 
-	sa := linux.Sig_Action(rawptr) {
-		handler = cleanup_on_signal,
-		flags   = {.RESETHAND},
-	}
+	sa: linux.Sig_Action
+	sa.handler = cleanup_on_signal
+	sa.flags = {.RESETHAND}
 	signals := []linux.Signal{
 		.SIGINT,
 		.SIGTERM,
@@ -258,8 +257,7 @@ install_signal_cleanup :: proc() {
 		.SIGABRT,
 	}
 	for s in signals {
-		// nil oldact via casting; we don't care about the previous handler.
-		linux.rt_sigaction(s, &sa, (^linux.Sig_Action(rawptr))(nil))
+		linux.rt_sigaction(s, &sa, nil)
 	}
 }
 

--- a/src/redin/bridge/shell.odin
+++ b/src/redin/bridge/shell.odin
@@ -24,10 +24,9 @@ g_sigpipe_ignored: bool
 ignore_sigpipe :: proc() {
 	if g_sigpipe_ignored do return
 	g_sigpipe_ignored = true
-	sa := linux.Sig_Action(rawptr) {
-		handler = transmute(linux.Sig_Handler_Fn)(uintptr(linux.Sig_Action_Special.SIG_IGN)),
-	}
-	linux.rt_sigaction(.SIGPIPE, &sa, (^linux.Sig_Action(rawptr))(nil))
+	sa: linux.Sig_Action
+	sa.special = .SIG_IGN
+	linux.rt_sigaction(.SIGPIPE, &sa, nil)
 }
 
 Shell_Request :: struct {


### PR DESCRIPTION
## Summary

Migrates the tree to the current Odin release (dev-2026-07) and the raylib 6.0 that ships with it in `vendor:raylib`.

- **`Sig_Action` migration** — the only source breakage. `core:sys/linux.Sig_Action` is no longer parametric; both call sites (`bridge/shell.odin` SIGPIPE ignore, `bridge/devserver.odin` signal-cleanup install) now use the plain struct: `special = .SIG_IGN` for the ignore disposition, direct field assignment for the handler, and a plain `nil` old-action pointer instead of the old cast.
- **raylib 6.0** — zero code changes needed; redin's raylib surface compiles as-is.
- **CI pins** — both `test.yml` Odin pins bumped `dev-2026-04` → `dev-2026-07`. The old pin existed precisely because of this `Sig_Action` break; the migrated code requires the new API, so the bump lands in the same change.
- **Docs** — README states the minimum Odin version and raylib 6.0 (vendored); the maintenance skill's incorrect `libraylib-dev` requirement replaced with the actual X11/GL dev-lib list (CI never installed raylib — it's bundled with Odin).

## Verification

- Release build and `./build-dev.sh -define:REDIN_AGENT=true` compile clean on dev-2026-07
- 154 Fennel runtime tests pass
- All Odin unit-test packages pass (parser, markdown, profile, input, bridge, canvas — 228 tests)
- Full headless UI suite: all suites passed
- Visual check: kitchen-sink screenshot under raylib 6 renders correctly (fonts, shadows, radii, scrollbar, drag handles, canvas, animate decoration, profile overlay)

Note: the flaky compiler segfault CI occasionally hit on the old pin (exit 139, no test output) is a known re-run-able flake; whether dev-2026-07 still exhibits it will show over upcoming runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)