### PR TITLE
fix(#233): reject duplicate Host/Authorization and Transfer-Encoding (L2, L3)

### DIFF
--- a/docs/reference/dev-server.md
+++ b/docs/reference/dev-server.md
@@ -22,7 +22,7 @@ On startup the server generates a random 256-bit token and writes it to `./.redi
 Authorization: Bearer <contents of .redin-token>
 ```
 
-The server also verifies the `Host` header matches `localhost:<port>` or `127.0.0.1:<port>` to blunt DNS-rebinding attacks. CORS preflight is not served — the endpoint is intended for local tools, not browsers. Missing token → `401`; bad Host → `403`; OPTIONS → `405`; malformed `Content-Length` (more than 12 digits) → `400 Bad Request`.
+The server also verifies the `Host` header matches `localhost:<port>` or `127.0.0.1:<port>` to blunt DNS-rebinding attacks. CORS preflight is not served — the endpoint is intended for local tools, not browsers. Missing token → `401`; bad Host → `403`; OPTIONS → `405`. A request is rejected with `400 Bad Request` when it is ambiguous or unsupported for framing: malformed `Content-Length` (more than 12 digits), a duplicated `Content-Length`, `Host`, or `Authorization` header, or any `Transfer-Encoding` header (only `Content-Length` framing is supported).
 
 If the server cannot write `.redin-token` or `.redin-port` at startup (read-only directory, etc.), it aborts startup and prints a clear stderr line. The dev server never runs without a token file in place.
 

--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -575,6 +575,23 @@ handle_one_connection :: proc(ds: ^Dev_Server, client: net.TCP_Socket, stack_buf
 					bad_request = true
 					break
 				}
+				// #233 L2: RFC 7230 §5.4 — more than one Host MUST be a 400;
+				// duplicate Authorization is likewise ambiguous. find_header_value
+				// / check_host_header / check_bearer_token only ever read the
+				// first, so a second occurrence could smuggle a different value
+				// past the rebinding / auth checks. Reject rather than guess.
+				if header_count(req_str[:header_end], "host") > 1 ||
+				   header_count(req_str[:header_end], "authorization") > 1 {
+					bad_request = true
+					break
+				}
+				// #233 L3: bodies are framed by Content-Length only. Transfer-
+				// Encoding (chunked) is never parsed; if present it's a TE/CL
+				// desync smuggling primitive behind a proxy. Reject any TE.
+				if header_count(req_str[:header_end], "transfer-encoding") > 0 {
+					bad_request = true
+					break
+				}
 				// Check Content-Length for body
 				cl := find_content_length(req_str[:header_end])
 				body_start := header_end + 4

--- a/src/redin/bridge/devserver_headers_test.odin
+++ b/src/redin/bridge/devserver_headers_test.odin
@@ -147,3 +147,37 @@ test_find_content_length_ignores_request_line :: proc(t: ^testing.T) {
 	headers := "GET /state/x?content-length:9 HTTP/1.1\r\nHost: localhost:8800\r\n"
 	testing.expect_value(t, find_content_length(headers), 0)
 }
+
+// --- #233 L2/L3: header_count backs the duplicate-Host/Authorization and
+// Transfer-Encoding rejections in the request parser. ---
+
+@(test)
+test_header_count_duplicate_host :: proc(t: ^testing.T) {
+	headers := "GET / HTTP/1.1\r\nHost: localhost:8800\r\nHost: evil.com:8800\r\n"
+	testing.expect_value(t, header_count(headers, "host"), 2)
+}
+
+@(test)
+test_header_count_single_host :: proc(t: ^testing.T) {
+	headers := "GET / HTTP/1.1\r\nHost: localhost:8800\r\n"
+	testing.expect_value(t, header_count(headers, "host"), 1)
+}
+
+@(test)
+test_header_count_duplicate_authorization :: proc(t: ^testing.T) {
+	headers := "GET / HTTP/1.1\r\nAuthorization: Bearer a\r\nAuthorization: Bearer b\r\n"
+	testing.expect_value(t, header_count(headers, "authorization"), 2)
+}
+
+@(test)
+test_header_count_transfer_encoding_present :: proc(t: ^testing.T) {
+	headers := "POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n"
+	testing.expect_value(t, header_count(headers, "transfer-encoding"), 1)
+}
+
+@(test)
+test_header_count_host_ignores_request_line :: proc(t: ^testing.T) {
+	// A "host:" inside the request-line URL is not a header line.
+	headers := "GET /x?host:1 HTTP/1.1\r\nHost: localhost:8800\r\n"
+	testing.expect_value(t, header_count(headers, "host"), 1)
+}


### PR DESCRIPTION
Closes part of #233 (findings **L2** and **L3** — dev-server request-parsing hardening). Also note: **L4** (agent `id` JSON escaping) is already resolved by the merged #232 (`agent_nodes_walker` uses `json_string` for id/mode/tag; `emit_agent_content` emits only an escaped `content` value).

## L2 — duplicate Host / Authorization (first-wins)

`find_header_value`, `check_host_header`, and `check_bearer_token` all return the *first* matching header, so `Host: localhost\r\nHost: evil.com` passes the rebinding defence and a second `Authorization` could smuggle a different token past the auth check. RFC 7230 §5.4 requires multiple `Host` to be `400`. The Content-Length duplicate guard (`header_count > 1`) is extended to `Host` and `Authorization`.

## L3 — Transfer-Encoding ignored, not rejected

Bodies are framed by `Content-Length` only; `Transfer-Encoding: chunked` was silently treated as `CL: 0`. Behind a proxy that honours it, that's a TE/CL desync smuggling primitive. Any `Transfer-Encoding` header now → `400`.

Both checks sit in the same header-complete block as the #217 M2 guard and short-circuit before dispatch.

## Verification

- Bridge unit tests: 137 pass (+5 `header_count` cases).
- **Live raw-socket test**: duplicate `Host`, duplicate `Authorization`, and `Transfer-Encoding: chunked` each return `400`; a normal request stays `200`.
- `docs/reference/dev-server.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)