### PR TITLE
fix(#225): reclaim intrinsic-height cache after a tree spike (L6)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,8 @@ jobs:
       - name: Run Odin canvas tests
         run: odin test src/redin/canvas -collection:lib=lib -collection:luajit=vendor/luajit
 
+      # ODIN_TEST_THREADS=1: the layout-cache tests mutate the package-global
+      # intrinsic_cache, so they must not run in parallel with each other.
       - name: Run Odin text tests
         run: odin test src/redin/text -collection:lib=lib -collection:luajit=vendor/luajit -define:ODIN_TEST_THREADS=1
 

--- a/src/redin/text/layout.odin
+++ b/src/redin/text/layout.odin
@@ -25,8 +25,22 @@ Intrinsic_Entry :: struct {
 @(private)
 intrinsic_cache: [dynamic]Intrinsic_Entry
 
-// Grow the cache to at least `n` entries. New slots are initialized
-// as unpopulated. Existing entries are preserved (cross-frame hits).
+// Slack kept when reclaiming the cache after the tree shrinks (#225 L6).
+// We only give the backing array back to the allocator when it is more than
+// this many entries larger than the current need, so normal per-frame node-
+// count fluctuations don't thrash realloc.
+@(private)
+CACHE_SHRINK_SLACK :: 512
+
+// Grow the cache to at least `n` entries. New slots are initialized as
+// unpopulated. Existing entries are preserved (cross-frame hits).
+//
+// #225 L6: the cache previously only ever grew to the peak node count and
+// never shrank, so a transient large tree (e.g. a POST /events that briefly
+// lays out a 10k-node view before reverting) pinned that backing array for
+// the process lifetime. When the tree shrinks well below the high-water
+// mark, free any line slices still held past the new end and hand the
+// backing capacity back.
 ensure_intrinsic_cache :: proc(n: int) {
 	old_len := len(intrinsic_cache)
 	if n > old_len {
@@ -34,6 +48,14 @@ ensure_intrinsic_cache :: proc(n: int) {
 		for i in old_len ..< n {
 			intrinsic_cache[i] = Intrinsic_Entry{width = -1}
 		}
+	} else if old_len - n > CACHE_SHRINK_SLACK {
+		for i in n ..< old_len {
+			if intrinsic_cache[i].lines_valid {
+				delete(intrinsic_cache[i].lines)
+			}
+		}
+		resize(&intrinsic_cache, n)
+		shrink(&intrinsic_cache)
 	}
 }
 

--- a/src/redin/text/layout_cache_test.odin
+++ b/src/redin/text/layout_cache_test.odin
@@ -1,0 +1,56 @@
+package text
+
+// #225 L6: the intrinsic-height cache grew to the peak node count and never
+// shrank, pinning that backing array for the process lifetime after a
+// transient large tree. ensure_intrinsic_cache now reclaims the backing
+// capacity once the tree shrinks well past the slack, without thrashing on
+// small fluctuations. These tests mutate the package-global cache, so the
+// text package is run with -define:ODIN_TEST_THREADS=1 (see test.yml).
+
+import "core:testing"
+
+@(test)
+test_intrinsic_cache_shrinks_after_spike :: proc(t: ^testing.T) {
+	destroy_intrinsic_cache() // clean slate
+	defer destroy_intrinsic_cache()
+
+	ensure_intrinsic_cache(10_000)
+	testing.expect_value(t, len(intrinsic_cache), 10_000)
+
+	// A tiny tree afterwards is far past the slack, so the backing array is
+	// reclaimed rather than pinned at the 10k high-water mark.
+	ensure_intrinsic_cache(100)
+	testing.expect_value(t, len(intrinsic_cache), 100)
+	testing.expect(t, cap(intrinsic_cache) <= 100 + CACHE_SHRINK_SLACK,
+		"backing capacity should be reclaimed after a large spike")
+}
+
+@(test)
+test_intrinsic_cache_no_thrash_within_slack :: proc(t: ^testing.T) {
+	destroy_intrinsic_cache()
+	defer destroy_intrinsic_cache()
+
+	ensure_intrinsic_cache(1000)
+	cap_before := cap(intrinsic_cache)
+
+	// A shrink within CACHE_SHRINK_SLACK must not realloc or resize — the
+	// spare slots are kept to absorb ordinary per-frame fluctuation.
+	ensure_intrinsic_cache(1000 - (CACHE_SHRINK_SLACK - 1))
+	testing.expect_value(t, len(intrinsic_cache), 1000)
+	testing.expect_value(t, cap(intrinsic_cache), cap_before)
+}
+
+@(test)
+test_intrinsic_cache_grows :: proc(t: ^testing.T) {
+	destroy_intrinsic_cache()
+	defer destroy_intrinsic_cache()
+
+	ensure_intrinsic_cache(50)
+	testing.expect_value(t, len(intrinsic_cache), 50)
+	// New slots start unpopulated (sentinel width < 0).
+	_, ok := lookup_intrinsic(10, 200)
+	testing.expect(t, !ok, "fresh slot must be a cache miss")
+
+	ensure_intrinsic_cache(75)
+	testing.expect_value(t, len(intrinsic_cache), 75)
+}


### PR DESCRIPTION
Closes part of #225 (finding **L6**, low — memory amplification).

## Problem

`intrinsic_cache` (indexed by node idx) only ever grew to the peak node count and never shrank. A transient large tree — e.g. a `POST /events` that briefly lays out a many-node view before reverting — pinned that backing array for the process lifetime.

## Fix

`ensure_intrinsic_cache` now, when the tree shrinks more than `CACHE_SHRINK_SLACK` (512) entries below the high-water mark, frees any line slices still held past the new end and hands the backing capacity back (`resize` + `shrink`). The slack keeps ordinary per-frame node-count fluctuation from thrashing realloc. Growth and cross-frame hits are unchanged.

## Verification

- Adds the text package's first unit tests (grow, shrink-after-spike, no-thrash-within-slack); wires `odin test src/redin/text` into CI (`-define:ODIN_TEST_THREADS=1`, since the tests mutate the package-global cache) and the maintenance skill's list. 3 tests pass.
- **Live tracking-allocator run**: toggling between 3000 text nodes and 1, four times, shuts down leak-free with no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)