### PR TITLE
fix(#233): make click→cursor mapping O(n) instead of O(n²) (L6)

### DIFF
--- a/.claude/skills/redin-maintenance/SKILL.md
+++ b/.claude/skills/redin-maintenance/SKILL.md
@@ -36,6 +36,7 @@ odin test src/redin/profile  -collection:lib=lib -collection:luajit=vendor/luaji
 odin test src/redin/input    -collection:lib=lib -collection:luajit=vendor/luajit -define:ODIN_TEST_THREADS=1
 odin test src/redin/bridge   -collection:lib=lib -collection:luajit=vendor/luajit
 odin test src/redin/canvas   -collection:lib=lib -collection:luajit=vendor/luajit
+odin test src/redin/text     -collection:lib=lib -collection:luajit=vendor/luajit -define:ODIN_TEST_THREADS=1
 ```
 
 When you add a new `src/redin/<pkg>/*_test.odin`, add a matching step to `.github/workflows/test.yml` so the suite stays visible in CI. The `input` package needs `-define:ODIN_TEST_THREADS=1` until #118 lands; once it does, drop the flag here and in the workflow.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Run Odin canvas tests
         run: odin test src/redin/canvas -collection:lib=lib -collection:luajit=vendor/luajit
 
+      - name: Run Odin text tests
+        run: odin test src/redin/text -collection:lib=lib -collection:luajit=vendor/luajit -define:ODIN_TEST_THREADS=1
+
       - name: Build redin
         run: |
           mkdir -p build

--- a/src/redin/input/edit.odin
+++ b/src/redin/input/edit.odin
@@ -282,25 +282,6 @@ paste :: proc() {
 
 // --- Click to position ---
 
-click_to_cursor :: proc(text: []u8, click_x: f32, font_obj: rl.Font, font_size: f32, spacing: f32) -> int {
-	if len(text) == 0 do return 0
-	best_pos := 0
-	best_dist: f32 = abs(click_x)
-	pos := 0
-	for pos < len(text) {
-		_, size := utf8.decode_rune(text[pos:])
-		pos += size
-		cstr := strings.clone_to_cstring(string(text[:pos]), context.temp_allocator)
-		measured := rl.MeasureTextEx(font_obj, cstr, font_size, spacing)
-		dist := abs(click_x - measured.x)
-		if dist < best_dist {
-			best_dist = dist
-			best_pos = pos
-		}
-	}
-	return best_pos
-}
-
 // --- Line-aware movement (requires layout lines) ---
 
 // Move cursor up one visual line, preserving X position.
@@ -365,24 +346,10 @@ move_end_line :: proc(lines: []text_pkg.Text_Line, shift: bool) {
 	}
 }
 
-// Find byte offset in a line closest to a given X pixel position.
+// Find byte offset in a line closest to a given X pixel position. Delegates
+// to the O(n) text.offset_at_x (was O(n²) — issue #233 L6).
 x_to_cursor_in_line :: proc(text_str: string, line: text_pkg.Text_Line, target_x: f32, font_obj: rl.Font, font_size: f32, sp: f32) -> int {
-	if line.start >= line.end do return line.start
-	best_pos := line.start
-	best_dist := abs(target_x)
-
-	pos := line.start
-	for pos < line.end {
-		_, size := utf8.decode_rune(transmute([]u8)text_str[pos:])
-		pos += size
-		w := text_pkg.measure_range(text_str, line.start, pos, font_obj, font_size, sp)
-		dist := abs(target_x - w)
-		if dist < best_dist {
-			best_dist = dist
-			best_pos = pos
-		}
-	}
-	return best_pos
+	return text_pkg.offset_at_x(text_str, line.start, line.end, target_x, font_obj, font_size, sp)
 }
 
 // --- Dynamic array helper ---

--- a/src/redin/text/layout.odin
+++ b/src/redin/text/layout.odin
@@ -242,6 +242,50 @@ cursor_to_line :: proc(lines: []Text_Line, cursor: int) -> (line_idx: int, col_o
 	return len(lines) - 1, 0
 }
 
+// Map a target x (pixels, relative to the substring's start) to the closest
+// codepoint boundary in text[start:end]. O(n): accumulates one glyph advance
+// per character the same way compute_lines does (scale by font_size/baseSize,
+// spacing between glyphs), instead of remeasuring the growing prefix via
+// MeasureTextEx on every character — which made the cursor mappings O(n²) and
+// turned a click on a very long line into seconds of CPU (issue #233 L6).
+// Using the same advance source as wrapping also keeps cursor placement
+// consistent with the computed line widths.
+offset_at_x :: proc(
+	text: string,
+	start, end: int,
+	target_x: f32,
+	font_obj: rl.Font,
+	font_size: f32,
+	spacing: f32,
+) -> int {
+	if start >= end do return start
+
+	scale: f32 = 1
+	if font_obj.baseSize > 0 do scale = font_size / f32(font_obj.baseSize)
+
+	best_pos := start
+	best_dist := abs(target_x) // distance at the start (width 0)
+	current_px: f32 = 0
+	char_count := 0
+
+	pos := start
+	for pos < end {
+		r, size := utf8.decode_rune(transmute([]u8)text[pos:])
+		glyph_px := glyph_advance_raw(font_obj, r) * scale
+		if char_count > 0 do current_px += spacing
+		current_px += glyph_px
+		pos += size
+		char_count += 1
+
+		dist := abs(target_x - current_px)
+		if dist < best_dist {
+			best_dist = dist
+			best_pos = pos
+		}
+	}
+	return best_pos
+}
+
 // Map a click position (relative to content area top-left) to a byte offset.
 point_to_cursor :: proc(
 	lines: []Text_Line,
@@ -263,25 +307,8 @@ point_to_cursor :: proc(
 	if line_idx >= len(lines) do line_idx = len(lines) - 1
 
 	line := lines[line_idx]
-	if line.start >= line.end do return line.start
-
 	adjusted_x := x + scroll_x
-	best_pos := line.start
-	best_dist := abs(adjusted_x)
-
-	pos := line.start
-	for pos < line.end {
-		_, size := utf8.decode_rune(transmute([]u8)text[pos:])
-		pos += size
-		w := measure_range(text, line.start, pos, font_obj, font_size, spacing)
-		dist := abs(adjusted_x - w)
-		if dist < best_dist {
-			best_dist = dist
-			best_pos = pos
-		}
-	}
-
-	return best_pos
+	return offset_at_x(text, line.start, line.end, adjusted_x, font_obj, font_size, spacing)
 }
 
 // Compute line height from font size. `ratio` is the theme line-height

--- a/src/redin/text/offset_at_x_test.odin
+++ b/src/redin/text/offset_at_x_test.odin
@@ -1,0 +1,51 @@
+package text
+
+// #233 L6: offset_at_x replaces the O(n²) prefix-remeasure loops in
+// point_to_cursor / x_to_cursor_in_line with an O(n) running-width scan.
+// A raylib Font isn't available in a headless unit test (no GPU / font
+// atlas), so these tests pin the structural invariants that hold for any
+// font: a target left of the start maps to start, a huge target maps to the
+// end, results are codepoint-aligned, and a million-char line returns
+// promptly (would hang under the old O(n²) behaviour).
+
+import "core:strings"
+import "core:testing"
+import "core:unicode/utf8"
+
+@(test)
+test_offset_at_x_empty_range :: proc(t: ^testing.T) {
+	// start >= end returns start without touching the font.
+	testing.expect_value(t, offset_at_x("hello", 3, 3, 100, {}, 16, 0), 3)
+	testing.expect_value(t, offset_at_x("hello", 4, 2, 100, {}, 16, 0), 4)
+}
+
+@(test)
+test_offset_at_x_target_before_start :: proc(t: ^testing.T) {
+	// A negative / zero target is closest to the start (width 0). With a nil
+	// font every glyph advance is 0, so all widths are 0 and best stays at
+	// start.
+	testing.expect_value(t, offset_at_x("hello world", 0, 11, -50, {}, 16, 0), 0)
+}
+
+@(test)
+test_offset_at_x_is_codepoint_aligned :: proc(t: ^testing.T) {
+	// Multi-byte content: any returned offset must land on a rune boundary,
+	// never inside a codepoint.
+	s := "héllo wörld"        // é and ö are 2 bytes each
+	got := offset_at_x(s, 0, len(s), 1e9, {}, 16, 0)
+	// A huge target with a zero-advance font still returns the start (all
+	// widths 0 → start is closest); the key invariant is boundary alignment.
+	testing.expect(t, utf8.rune_start(s[got]) if got < len(s) else true,
+		"offset must be on a codepoint boundary")
+	testing.expect(t, got >= 0 && got <= len(s), "offset in range")
+}
+
+@(test)
+test_offset_at_x_large_line_returns :: proc(t: ^testing.T) {
+	// The old implementation remeasured the growing prefix each step, so this
+	// was ~10^12 glyph ops. O(n) completes instantly. Reaching the assertion
+	// at all is the test.
+	big := strings.repeat("a", 1_000_000, context.temp_allocator)
+	got := offset_at_x(big, 0, len(big), 500, {}, 16, 0)
+	testing.expect(t, got >= 0 && got <= len(big), "offset in range for a huge line")
+}


### PR DESCRIPTION
Closes part of #233 (finding **L6**, low — CPU/DoS).

## Problem

`point_to_cursor` and `x_to_cursor_in_line` mapped a click x to a byte offset by looping rune-by-rune and, at each step, remeasuring the growing prefix from the line start via `MeasureTextEx` (itself O(prefix)). That's **O(n²)** per click — a hostile app pushing a 10⁶-char string into an input turned every click into seconds of CPU plus a large temp-arena burn.

## Fix

Add `text.offset_at_x` — an **O(n)** running-width scan using `glyph_advance_raw`, the same advance source `compute_lines` already uses for wrapping (so cursor placement now matches the computed line widths). Both `point_to_cursor` and `x_to_cursor_in_line` route through it. `click_to_cursor` — the third O(n²) copy of this loop, with no callers anywhere — is deleted.

The text package's first tests land here, so `odin test src/redin/text` is wired into CI (`-define:ODIN_TEST_THREADS=1`) and the maintenance skill.

## Verification

- Text tests (4): empty range, target-before-start, codepoint alignment, and a **1,000,000-char line that returns instantly** (would hang under O(n²)).
- Input (32) and the **text_select / input / multiline UI suites** all pass unchanged — behavioural parity.

> Note: overlaps with #244 on the one-line `Run Odin text tests` CI step and the maintenance-skill list entry (both add the text package to CI); trivial reconcile at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)