### PR TITLE
fix(devserver): JSON-safe /selection + /scroll-info, bound /state path (#250 L1/L2/I1)

### DIFF
--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -1667,13 +1667,16 @@ handle_get_state_path :: proc(ds: ^Dev_Server, ch: ^Response_Channel, dot_path: 
 	// an app that sets __index on a state table could otherwise be
 	// coaxed into executing Lua via crafted URL paths.
 	MAX_PATH_SEGMENTS :: 32
-	segments := strings.split(dot_path, ".")
-	defer delete(segments)
-	if len(segments) > MAX_PATH_SEGMENTS {
+	// #250 I1: reject before the split. strings.split materializes the full
+	// []string first; `count(".") + 1` equals the eventual segment count, so
+	// count separators up front and refuse an over-deep path before allocating.
+	if strings.count(dot_path, ".") + 1 > MAX_PATH_SEGMENTS {
 		lua_pop(L, 1)
 		respond_json_error(ch, 400, `{"error":"path too deep"}`)
 		return
 	}
+	segments := strings.split(dot_path, ".")
+	defer delete(segments)
 	if any_segment_too_long(segments) {
 		lua_pop(L, 1)
 		respond_json_error(ch, 400, `{"error":"path segment too long"}`)
@@ -1757,6 +1760,18 @@ handle_get_profile :: proc(ch: ^Response_Channel) {
 	respond_json(ch, strings.to_string(b))
 }
 
+// Build the /selection JSON body for a resolved selection. Split out so the
+// escaping is unit-testable without driving the full input state + response
+// channel. #250 L1: the `text` field must go through json_string, not Odin's
+// `%q` — `%q` routes through strconv.quote and emits Odin escapes (\a, \v,
+// \xNN, \u{..}) that are not valid JSON. `kind` is a fixed "input"/"text"
+// literal (not user-controlled), so interpolating it is safe.
+selection_json :: proc(b: ^strings.Builder, kind: string, lo, hi: int, text: string) {
+	fmt.sbprintf(b, `{{"kind":"%s","start":%d,"end":%d,"text":`, kind, lo, hi)
+	json_string(b, text)
+	strings.write_byte(b, '}')
+}
+
 handle_get_selection :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
 	b := strings.builder_make()
 	defer strings.builder_destroy(&b)
@@ -1780,10 +1795,7 @@ handle_get_selection :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
 		if clamped_hi > len(content) do clamped_hi = len(content)
 		sub := ""
 		if lo < clamped_hi do sub = content[lo:clamped_hi]
-		fmt.sbprintf(&b,
-			`{{"kind":"input","start":%d,"end":%d,"text":%q}}`,
-			lo, clamped_hi, sub,
-		)
+		selection_json(&b, "input", lo, clamped_hi, sub)
 
 	case .Text:
 		// Resolve the selected path back to a NodeText.
@@ -1796,10 +1808,7 @@ handle_get_selection :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
 		if clamped_hi > len(content) do clamped_hi = len(content)
 		sub := ""
 		if lo < clamped_hi do sub = content[lo:clamped_hi]
-		fmt.sbprintf(&b,
-			`{{"kind":"text","start":%d,"end":%d,"text":%q}}`,
-			lo, clamped_hi, sub,
-		)
+		selection_json(&b, "text", lo, clamped_hi, sub)
 	}
 
 	respond_json(ch, strings.to_string(b))
@@ -2317,7 +2326,15 @@ handle_get_scroll_info :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
 	for idx, info in ds.current_scroll_info {
 		if !first do strings.write_string(&b, ",")
 		first = false
-		fmt.sbprintf(&b, `"%d":{{"total":%g,"off":%g}}`, idx, info.total, info.off)
+		// #250 L2: total/off via json_number (emits null for NaN/±Inf) rather
+		// than %g, which prints bare +Inf/-Inf/NaN tokens that aren't valid
+		// JSON. No non-finite path reaches here after #184, so this is
+		// defence-in-depth / codebase-convention consistency.
+		fmt.sbprintf(&b, `"%d":{{"total":`, idx)
+		json_number(&b, f64(info.total))
+		strings.write_string(&b, `,"off":`)
+		json_number(&b, f64(info.off))
+		strings.write_byte(&b, '}')
 	}
 	strings.write_string(&b, "}")
 	respond_json(ch, strings.to_string(b))

--- a/src/redin/bridge/devserver_test.odin
+++ b/src/redin/bridge/devserver_test.odin
@@ -259,6 +259,27 @@ test_frame_tag_is_json_escaped :: proc(t: ^testing.T) {
 	testing.expectf(t, !strings.contains(out, `ev"il"`), "tag must not close the JSON string early: %s", out)
 }
 
+// #250 L1: /selection built its body with Odin's %q, which emits Odin escapes
+// (\a for 0x07, \x00 for NUL, \xNN for invalid UTF-8) that are not valid JSON.
+// selection_json now routes the text through json_string, so control bytes
+// become \u00XX and the body stays strict-JSON parseable.
+@(test)
+test_selection_json_escapes_control_bytes :: proc(t: ^testing.T) {
+	b := strings.builder_make()
+	defer strings.builder_destroy(&b)
+
+	// "a" + NUL + "b" + BEL(0x07) + "c" — the two control bytes %q would have
+	// emitted as \x00 and \a.
+	selection_json(&b, "text", 0, 5, "a\x00b\x07c")
+	got := strings.to_string(b)
+
+	want := `{"kind":"text","start":0,"end":5,"text":"a` + `\u0000` + `b` + `\u0007` + `c"}`
+	testing.expectf(t, got == want, "got %q, want %q", got, want)
+	// The invalid Odin escapes must not appear.
+	testing.expectf(t, !strings.contains(got, `\a`), "must not emit Odin \\a escape: %s", got)
+	testing.expectf(t, !strings.contains(got, `\x00`), "must not emit Odin \\x00 escape: %s", got)
+}
+
 // agent_nodes_walker is compiled only in REDIN_AGENT builds, so this test
 // is too. Run it with: odin test src/redin/bridge ... -define:REDIN_AGENT=true
 when REDIN_AGENT {


### PR DESCRIPTION
Three dev-server hardening items from audit #250, all gated on `REDIN_DEV` / `REDIN_AGENT`.

## L1 (low, live) — `/selection` emits invalid JSON via `%q`

`handle_get_selection` built its body with Odin's `%q`, which routes through `strconv.quote` and emits Odin-flavoured escapes (`\a` for 0x07, `\x00` for NUL, `\xNN` for invalid UTF-8) — none of which are valid JSON. An attacker who can influence a text node's bytes (e.g. a handler that writes agent-supplied bytes into state that later renders as text) could break every tool that parses `/selection`.

Fix: route the `text` field through `json_string` — the exact remediation applied at #225 L1 for `/frames`. The JSON-building is factored into a small testable `selection_json` helper (the `.Input` and `.Text` cases were duplicated), with a regression test asserting a control-byte selection escapes to `\u00XX` and never emits the Odin `\a` / `\x00` forms.

## L2 (low, defence-in-depth) — `/scroll-info` emits invalid JSON via `%g`

`%g` on a non-finite `f64` prints bare `+Inf` / `-Inf` / `NaN` tokens. No non-finite value reaches this endpoint after #184, so it's not exploitable today — but the `%g` was out of step with the codebase-wide `json_number` convention (which substitutes `null`). Switched to `json_number`.

## I1 (info) — `/state/<path>` allocates the split before the segment cap

`strings.split` materialized the full `[]string` before the `MAX_PATH_SEGMENTS` check. Now counts separators up front (`count(".") + 1` equals the eventual segment count) and rejects before allocating, matching the reject-before-alloc pattern used for `/screenshot` (#162 H3) and `MAX_JSON_ARRAY_LEN` (#162 M2). The post-split length check is now redundant and removed.

## Verification

`odin test src/redin/bridge` → **161 tests pass** (160 + the new L1 regression test).

Remaining #250 items handled separately: I4 in its own PR; I2/I3 are TOCTOUs the audit itself bounds to the same-user threat model (documented on the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
