### PR TITLE
fix(#233): derive SSRF name-check and resolve host from one parse (M1)

### DIFF
--- a/src/redin/bridge/http_client.odin
+++ b/src/redin/bridge/http_client.odin
@@ -40,9 +40,11 @@ header_safe :: proc(s: string) -> bool {
 	return true
 }
 
+// authority_extract returns the authority component of a URL — everything
+// between "://" and the first '/', '?' or '#'. "" if there's no scheme
+// separator.
 @(private = "file")
-url_host :: proc(url: string) -> string {
-	// "http://host:port/path" → "host"
+authority_extract :: proc(url: string) -> string {
 	idx := strings.index(url, "://")
 	if idx < 0 do return ""
 	rest := url[idx + 3:]
@@ -51,7 +53,22 @@ url_host :: proc(url: string) -> string {
 		c := rest[i]
 		if c == '/' || c == '?' || c == '#' { end = i; break }
 	}
-	host := rest[:end]
+	return rest[:end]
+}
+
+// authority_host normalizes an authority string ("user@[::1]:8080", or the
+// raw `host` field odin-http's url_parse leaves userinfo/port/brackets/
+// fragment inside) down to the bare host ("::1"). Both the SSRF whitelist
+// name-check and DNS resolution must run on the identical bare host, so this
+// is the single source of truth — see #233 M1.
+@(private = "package")
+authority_host :: proc(authority: string) -> string {
+	host := authority
+	// odin-http's url_parse doesn't split the fragment, so a '#' can survive
+	// into its `host`; terminate the authority at it.
+	if h := strings.index_byte(host, '#'); h >= 0 {
+		host = host[:h]
+	}
 	// Strip userinfo: "user:pass@host" → "host". Last `@` since password may
 	// itself be percent-encoded but cannot contain a literal `@`.
 	if at := strings.last_index_byte(host, '@'); at >= 0 {
@@ -71,20 +88,15 @@ url_host :: proc(url: string) -> string {
 	return host
 }
 
-// url_port extracts the explicit port from a URL host:port, or 0 if absent.
-// Mirrors url_host's parsing (userinfo + IPv6 brackets) so an authority like
-// "user@[::1]:8080" yields 8080. #162 M3.
-@(private = "file")
-url_port :: proc(url: string) -> int {
-	idx := strings.index(url, "://")
-	if idx < 0 do return 0
-	rest := url[idx + 3:]
-	end := len(rest)
-	for i in 0 ..< len(rest) {
-		c := rest[i]
-		if c == '/' || c == '?' || c == '#' { end = i; break }
+// authority_port extracts the explicit port from an authority, or 0 if
+// absent. Mirrors authority_host's parsing (fragment + userinfo + IPv6
+// brackets) so "user@[::1]:8080" yields 8080. #162 M3.
+@(private = "package")
+authority_port :: proc(authority: string) -> int {
+	host := authority
+	if h := strings.index_byte(host, '#'); h >= 0 {
+		host = host[:h]
 	}
-	host := rest[:end]
 	if at := strings.last_index_byte(host, '@'); at >= 0 {
 		host = host[at+1:]
 	}
@@ -103,6 +115,13 @@ url_port :: proc(url: string) -> int {
 		if p, ok := strconv.parse_int(host[colon+1:], 10); ok do return p
 	}
 	return 0
+}
+
+// url_host takes a full URL for logging / diagnostics and routes through the
+// same normalization as the security path, so it can't drift from it.
+@(private = "file")
+url_host :: proc(url: string) -> string {
+	return authority_host(authority_extract(url))
 }
 
 Http_Request :: struct {
@@ -531,8 +550,14 @@ execute_http_request :: proc(req: Http_Request, client: ^Http_Client = nil) -> H
 	parsed_url := http.url_parse(req.url)
 	checked_endpoint: net.Endpoint
 	{
-		host := url_host(req.url)
-		ep4, ep6, resolve_err := net.resolve(parsed_url.host)
+		// #233 M1: derive the whitelist-check host AND the resolved host from
+		// a single normalization of the SAME parsed authority. Previously the
+		// name-check used url_host(req.url) (a second, hand-rolled parser)
+		// while resolution used parsed_url.host raw, so a URL the two parsers
+		// disagreed on (fragment, userinfo, brackets) could name-match a
+		// whitelisted host yet dial the IP resolved from a different one.
+		host := authority_host(parsed_url.host)
+		ep4, ep6, resolve_err := net.resolve(host)
 		if resolve_err != nil {
 			// #162 L4: don't echo the resolver error (it can confirm
 			// internal names); log detail, return generic.
@@ -548,7 +573,7 @@ execute_http_request :: proc(req: Http_Request, client: ^Http_Client = nil) -> H
 			return response
 		}
 		// Fill in the port the same way odin-http's parse_endpoint would.
-		checked_endpoint.port = url_port(req.url)
+		checked_endpoint.port = authority_port(parsed_url.host)
 		if checked_endpoint.port == 0 {
 			checked_endpoint.port = parsed_url.scheme == "https" ? 443 : 80
 		}

--- a/src/redin/bridge/url_authority_test.odin
+++ b/src/redin/bridge/url_authority_test.odin
@@ -1,0 +1,77 @@
+package bridge
+
+// #233 M1: the SSRF whitelist name-check and DNS resolution must run on the
+// *same* bare host. Previously the name-check used a hand-rolled parser
+// (url_host) while resolution used odin-http's parsed_url.host raw — two
+// parsers that can disagree on the authority, so a URL could name-match a
+// whitelisted host yet dial the IP resolved from a different one. Both paths
+// now normalize the single parsed authority via authority_host; these tests
+// pin that normalization, including the odin-http quirk that leaves a
+// fragment inside `host`.
+
+import http "lib:odin-http"
+import "core:testing"
+
+@(test)
+test_authority_host_plain :: proc(t: ^testing.T) {
+	testing.expect_value(t, authority_host("example.com"), "example.com")
+}
+
+@(test)
+test_authority_host_strips_port :: proc(t: ^testing.T) {
+	testing.expect_value(t, authority_host("example.com:8080"), "example.com")
+}
+
+@(test)
+test_authority_host_strips_userinfo :: proc(t: ^testing.T) {
+	testing.expect_value(t, authority_host("user:pass@example.com"), "example.com")
+	testing.expect_value(t, authority_host("user@169.254.169.254"), "169.254.169.254")
+}
+
+@(test)
+test_authority_host_ipv6_brackets :: proc(t: ^testing.T) {
+	testing.expect_value(t, authority_host("[::1]:8080"), "::1")
+	testing.expect_value(t, authority_host("[2001:db8::1]"), "2001:db8::1")
+}
+
+@(test)
+test_authority_host_strips_fragment :: proc(t: ^testing.T) {
+	// odin-http's url_parse leaves a '#fragment' inside host; the bare host
+	// is what precedes it.
+	testing.expect_value(t, authority_host("example.com#@169.254.169.254"), "example.com")
+}
+
+@(test)
+test_authority_port :: proc(t: ^testing.T) {
+	testing.expect_value(t, authority_port("example.com:8080"), 8080)
+	testing.expect_value(t, authority_port("example.com"), 0)
+	testing.expect_value(t, authority_port("[::1]:443"), 443)
+	testing.expect_value(t, authority_port("user@host:1234"), 1234)
+	// A ':N' living inside the fragment must not be read as a port.
+	testing.expect_value(t, authority_port("example.com#x:9"), 0)
+}
+
+// The core invariant: the bare host we derive for the whitelist / resolve is
+// taken from odin-http's own parse of the URL, so name-check and dial can
+// never target different hosts. For the fragment-injection URL, the derived
+// host is the benign prefix, NOT the injected internal address.
+@(test)
+test_parsed_authority_matches_security_host :: proc(t: ^testing.T) {
+	cases := []struct {
+		url:  string,
+		want: string,
+	}{
+		{"http://example.com/path", "example.com"},
+		{"http://example.com:8080/path?q=1", "example.com"},
+		{"http://user@example.com/", "example.com"},
+		{"http://[::1]:80/", "::1"},
+		// Fragment injection: we must resolve/dial example.com, not the
+		// internal metadata address hidden after the '#'.
+		{"http://example.com#@169.254.169.254/", "example.com"},
+	}
+	for c in cases {
+		parsed := http.url_parse(c.url)
+		got := authority_host(parsed.host)
+		testing.expectf(t, got == c.want, "url %q: got host %q, want %q", c.url, got, c.want)
+	}
+}


### PR DESCRIPTION
Closes part of #233 (finding **M1**, medium — SSRF whitelist parser divergence).

## Problem

`execute_http_request` computed the whitelist-check host and the resolved host with **two different parsers**:

```odin
host := url_host(req.url)                    // hand-rolled
ep4, ep6, _ := net.resolve(parsed_url.host)  // odin-http's parser
...
if !http_access_allowed(host, checked_endpoint.address) { ... }
```

Any URL the two parsers disagree on (userinfo, IPv6 brackets, and especially a **fragment** — odin-http's `url_parse` leaves `#…` inside `host`) name-checks one authority while the socket lands on the IP resolved from the other. `http://example.com#@169.254.169.254/` name-matches `example.com` yet resolves the trailing address. The final IP is still class-checked, so loopback/link-local reach is blocked, but an arbitrary **public** host bypass is possible.

## Fix

Single source of truth: normalize the one parsed authority (`parsed_url.host`) through `authority_host`, and use that identical bare host for **both** the whitelist check and `net.resolve`; take the port from the same authority via `authority_port`. Name-check and dial can no longer target different hosts — it's the same string by construction. `url_host` (now logging-only) routes through the same normalization so it can't drift.

## Verification

- Bridge unit tests: 139 pass (+7). New `url_authority_test.odin` pins `authority_host`/`authority_port` normalization (port/userinfo/bracket/fragment) and asserts that for a fragment-injection URL the security host derived from odin-http's own parse is the benign prefix (`example.com`), not the injected internal address.
- Port handling for legit URLs is unchanged (`checked_endpoint.port` was already overridden explicitly; resolve never used the authority's port).

🤖 Generated with [Claude Code](https://claude.com/claude-code)