### PR TITLE
chore(#233): record and CI-assert vendored LuaJIT/Fennel provenance (M3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,15 @@ jobs:
             exit 1
           }
 
+      # #233 M3: LuaJIT (linked into the binary) and Fennel (byte-shipped in
+      # the tarball) are vendored blobs with no submodule pin. Assert their
+      # sha256 before packaging so a tampered blob can't be published. Bump
+      # together with vendor/*/BUILD.md.
+      - name: Verify vendored blob hashes
+        run: |
+          echo "815b62f89420861c76b6ddd48b9efcff93248c10df4688cda18f85cac9e45f3b  vendor/luajit/lib/libluajit-5.1.a" | sha256sum -c -
+          echo "420b3e4771be263066c220aa042f02457ce5848e493ddf463cff4eca76ef9ba1  vendor/fennel/fennel.lua" | sha256sum -c -
+
       # Validate the workflow input before using it anywhere. Without this,
       # a maintainer typo like `v1.0.0; rm -rf /` flows verbatim into the
       # release name and tag (#136 L2). The trigger is workflow_dispatch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,15 @@ jobs:
             exit 1
           }
 
+      # #233 M3: LuaJIT and Fennel are vendored binary/opaque blobs with no
+      # submodule pin. Assert their sha256 so an unreviewed swap (e.g. a
+      # backdoored libluajit-5.1.a) fails CI instead of merging as an opaque
+      # diff. Bump these together with vendor/*/BUILD.md when rolling forward.
+      - name: Verify vendored blob hashes
+        run: |
+          echo "815b62f89420861c76b6ddd48b9efcff93248c10df4688cda18f85cac9e45f3b  vendor/luajit/lib/libluajit-5.1.a" | sha256sum -c -
+          echo "420b3e4771be263066c220aa042f02457ce5848e493ddf463cff4eca76ef9ba1  vendor/fennel/fennel.lua" | sha256sum -c -
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -105,6 +114,15 @@ jobs:
             echo "::error::odin-http submodule SHA mismatch (got $actual, expected $expected)"
             exit 1
           }
+
+      # #233 M3: LuaJIT and Fennel are vendored binary/opaque blobs with no
+      # submodule pin. Assert their sha256 so an unreviewed swap (e.g. a
+      # backdoored libluajit-5.1.a) fails CI instead of merging as an opaque
+      # diff. Bump these together with vendor/*/BUILD.md when rolling forward.
+      - name: Verify vendored blob hashes
+        run: |
+          echo "815b62f89420861c76b6ddd48b9efcff93248c10df4688cda18f85cac9e45f3b  vendor/luajit/lib/libluajit-5.1.a" | sha256sum -c -
+          echo "420b3e4771be263066c220aa042f02457ce5848e493ddf463cff4eca76ef9ba1  vendor/fennel/fennel.lua" | sha256sum -c -
 
       - name: Install system dependencies
         run: |

--- a/vendor/fennel/BUILD.md
+++ b/vendor/fennel/BUILD.md
@@ -1,0 +1,33 @@
+# Vendored Fennel
+
+`fennel.lua` is the single-file Fennel compiler, byte-shipped in every redin
+release tarball and loaded at startup (see `load_fennel` in
+`src/redin/bridge/bridge.odin`). It is copied verbatim from an upstream
+release, so its provenance is recorded here and its hash is asserted in CI.
+
+| Field | Value |
+|-------|-------|
+| Upstream | https://fennel-lang.org / https://git.sr.ht/~technomancy/fennel |
+| Version | `1.5.1` (see `version = "1.5.1"` in `fennel.lua`) |
+| License | MIT |
+| File | `fennel.lua` |
+| sha256 | `420b3e4771be263066c220aa042f02457ce5848e493ddf463cff4eca76ef9ba1` |
+
+The version can be recovered from the file itself:
+
+```bash
+grep -m1 'version = "' vendor/fennel/fennel.lua
+```
+
+## Updating
+
+Download the single-file build for the desired release and replace the file:
+
+```bash
+curl -fsSLo vendor/fennel/fennel.lua https://fennel-lang.org/downloads/fennel-<version>
+```
+
+Then update **both** the `Version` / `sha256` above **and** the expected hash
+in `.github/workflows/test.yml` (the "Verify vendored blob hashes" step) in
+the same commit, so an unreviewed replacement of this shipped file can't pass
+CI. See #233 M3.

