### PR TITLE
fix(#233): resolve real exe dir for bare argv[0], not cwd (H1)

### DIFF
--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -79,17 +79,22 @@ init :: proc(b: ^Bridge) {
 	// tracking allocator flags as a "Bad free"; the dev-nightly Odin
 	// allocates). Lua copies the cstring on push, so the temp clone is
 	// reclaimed by the first frame's free_all(context.temp_allocator).
-	exe_path := string(os.args[0])
-	exe_dir: string
-	{
-		last_sep := -1
-		for i := len(exe_path) - 1; i >= 0; i -= 1 {
-			if exe_path[i] == '/' || exe_path[i] == '\\' {
-				last_sep = i
-				break
+	//
+	// #233 H1: when redin is on $PATH and invoked bare (`redin app.fnl`),
+	// argv[0] is just "redin" with no separator. Defaulting exe_dir to "."
+	// then makes setup_lua_paths / load_fennel look for
+	// ./vendor/fennel/fennel.lua relative to the *current* directory —
+	// before any source-tree gate — so `cd /tmp/tainted && redin x.fnl`
+	// would execute an attacker-planted ./vendor/fennel/fennel.lua at
+	// startup. Resolve the real binary via /proc/self/exe in that case so
+	// the search stays anchored to the install directory, never cwd.
+	exe_dir, exe_has_sep := path_parent_dir(string(os.args[0]))
+	if !exe_has_sep {
+		if real, err := os.get_executable_path(context.temp_allocator); err == nil {
+			if real_dir, real_has_sep := path_parent_dir(real); real_has_sep {
+				exe_dir = real_dir
 			}
 		}
-		exe_dir = exe_path[:last_sep] if last_sep > 0 else "."
 	}
 	exe_dir_c := strings.clone_to_cstring(exe_dir, context.temp_allocator)
 	lua_pushstring(b.L, exe_dir_c)

--- a/src/redin/bridge/exe_path.odin
+++ b/src/redin/bridge/exe_path.odin
@@ -1,0 +1,29 @@
+package bridge
+
+// path_parent_dir returns the directory portion of `path` — everything up
+// to the last '/' or '\\' separator — and whether a separator was present.
+//
+//   "build/redin"   -> ("build", true)
+//   "/usr/bin/redin"-> ("/usr/bin", true)
+//   "/redin"        -> ("/", true)      // root-anchored, dir is the root
+//   "redin"         -> ("", false)      // bare name, no directory
+//
+// A slice of the input is returned (no allocation), matching the
+// tracking-allocator constraints documented at the call site in `init`.
+// The `false` case tells the caller argv[0] carried no path — a bare
+// $PATH-resolved command name — so it must recover the real install
+// directory via /proc/self/exe rather than assume the current directory
+// (#233 H1).
+@(private = "package")
+path_parent_dir :: proc(path: string) -> (dir: string, has_sep: bool) {
+	last_sep := -1
+	for i := len(path) - 1; i >= 0; i -= 1 {
+		if path[i] == '/' || path[i] == '\\' {
+			last_sep = i
+			break
+		}
+	}
+	if last_sep < 0 do return "", false
+	if last_sep == 0 do return path[:1], true // separator is the root itself
+	return path[:last_sep], true
+}

--- a/src/redin/bridge/exe_path_test.odin
+++ b/src/redin/bridge/exe_path_test.odin
@@ -1,0 +1,49 @@
+package bridge
+
+import "core:testing"
+
+@(test)
+test_path_parent_dir_relative :: proc(t: ^testing.T) {
+	dir, has_sep := path_parent_dir("build/redin")
+	testing.expect(t, has_sep, "relative path has a separator")
+	testing.expect_value(t, dir, "build")
+}
+
+@(test)
+test_path_parent_dir_absolute :: proc(t: ^testing.T) {
+	dir, has_sep := path_parent_dir("/usr/local/bin/redin")
+	testing.expect(t, has_sep)
+	testing.expect_value(t, dir, "/usr/local/bin")
+}
+
+@(test)
+test_path_parent_dir_root_anchored :: proc(t: ^testing.T) {
+	// A binary directly under root: the parent dir is the root, not "".
+	dir, has_sep := path_parent_dir("/redin")
+	testing.expect(t, has_sep)
+	testing.expect_value(t, dir, "/")
+}
+
+@(test)
+test_path_parent_dir_bare_name :: proc(t: ^testing.T) {
+	// The security-relevant case (#233 H1): a $PATH-resolved bare command
+	// name has no separator, so has_sep must be false so the caller falls
+	// back to /proc/self/exe instead of defaulting exe_dir to ".".
+	dir, has_sep := path_parent_dir("redin")
+	testing.expect(t, !has_sep, "bare name must report no separator")
+	testing.expect_value(t, dir, "")
+}
+
+@(test)
+test_path_parent_dir_backslash :: proc(t: ^testing.T) {
+	dir, has_sep := path_parent_dir("C:\\tools\\redin.exe")
+	testing.expect(t, has_sep)
+	testing.expect_value(t, dir, "C:\\tools")
+}
+
+@(test)
+test_path_parent_dir_empty :: proc(t: ^testing.T) {
+	dir, has_sep := path_parent_dir("")
+	testing.expect(t, !has_sep)
+	testing.expect_value(t, dir, "")
+}


### PR DESCRIPTION
Closes part of #233 (finding **H1**, high severity).

## Problem

When `redin` is on `$PATH` and invoked bare (`redin app.fnl`), most shells pass `argv[0]` as `"redin"` — no path separator. `bridge.init` derived the executable directory by slicing `argv[0]` to the last separator and **defaulted to `"."`** when none was found. `setup_lua_paths` and `load_fennel` then consult `<exe_dir>/vendor/fennel/fennel.lua`, i.e. `./vendor/fennel/fennel.lua` relative to the **current directory**, *before* any source-tree gate:

```
cd /tmp/tainted && redin harmless.fnl
```

executes an attacker-planted `./vendor/fennel/fennel.lua` at startup with the user's privileges.

## Fix

When `argv[0]` carries no separator, resolve the real binary path via `/proc/self/exe` (`os.get_executable_path`) and anchor the Fennel search there instead of `"."`. The common separator'd invocation (`build/redin`, `/usr/bin/redin`) is unchanged — it never hits the `/proc` path. If resolution fails, `exe_dir` degrades to `""` (root-anchored lookups that find nothing), which is strictly safer than the old cwd default.

The dir-slicing is extracted into a package-private `path_parent_dir` helper with unit coverage (bare name → `("", false)`, root-anchored `/redin` → `("/", true)`, backslash paths, empty).

## Verification

- **A/B against the actual attack**: planted `./vendor/fennel/fennel.lua` writes a sentinel when executed. Pre-fix binary executes it (sentinel written); patched binary does not.
- Bridge unit tests: 138 pass (+6 new `path_parent_dir` cases).
- Normal source-tree startup + smoke UI suite still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)