### PR TITLE
fix(#233): clear text selection when selection_start is stale too (L7)

### DIFF
--- a/src/redin/input/text_select.odin
+++ b/src/redin/input/text_select.odin
@@ -249,7 +249,13 @@ resolve_text_selection :: proc(paths: []types.Path, nodes: []types.Node) {
 		clear_text_selection()
 		return
 	}
-	if state.selection_end > len(text_node.content) {
+	// #233 L7: clear when *either* endpoint is stale, not just selection_end.
+	// If the node's content shrank since the selection was made, a
+	// selection_start left beyond len(content) is a latent OOB slice for any
+	// caller that indexes with it directly (today's readers clamp, but the
+	// invariant shouldn't depend on that).
+	if state.selection_start > len(text_node.content) ||
+	   state.selection_end > len(text_node.content) {
 		clear_text_selection()
 	}
 }

--- a/src/redin/input/text_select_test.odin
+++ b/src/redin/input/text_select_test.odin
@@ -45,3 +45,21 @@ test_resolve_clears_when_content_shrinks :: proc(t: ^testing.T) {
 	resolve_text_selection(paths, nodes)
 	testing.expect_value(t, state.selection_kind, Selection_Kind.None)
 }
+
+@(test)
+test_resolve_clears_when_only_start_stale :: proc(t: ^testing.T) {
+	// #233 L7: a backwards selection (anchor after focus) whose anchor
+	// (selection_start) is beyond shrunk content while selection_end still
+	// fits must also clear. The old code only checked selection_end.
+	sync.lock(&g_input_test_state_mutex)
+	defer sync.unlock(&g_input_test_state_mutex)
+	state_init()
+	defer state_destroy()
+
+	p := [1]u8{0x01}
+	paths := []types.Path{{value = p[:], length = 1}}
+	nodes := []types.Node{types.NodeText{content = "hi"}}   // len 2
+	set_text_selection([]u8{0x01}, 5, 1) // start=5 stale, end=1 in-bounds
+	resolve_text_selection(paths, nodes)
+	testing.expect_value(t, state.selection_kind, Selection_Kind.None)
+}


### PR DESCRIPTION
Closes part of #233 (finding **L7**, low — defense-in-depth).

## Problem

`resolve_text_selection` cleared a selection whose `selection_end` had fallen past the node's (possibly shrunk) content, but not one whose `selection_start` had. A backwards selection (anchor after focus) whose anchor sits beyond the shrunk content while the focus still fits leaves `selection_start > len(content)` — a latent OOB slice for any caller that indexes with `selection_start` directly. (Today's readers clamp, but the invariant shouldn't depend on that.)

## Fix

Guard both endpoints in the stale-content check.

## Verification

- Input tests: 33 pass (+1) — a start-stale / end-in-bounds selection now clears; existing end-stale and path-missing cases unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)