--- a/vendor/luajit/BUILD.md
+++ b/vendor/luajit/BUILD.md
@@ -1,0 +1,38 @@
+# Vendored LuaJIT
+
+`lib/libluajit-5.1.a` is a prebuilt static archive of the LuaJIT C library,
+statically linked into every redin binary (see `foreign import luajit` in
+`src/redin/bridge/lua_api.odin`). It is **not** built from source in this
+repo, so its provenance is recorded here and its hash is asserted in CI.
+
+| Field | Value |
+|-------|-------|
+| Upstream | https://github.com/LuaJIT/LuaJIT |
+| Branch | `v2.1` (rolling release) |
+| Version string | `LuaJIT 2.1.1703358377` |
+| Upstream commit | the `v2.1` commit whose committer timestamp is `1703358377` (2023-12-23 19:06 UTC) — LuaJIT's rolling version is `2.1.<committer-unix-timestamp>` |
+| Lua API level | 5.1 (LuaJIT implements the Lua 5.1 API + extensions) |
+| License | MIT (Copyright © 2005–2023 Mike Pall) |
+| File | `lib/libluajit-5.1.a` |
+| sha256 | `815b62f89420861c76b6ddd48b9efcff93248c10df4688cda18f85cac9e45f3b` |
+
+The version string can be recovered from the archive itself:
+
+```bash
+strings vendor/luajit/lib/libluajit-5.1.a | grep -m1 'LuaJIT 2'
+```
+
+## Updating
+
+Rebuild from the desired upstream commit and replace the archive:
+
+```bash
+git clone https://github.com/LuaJIT/LuaJIT
+cd LuaJIT && git checkout <commit> && make
+# produces src/libluajit.a → copy to vendor/luajit/lib/libluajit-5.1.a
+```
+
+Then update **both** the `Version string` / `sha256` above **and** the
+expected hash in `.github/workflows/test.yml` (the "Verify vendored blob
+hashes" step) in the same commit, so an unreviewed swap of this binary blob
+can't pass CI. See #233 M3.


### PR DESCRIPTION
Closes part of #233 (finding **M3**, medium — supply chain; also hardens **L9**).

## Problem

`vendor/luajit/lib/libluajit-5.1.a` (linked into every binary) and `vendor/fennel/fennel.lua` (byte-shipped in the release tarball) had no `VERSION`/`SOURCE`/hash recorded and no CI assertion — unlike the `odin-http` submodule SHA (#221). A commit swapping `libluajit-5.1.a` for a backdoored build would surface only as an opaque binary-blob diff and pass CI unchanged.

## Fix

- `vendor/luajit/BUILD.md` and `vendor/fennel/BUILD.md` record the upstream, version, license, and sha256 of each file, plus the update procedure. LuaJIT is `2.1.1703358377` (v2.1 rolling, committer date 2023-12-23 — recovered from the archive's embedded version string); Fennel is `1.5.1` (from `fennel.lua`).
- A **"Verify vendored blob hashes"** step in both `test.yml` jobs and `release.yml` recomputes and asserts both sha256s (`sha256sum -c`), mirroring the odin-http / Babashka pins. A tampered blob fails CI before merge and before publish.

## Verification

- The assertion passes on the current blobs, fails on a wrong hash, and both workflows parse (`yaml.safe_load`).

> Note: `.github/workflows/test.yml` overlaps with #244 / #245 (the text-package CI step); trivial reconcile at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)