### PR TITLE
fix(#233): reject font paths resolving outside the project dir (M4)

### DIFF
--- a/docs/reference/theme.md
+++ b/docs/reference/theme.md
@@ -56,7 +56,7 @@ Register custom fonts via a `:font-face` block in the theme. Each font name maps
 
 `:font-face` is not an aspect -- it's processed separately to load font files before the theme is applied. Font files are loaded via Raylib's `LoadFont`.
 
-Paths are validated before load: they must be relative (no leading `/`), contain no `..` segments, and no NUL bytes. Rejected paths are logged but don't abort the theme — the rest still applies. This matters because themes can come from `PUT /aspects` as well as Fennel code; the check keeps arbitrary filesystem paths out of the font loader regardless of source.
+Paths are validated before load: they must be relative (no leading `/`), contain no `..` segments, and no NUL bytes, and — when the file exists — must resolve (after following any symlinks) to a location inside the project's working directory. A symlink placed under the project that points outside it is rejected. Rejected paths are logged but don't abort the theme — the rest still applies. This matters because themes can come from `PUT /aspects` as well as Fennel code; the check keeps arbitrary filesystem paths out of the font loader regardless of source.
 
 ### Bundled fonts
 

--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -1755,6 +1755,35 @@ validate_font_path :: proc(path: string) -> bool {
 	return true
 }
 
+// font_path_escapes_cwd closes the gap validate_font_path can't (#233 M4):
+// the lexical `..` ban confines a font path to the cwd subtree only
+// textually, but a symlink placed inside that subtree ("assets/x.ttf" ->
+// /etc/shadow) still resolves out of it — and the theme, hence the font
+// path, can arrive from an authenticated `PUT /aspects`. Canonicalize the
+// path (os.get_absolute_path opens the file and reads its symlink-resolved
+// /proc/self/fd link) and require the real target to stay within the
+// working directory.
+//
+// Returns false — allow — when the file doesn't exist yet (open fails):
+// rl.LoadFont will simply fail to open it, exactly as before, and the
+// lexical guard already ran. Only an existing file whose real path escapes
+// cwd is rejected, so legitimate relative fonts under the project are
+// unaffected.
+font_path_escapes_cwd :: proc(path: string) -> bool {
+	real, err := os.get_absolute_path(path, context.temp_allocator)
+	if err != nil do return false // missing / unreadable — LoadFont fails on its own
+	cwd, cwd_err := os.get_working_directory(context.temp_allocator)
+	if cwd_err != nil do return false // can't determine cwd; don't block on it
+	if real == cwd do return true // resolves to the cwd directory itself — reject
+	if strings.has_prefix(real, cwd) {
+		rest := real[len(cwd):]
+		// Guard the path boundary so a sibling ("<cwd>2/x") isn't read as
+		// inside "<cwd>". A real subpath starts with the separator.
+		if len(rest) > 0 && rest[0] == '/' do return false
+	}
+	return true
+}
+
 load_font_faces :: proc(L: ^Lua_State, index: i32) {
 	lua_pushnil(L)
 	for lua_next(L, index) != 0 {
@@ -1774,6 +1803,11 @@ load_font_faces :: proc(L: ^Lua_State, index: i32) {
 					path := string(lua_tostring_raw(L, -1))
 					if !validate_font_path(path) {
 						fmt.eprintfln("Rejected font path (must be relative, no ..): %s", path)
+						lua_pop(L, 1)
+						continue
+					}
+					if font_path_escapes_cwd(path) {
+						fmt.eprintfln("Rejected font path (resolves outside project dir): %s", path)
 						lua_pop(L, 1)
 						continue
 					}

--- a/src/redin/bridge/font_path_escape_test.odin
+++ b/src/redin/bridge/font_path_escape_test.odin
@@ -1,0 +1,84 @@
+package bridge
+
+// #233 M4: the lexical validate_font_path confines a font path to the cwd
+// subtree only textually — a symlink inside that subtree can still resolve
+// out of it. font_path_escapes_cwd canonicalizes the path and rejects a real
+// target that leaves the working directory. These tests exercise it against
+// real files and symlinks on disk.
+
+import "core:fmt"
+import "core:os"
+import "core:strings"
+import "core:sys/linux"
+import "core:testing"
+
+@(test)
+test_font_path_inside_cwd_ok :: proc(t: ^testing.T) {
+	dir := "test_font_escape_tmp"
+	os.make_directory(dir)
+	defer os.remove_all(dir)
+
+	real := fmt.tprintf("%s/real.ttf", dir)
+	werr := os.write_entire_file(real, transmute([]u8)string("not-a-real-font"))
+	testing.expect(t, werr == os.ERROR_NONE, "wrote the in-tree font file")
+
+	// A real file under cwd does not escape.
+	testing.expect(t, !font_path_escapes_cwd(real), "in-tree font must be allowed")
+}
+
+@(test)
+test_font_path_missing_is_allowed :: proc(t: ^testing.T) {
+	// A non-existent path can't be canonicalized; LoadFont will just fail.
+	// The guard must not reject it (that would change existing behavior).
+	testing.expect(t, !font_path_escapes_cwd("test_font_escape_tmp/does-not-exist.ttf"))
+}
+
+@(test)
+test_font_path_symlink_escape_rejected :: proc(t: ^testing.T) {
+	dir := "test_font_escape_tmp2"
+	os.make_directory(dir)
+	defer os.remove_all(dir)
+
+	// An escape target that exists OUTSIDE the working directory.
+	tmpdir := os.get_env("TMPDIR", context.temp_allocator)
+	if tmpdir == "" do tmpdir = "/tmp"
+	target := fmt.tprintf("%s/redin_font_escape_target.ttf", tmpdir)
+	werr := os.write_entire_file(target, transmute([]u8)string("outside-cwd"))
+	testing.expect(t, werr == os.ERROR_NONE, "wrote the out-of-tree target")
+	defer os.remove(target)
+
+	// A symlink inside cwd pointing at it: lexically clean, but escapes.
+	link := fmt.tprintf("%s/escape.ttf", dir)
+	target_c := strings.clone_to_cstring(target, context.temp_allocator)
+	link_c := strings.clone_to_cstring(link, context.temp_allocator)
+	if errno := linux.symlink(target_c, link_c); errno != .NONE {
+		testing.fail_now(t, "could not create escaping symlink")
+	}
+
+	// The lexical guard passes it (no "..", relative), but the resolved-path
+	// guard must catch the escape.
+	testing.expect(t, validate_font_path(link), "symlink path is lexically clean")
+	testing.expect(t, font_path_escapes_cwd(link), "symlink escaping cwd must be rejected")
+}
+
+@(test)
+test_font_path_symlink_inside_ok :: proc(t: ^testing.T) {
+	dir := "test_font_escape_tmp3"
+	os.make_directory(dir)
+	defer os.remove_all(dir)
+
+	real := fmt.tprintf("%s/real.ttf", dir)
+	werr := os.write_entire_file(real, transmute([]u8)string("in-tree-target"))
+	testing.expect(t, werr == os.ERROR_NONE)
+
+	// A symlink that stays within cwd is fine.
+	cwd, _ := os.get_working_directory(context.temp_allocator)
+	abs_real := fmt.tprintf("%s/%s", cwd, real)
+	link := fmt.tprintf("%s/link.ttf", dir)
+	target_c := strings.clone_to_cstring(abs_real, context.temp_allocator)
+	link_c := strings.clone_to_cstring(link, context.temp_allocator)
+	if errno := linux.symlink(target_c, link_c); errno != .NONE {
+		testing.fail_now(t, "could not create in-tree symlink")
+	}
+	testing.expect(t, !font_path_escapes_cwd(link), "symlink resolving inside cwd is allowed")
+}


### PR DESCRIPTION
Closes part of #233 (finding **M4**, medium — info-disclosure / probe via the font loader).

## Problem

`validate_font_path` rejects `..`, absolute, backslash, and drive-letter paths, but the `..` ban only confines a font path to the cwd subtree *textually*. A symlink placed inside that subtree (`assets/x.ttf` → `/etc/shadow`) still resolves out of it. Because the theme — and hence the font path — can arrive from an authenticated `PUT /aspects`, an attacker chooses the path; `rl.LoadFont` then opens the target (an existence oracle, and the bytes are parsed as a font).

## Fix

`font_path_escapes_cwd` canonicalizes an existing path with `os.get_absolute_path` (opens the file and reads its symlink-resolved `/proc/self/fd` link) and requires the real target to stay within the working directory. `load_font_faces` calls it after the lexical guard.

Deliberately **non-breaking**: non-existent paths are still allowed (LoadFont fails on its own; the lexical guard already ran), so the documented "any relative path, no `..`" contract and its tests are preserved. Only an existing file whose *real* path escapes cwd is rejected.

## Verification

- Bridge unit tests: 136 pass (+4) — in-tree file allowed, symlink escaping cwd rejected, symlink staying inside cwd allowed, missing path allowed.
- `docs/reference/theme.md` font-face section updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)