### PR TITLE
fix(#233): bound view-tree parser numeric literals (L5)

### DIFF
--- a/src/redin/parser/view_tree_parser.odin
+++ b/src/redin/parser/view_tree_parser.odin
@@ -121,6 +121,14 @@ _read_keyword :: proc(p: ^_Parser) -> string {
 	return p.text[start:p.pos]
 }
 
+// #233 L5: an arbitrarily long integer literal in a .fnl file would overflow
+// f32 to +Inf, which then flows through f16(num_val) into layout and wedges
+// it. NUM_MAX is far beyond any real coordinate / size / colour literal;
+// digits past it are still consumed so the parser position stays correct,
+// but they don't grow the value, and the result is clamped so it can never
+// be infinite.
+_NUM_MAX :: f32(1e9)
+
 _read_number :: proc(p: ^_Parser) -> f32 {
 	neg: f32 = 1
 	if p.pos < len(p.text) && p.text[p.pos] == '-' {
@@ -132,7 +140,9 @@ _read_number :: proc(p: ^_Parser) -> f32 {
 	for p.pos < len(p.text) {
 		c := p.text[p.pos]
 		if c >= '0' && c <= '9' {
-			result = result * 10 + f32(c - '0')
+			if result < _NUM_MAX {
+				result = result * 10 + f32(c - '0')
+			}
 			p.pos += 1
 		} else {
 			break
@@ -155,6 +165,7 @@ _read_number :: proc(p: ^_Parser) -> f32 {
 		}
 	}
 
+	if result > _NUM_MAX do result = _NUM_MAX
 	return result * neg
 }
 

--- a/src/redin/parser/view_tree_parser_test.odin
+++ b/src/redin/parser/view_tree_parser_test.odin
@@ -223,3 +223,27 @@ test_parse_rejects_excessive_nesting :: proc(t: ^testing.T) {
 	if ok do _tree_node_destroy(&tree)
 	testing.expect(t, !ok, "1000-deep nesting must be rejected by MAX_NESTING guard")
 }
+
+// #233 L5: a very long numeric literal must not overflow f32 to +Inf.
+@(test)
+test_read_number_huge_is_finite :: proc(t: ^testing.T) {
+	// 40 nines — well past f32's ~3.4e38 range; naive accumulation overflows.
+	input := "9999999999999999999999999999999999999999"
+	p := _Parser{text = input, pos = 0}
+	got := _read_number(&p)
+	testing.expect(t, got <= _NUM_MAX, "huge literal is clamped to a finite ceiling")
+	testing.expect(t, got == got, "result is not NaN")          // NaN != NaN
+	testing.expect(t, got < 1e30, "result is not +Inf")         // Inf would exceed this
+	// The whole literal is consumed so the parser position stays correct.
+	testing.expect_value(t, p.pos, len(input))
+}
+
+@(test)
+test_read_number_normal_unaffected :: proc(t: ^testing.T) {
+	for tc in ([]struct{s: string, want: f32}{
+		{"0", 0}, {"42", 42}, {"1280", 1280}, {"-16", -16}, {"3.5", 3.5}, {"-2.25", -2.25},
+	}) {
+		p := _Parser{text = tc.s, pos = 0}
+		testing.expect_value(t, _read_number(&p), tc.want)
+	}
+}


### PR DESCRIPTION
Closes part of #233 (finding **L5**, low — defense-in-depth).

## Problem

`_read_number` (view_tree_parser.odin, shared by the theme parser too) accumulated integer digits into an `f32` with no digit cap. A very long numeric literal in a `.fnl` file overflows `f32` to `+Inf`, which then flows through `f16(num_val)` into layout and wedges the math.

## Fix

Guard the accumulation against a finite ceiling (`_NUM_MAX = 1e9`, far beyond any real coordinate/size/colour literal), keep consuming trailing digits so the parser position stays correct, and clamp the result so it can never be infinite.

## Verification

- Parser tests: 30 pass (+2) — a 40-digit literal stays finite (not `NaN`, not `+Inf`) with the whole literal consumed; ordinary integers, decimals, and negatives are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)