### PR TITLE
fix(#225): NUL-safe string reads in dev-server handlers (L2)

### DIFF
--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -1162,7 +1162,7 @@ frame_value_to_json :: proc(
 	is_node := lua_isstring(L, -1)
 	tag := ""
 	if is_node {
-		tag = string(lua_tostring_raw(L, -1))
+		tag = lua_tostring_str(L, -1)
 		if len(tag) == 0 do is_node = false
 	}
 	lua_pop(L, 1)
@@ -1251,7 +1251,7 @@ agent_nodes_walker :: proc(b: ^strings.Builder, L: ^Lua_State, index: i32, first
 	is_node := lua_isstring(L, -1)
 	tag := ""
 	if is_node {
-		tag = string(lua_tostring_raw(L, -1))
+		tag = lua_tostring_str(L, -1)
 		if len(tag) == 0 do is_node = false
 	}
 	lua_pop(L, 1)
@@ -1265,7 +1265,7 @@ agent_nodes_walker :: proc(b: ^strings.Builder, L: ^Lua_State, index: i32, first
 		lua_getfield(L, attrs_idx, "agent")
 		mode := ""
 		if lua_isstring(L, -1) {
-			s := string(lua_tostring_raw(L, -1))
+			s := lua_tostring_str(L, -1)
 			if s == "read" || s == ":read" do mode = "read"
 			if s == "edit" || s == ":edit" do mode = "edit"
 		}
@@ -1274,7 +1274,7 @@ agent_nodes_walker :: proc(b: ^strings.Builder, L: ^Lua_State, index: i32, first
 		lua_getfield(L, attrs_idx, "id")
 		id := ""
 		if lua_isstring(L, -1) {
-			id = string(lua_tostring_raw(L, -1))
+			id = lua_tostring_str(L, -1)
 		}
 		lua_pop(L, 1)
 		if len(mode) > 0 && len(id) > 0 && tag != "canvas" {
@@ -1344,7 +1344,7 @@ agent_find_by_id :: proc(L: ^Lua_State, index: i32, target_id: string) -> bool {
 		if lua_istable(L, -1) {
 			lua_getfield(L, -1, "id")
 			id := ""
-			if lua_isstring(L, -1) do id = string(lua_tostring_raw(L, -1))
+			if lua_isstring(L, -1) do id = lua_tostring_str(L, -1)
 			lua_pop(L, 1)
 			lua_pop(L, 1) // attrs
 			if id == target_id {
@@ -1380,7 +1380,7 @@ agent_node_attr_string :: proc(L: ^Lua_State, attr: cstring) -> string {
 	lua_getfield(L, -1, attr)
 	defer lua_pop(L, 1)
 	if !lua_isstring(L, -1) do return ""
-	return strings.clone(string(lua_tostring_raw(L, -1)), context.temp_allocator)
+	return strings.clone(lua_tostring_str(L, -1), context.temp_allocator)
 }
 
 agent_node_tag :: proc(L: ^Lua_State) -> string {
@@ -1388,7 +1388,7 @@ agent_node_tag :: proc(L: ^Lua_State) -> string {
 	lua_rawgeti(L, -1, 1)
 	defer lua_pop(L, 1)
 	if !lua_isstring(L, -1) do return ""
-	return strings.clone(string(lua_tostring_raw(L, -1)), context.temp_allocator)
+	return strings.clone(lua_tostring_str(L, -1), context.temp_allocator)
 }
 
 // Emits {"content": ...} JSON for the node at -1 based on its tag.
@@ -1417,7 +1417,7 @@ emit_agent_content :: proc(b: ^strings.Builder, L: ^Lua_State, tag: string) {
 		// Default: leaf-text-like (text, button). Content is slot [3].
 		lua_rawgeti(L, -1, 3)
 		val := ""
-		if lua_isstring(L, -1) do val = string(lua_tostring_raw(L, -1))
+		if lua_isstring(L, -1) do val = lua_tostring_str(L, -1)
 		lua_pop(L, 1)
 		json_string(b, val)
 	}
@@ -2004,7 +2004,7 @@ read_mouse_button :: proc(L: ^Lua_State) -> (rl.MouseButton, bool) {
 	lua_getfield(L, -1, "button")
 	defer lua_pop(L, 1)
 	if !lua_isstring(L, -1) do return .LEFT, false
-	s := string(lua_tostring_raw(L, -1))
+	s := lua_tostring_str(L, -1)
 	switch s {
 	case "left":   return .LEFT,   true
 	case "right":  return .RIGHT,  true
@@ -2221,7 +2221,7 @@ handle_post_input_key :: proc(ds: ^Dev_Server, ch: ^Response_Channel, body: stri
 	}
 	lua_getfield(L, -1, "key")
 	key_str := ""
-	if lua_isstring(L, -1) do key_str = string(lua_tostring_raw(L, -1))
+	if lua_isstring(L, -1) do key_str = lua_tostring_str(L, -1)
 	lua_pop(L, 1)
 	key, ok := key_string_to_raylib(key_str)
 	if !ok {

--- a/src/redin/bridge/lua_api.odin
+++ b/src/redin/bridge/lua_api.odin
@@ -86,6 +86,19 @@ lua_tostring_raw :: #force_inline proc "contextless" (L: ^Lua_State, index: i32)
 	return lua_tolstring(L, index, nil)
 }
 
+// Read a Lua string with its explicit length, so embedded NULs are preserved.
+// `string(lua_tostring_raw(...))` is strlen-based and truncates at the first
+// NUL; Lua strings carry a length and may legitimately contain NULs. Prefer
+// this for any value that round-trips to a caller (dev-server JSON, agent
+// content) — see #218 and #225 L2. The returned slice borrows Lua's buffer;
+// clone it if it must outlive the current stack value.
+lua_tostring_str :: #force_inline proc "contextless" (L: ^Lua_State, index: i32) -> string {
+	n: uint
+	p := lua_tolstring(L, index, &n)
+	if p == nil do return ""
+	return string(([^]u8)(p)[:n])
+}
+
 lua_getglobal :: #force_inline proc "contextless" (L: ^Lua_State, name: cstring) {
 	lua_getfield(L, LUA_GLOBALSINDEX, name)
 }

--- a/src/redin/bridge/lua_tostring_str_test.odin
+++ b/src/redin/bridge/lua_tostring_str_test.odin
@@ -1,0 +1,54 @@
+package bridge
+
+import "core:testing"
+
+// #225 L2: ten dev-server handlers read Lua strings via
+// `string(lua_tostring_raw(...))`, which is strlen-based and truncates at the
+// first NUL — so an agent-edit value or a mouse-button / key name containing a
+// NUL round-tripped or matched incorrectly. They now use lua_tostring_str,
+// which reads the length-carrying value. These tests pin that helper against a
+// string with an embedded NUL and confirm the old read really did truncate.
+
+@(test)
+test_lua_tostring_str_preserves_embedded_nul :: proc(t: ^testing.T) {
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	// "ab" + NUL + "cd" — 5 bytes. strlen stops at index 2, yielding "ab".
+	buf := [5]u8{'a', 'b', 0, 'c', 'd'}
+	lua_pushlstring(L, cstring(raw_data(buf[:])), 5)
+	idx := lua_gettop(L)
+
+	got := lua_tostring_str(L, idx)
+	testing.expect_value(t, len(got), 5)
+	testing.expect(t, got == "ab\x00cd", "full byte range must survive the NUL")
+
+	// The old strlen-based read truncates at the NUL — this is the bug the
+	// helper fixes, asserted so the two paths can't silently converge.
+	truncated := string(lua_tostring_raw(L, idx))
+	testing.expect_value(t, len(truncated), 2)
+	testing.expect(t, truncated == "ab", "strlen-based read stops at the NUL")
+}
+
+@(test)
+test_lua_tostring_str_plain :: proc(t: ^testing.T) {
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	lua_pushlstring(L, "hello", 5)
+	got := lua_tostring_str(L, lua_gettop(L))
+	testing.expect(t, got == "hello", "plain string reads unchanged")
+}
+
+@(test)
+test_lua_tostring_str_empty :: proc(t: ^testing.T) {
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	lua_pushlstring(L, "", 0)
+	got := lua_tostring_str(L, lua_gettop(L))
+	testing.expect_value(t, len(got), 0)
+}


### PR DESCRIPTION
Closes part of #225 (finding **L2**, low — data integrity).

## Problem

Ten dev-server handlers read Lua strings via `string(lua_tostring_raw(...))`, which is strlen-based and truncates at the first NUL. Lua strings carry an explicit length and may contain NULs; the #218 length-carrying migration should have covered these but missed them. Effects: an agent-edit value containing a NUL round-trips through PUT→GET as only the pre-NUL prefix; a mouse-button name `left\0x` matches `.LEFT`; a key name or selection string truncates.

## Fix

Add a package-visible `lua_tostring_str` (length-carrying read via `lua_tolstring`) next to `lua_tostring_raw`, and route all ten sites — agent node tag/id/mode, agent content value/tag, `/input/mouse` button name, `/input/key` key name — through it (single `replace_all` of the identical `string(lua_tostring_raw(L, -1))` form; the error-log-only read stays a `cstring`).

## Verification

- Bridge unit tests: 135 pass (+3) — `lua_tostring_str` preserves a 5-byte `"ab\0cd"` while `lua_tostring_raw` truncates it to `"ab"`, plus plain/empty cases (deterministic, in-CI).
- The agent PUT/GET round-trip is additionally exercised end-to-end by CI's **test-agent** job (`test_agent.bb`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)