### PR TITLE
fix(#225): revalidate drag over/drop indices across re-flatten (L5)

### DIFF
--- a/src/redin/input/drag.odin
+++ b/src/redin/input/drag.odin
@@ -83,6 +83,31 @@ drag_matches :: proc(src, target: []string) -> bool {
 	return false
 }
 
+// #225 L5: is `node_idx` still a drag-over zone (resp. drop target) whose
+// tags overlap the drag payload's? Used to revalidate a stored
+// over_zone_idx / over_drop_idx at frame entry: the len-bounds clamp alone
+// doesn't catch a mid-drag re-flatten that reshuffles the tree to the same
+// size, leaving the index pointing at a *different* node. Validating against
+// the freshly-extracted listeners for this frame confirms the node still is
+// our zone/drop before any :leave fires against it.
+drag_over_idx_valid :: proc(node_idx: int, src_tags: []string, listeners: []types.Listener) -> bool {
+	for listener in listeners {
+		l, ok := listener.(types.DragOverListener)
+		if !ok do continue
+		if l.node_idx == node_idx && drag_matches(src_tags, l.tags) do return true
+	}
+	return false
+}
+
+dropable_idx_valid :: proc(node_idx: int, src_tags: []string, listeners: []types.Listener) -> bool {
+	for listener in listeners {
+		l, ok := listener.(types.DropListener)
+		if !ok do continue
+		if l.node_idx == node_idx && drag_matches(src_tags, l.tags) do return true
+	}
+	return false
+}
+
 // Deepest matching DropListener under `pt` whose tags overlap `src_tags`.
 // Deepest = highest node_idx (DFS-ordered nodes guarantee descendants > ancestors).
 deepest_dropable_match :: proc(
@@ -153,7 +178,9 @@ process_drag :: proc(
 			free_captured(s.captured)
 			drag = nil
 		case Drag_Active:
-			if s.over_zone_idx >= 0 && s.over_zone_idx < len(nodes) {
+			// #225 L5: only fire the cancel :leave if the stored zone index
+			// still resolves to a compatible drag-over zone this frame.
+			if s.over_zone_idx >= 0 && drag_over_idx_valid(s.over_zone_idx, s.src_tags, listeners) {
 				if ev := node_over_event(nodes[s.over_zone_idx]); len(ev) > 0 {
 					append(&dispatch, types.Dispatch_Event(types.Drag_Over_Event{
 						event_name = ev,
@@ -261,9 +288,17 @@ process_drag :: proc(
 			drag = nil
 			return dispatch
 		}
-		// Stale zone/drop indices from a previous frame's layout — clear before use.
-		if s.over_zone_idx >= len(nodes) do s.over_zone_idx = -1
-		if s.over_drop_idx >= len(nodes) do s.over_drop_idx = -1
+		// #225 L5: stale zone/drop indices from a previous frame's layout.
+		// A bounds clamp only catches a shrunk tree; a same-size re-flatten
+		// can leave the index pointing at a different node. Drop any stored
+		// index that no longer resolves to a compatible zone/drop for this
+		// drag, so no :leave fires against the wrong node below.
+		if s.over_zone_idx >= 0 && !drag_over_idx_valid(s.over_zone_idx, s.src_tags, listeners) {
+			s.over_zone_idx = -1
+		}
+		if s.over_drop_idx >= 0 && !dropable_idx_valid(s.over_drop_idx, s.src_tags, listeners) {
+			s.over_drop_idx = -1
+		}
 
 		// Hit-test compatible drop targets and zones.
 		new_zone := deepest_drag_over_match(s.src_tags, mouse, listeners, node_rects)

--- a/src/redin/input/drag_stale_idx_test.odin
+++ b/src/redin/input/drag_stale_idx_test.odin
@@ -1,0 +1,54 @@
+package input
+
+// #225 L5: a mid-drag re-flatten can leave over_zone_idx / over_drop_idx
+// pointing at a different node than the one entered. drag_over_idx_valid /
+// dropable_idx_valid revalidate a stored index against the current frame's
+// listeners (node identity + tag overlap) so no :leave fires against the
+// wrong node. These tests pin that predicate.
+
+import "core:testing"
+import "../types"
+
+@(test)
+test_drag_over_idx_valid_matches :: proc(t: ^testing.T) {
+	tags := []string{"row-drag"}
+	listeners := []types.Listener{
+		types.DragOverListener{node_idx = 4, tags = []string{"row-drag"}},
+	}
+	// Same index, overlapping tags → still our zone.
+	testing.expect(t, drag_over_idx_valid(4, tags, listeners))
+}
+
+@(test)
+test_drag_over_idx_valid_index_reused_by_other_zone :: proc(t: ^testing.T) {
+	// After a re-flatten, index 4 is now a drag-over zone with a
+	// non-overlapping tag set — not our zone; must be rejected.
+	tags := []string{"row-drag"}
+	listeners := []types.Listener{
+		types.DragOverListener{node_idx = 4, tags = []string{"palette"}},
+	}
+	testing.expect(t, !drag_over_idx_valid(4, tags, listeners))
+}
+
+@(test)
+test_drag_over_idx_valid_index_gone :: proc(t: ^testing.T) {
+	// The zone that was at index 4 no longer exists (shrunk / reshuffled
+	// tree): no DragOverListener carries that index.
+	tags := []string{"row-drag"}
+	listeners := []types.Listener{
+		types.DragOverListener{node_idx = 2, tags = []string{"row-drag"}},
+	}
+	testing.expect(t, !drag_over_idx_valid(4, tags, listeners))
+}
+
+@(test)
+test_dropable_idx_valid :: proc(t: ^testing.T) {
+	tags := []string{"row-drag"}
+	listeners := []types.Listener{
+		types.DropListener{node_idx = 7, tags = []string{"row-drag", "sword"}},
+		types.DropListener{node_idx = 8, tags = []string{"other"}},
+	}
+	testing.expect(t, dropable_idx_valid(7, tags, listeners), "overlapping tags at the index")
+	testing.expect(t, !dropable_idx_valid(8, tags, listeners), "non-overlapping tags")
+	testing.expect(t, !dropable_idx_valid(9, tags, listeners), "no listener at the index")
+}


### PR DESCRIPTION
Closes part of #225 (finding **L5**, low — state-machine correctness, reachable from the dev server).

## Problem

While a drag is active, `over_zone_idx` / `over_drop_idx` were only clamped against `len(nodes)` at frame entry. A mid-drag re-flatten to the same (or larger) size but different shape — easy to trigger via `POST /events` while a drag is held — leaves the stored index pointing at a **different** node. A subsequent `:leave` then fires against the wrong node (wrong `event_name` / `from_ref`), or a phantom `:drag-over` reaches a consumer whose tags no longer overlap the payload.

## Fix

Replace the bounds-only clamp with `drag_over_idx_valid` / `dropable_idx_valid`, which confirm the stored index still resolves to a compatible zone/drop against the freshly-extracted listeners for the current frame (node identity + tag overlap). An index that no longer matches is dropped without firing a leave. The ESC-cancel path's leave is guarded the same way.

## Verification

- Input tests: 36 pass (+4 predicate cases — same-index match, index reused by a non-overlapping zone, index gone, dropable overlap).
- Drag UI suite (12) still passes, including `drag-over-leave-fires` and `drag-esc-cancels`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)