### PR TITLE
fix(#233): refuse hot reload of a symlinked runtime path (M2)

### DIFF
--- a/src/redin/bridge/hotreload.odin
+++ b/src/redin/bridge/hotreload.odin
@@ -109,7 +109,30 @@ hotreload_arm_retry :: proc(hr: ^Hot_Reload) {
 	hr.retry_at = time.tick_now()
 }
 
+// #233 M2: get_file_mtime lstat's the watched paths (won't follow a
+// symlink), but the reload itself runs `require("init")`, and Lua's module
+// loader follows symlinks unconditionally when it opens the file. An
+// attacker with write access to src/runtime/ could swap a watched .fnl for
+// a symlink to an arbitrary file and have hotreload load+execute the
+// target. Refuse the reload if any watched runtime path is a symlink; the
+// design intent (see #162 L1) is never to follow one. Returns the
+// offending path and ok=false on the first symlink found.
+hotreload_paths_symlink_free :: proc(paths: []string) -> (offending: string, ok: bool) {
+	for p in paths {
+		fi, err := os.lstat(p, context.temp_allocator)
+		if err != os.ERROR_NONE do continue // missing / unreadable: mtime poll already handles it
+		if fi.type == .Symlink {
+			return p, false
+		}
+	}
+	return "", true
+}
+
 hotreload_execute :: proc(b: ^Bridge) -> (ok: bool) {
+	if offending, safe := hotreload_paths_symlink_free(b.hot_reload.watch_paths[:]); !safe {
+		fmt.eprintfln("Hot reload refused: watched runtime path is a symlink: %s", offending)
+		return false
+	}
 	code := `
 		package.loaded["dataflow"] = nil
 		package.loaded["effect"]   = nil

--- a/src/redin/bridge/hotreload_symlink_test.odin
+++ b/src/redin/bridge/hotreload_symlink_test.odin
@@ -1,0 +1,50 @@
+package bridge
+
+// #233 M2: hotreload lstat's watched paths to detect changes, but the reload
+// itself runs `require("init")` and Lua's loader follows symlinks when it
+// opens the file. hotreload_paths_symlink_free is the guard that refuses to
+// reload when a watched runtime path has been swapped for a symlink. This
+// test exercises it against a real symlink on disk.
+
+import "core:fmt"
+import "core:os"
+import "core:strings"
+import "core:sys/linux"
+import "core:testing"
+
+@(test)
+test_hotreload_rejects_symlinked_path :: proc(t: ^testing.T) {
+	dir := "test_hotreload_symlink_tmp"
+	os.make_directory(dir)
+	defer os.remove_all(dir)
+
+	real := fmt.tprintf("%s/real.fnl", dir)
+	link := fmt.tprintf("%s/link.fnl", dir)
+
+	werr := os.write_entire_file(real, transmute([]u8)string("(local t {}) t"))
+	testing.expect(t, werr == os.ERROR_NONE, "wrote the regular watched file")
+
+	// A regular watched file is safe.
+	if _, ok := hotreload_paths_symlink_free([]string{real}); !ok {
+		testing.fail_now(t, "a regular watched file must be accepted")
+	}
+
+	// Create a symlink alongside it and confirm the guard refuses and names it.
+	target_c := strings.clone_to_cstring(real, context.temp_allocator)
+	link_c := strings.clone_to_cstring(link, context.temp_allocator)
+	if errno := linux.symlink(target_c, link_c); errno != .NONE {
+		testing.fail_now(t, "could not create test symlink")
+	}
+
+	offending, ok := hotreload_paths_symlink_free([]string{real, link})
+	testing.expect(t, !ok, "a symlinked watched path must be refused")
+	testing.expect_value(t, offending, link)
+}
+
+@(test)
+test_hotreload_symlink_free_ignores_missing :: proc(t: ^testing.T) {
+	// A missing path isn't a symlink; the mtime poll handles absence. The
+	// guard must not treat "unreadable" as "unsafe" (that would wedge reload).
+	_, ok := hotreload_paths_symlink_free([]string{"does/not/exist.fnl"})
+	testing.expect(t, ok, "missing watched path is not treated as a symlink")
+}


### PR DESCRIPTION
Closes part of #233 (finding **M2**, medium — requires local write access to the source tree).

## Problem

`get_file_mtime` correctly uses `os.lstat` so a symlink swap in `src/runtime/` is *observed* as a change rather than followed (#162 L1). But the reload it triggers runs `require("init")`, and Lua's module loader follows symlinks unconditionally when it opens the file. An attacker with write access to `src/runtime/` could replace a watched `.fnl` with a symlink to any `.fnl`/`.lua` and have hotreload load and execute the target.

## Fix

`hotreload_paths_symlink_free` lstat's every watched runtime path; `hotreload_execute` calls it first and refuses the reload (logging the offending path) if any is a symlink. A missing/unreadable path is *not* treated as unsafe — the mtime poll already handles absence — so a transient editor save can't wedge reload. Dev-only path (`check_hotreload` is `when !REDIN_DEV do return`).

## Verification

- Bridge unit tests: 134 pass (+2) — one creates a **real on-disk symlink** and asserts the guard refuses and names it; one confirms a missing path is accepted.
- **Live run**: a normal `touch` of a watched file still reloads (`Hot reload: runtime reloaded`); swapping a watched file for a symlink is refused (`Hot reload refused: watched runtime path is a symlink: …`) and the target is not loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)