### PR TITLE
fix(hotreload): assert the watch list covers src/runtime (#250 I4)

### DIFF
--- a/src/redin/bridge/hotreload.odin
+++ b/src/redin/bridge/hotreload.odin
@@ -32,23 +32,32 @@ Hot_Reload :: struct {
 	retry_at:       time.Tick,
 }
 
+// The runtime .fnl modules watched for hot reload. Kept as an explicit list
+// (rather than globbed at runtime) so the watch set is deterministic and free
+// of directory-read failure modes on the reload hot path. #250 I4: a module
+// missing from this list escapes both the mtime watch AND the symlink guard
+// that hotreload_execute runs before require("init") transitively loads it via
+// fennel.path — so test_watch_list_covers_runtime_dir asserts this stays in
+// sync with src/runtime/*.fnl, turning "forgot to add the new module" (which
+// already happened once, see the #183 note below) into a CI failure.
+runtime_watch_files := []string {
+	"src/runtime/dataflow.fnl",
+	"src/runtime/effect.fnl",
+	"src/runtime/frame.fnl",
+	"src/runtime/theme.fnl",
+	"src/runtime/view.fnl",
+	"src/runtime/init.fnl",
+	// #183: also watch these so editing them triggers a reload.
+	"src/runtime/agent.fnl",
+	"src/runtime/markdown.fnl",
+	"src/runtime/canvas.fnl",
+}
+
 hotreload_init :: proc(hr: ^Hot_Reload, source_tree: bool) {
 	hr.check_interval = 60
 	if !source_tree do return  // #129 H6: cwd-relative watch list only
 	                            // active inside the redin source tree.
-	files := []string{
-		"src/runtime/dataflow.fnl",
-		"src/runtime/effect.fnl",
-		"src/runtime/frame.fnl",
-		"src/runtime/theme.fnl",
-		"src/runtime/view.fnl",
-		"src/runtime/init.fnl",
-		// #183: also watch these so editing them triggers a reload.
-		"src/runtime/agent.fnl",
-		"src/runtime/markdown.fnl",
-		"src/runtime/canvas.fnl",
-	}
-	for f in files {
+	for f in runtime_watch_files {
 		append(&hr.watch_paths, f)
 		hr.last_mtimes[f] = get_file_mtime(f)
 	}

--- a/src/redin/bridge/hotreload_test.odin
+++ b/src/redin/bridge/hotreload_test.odin
@@ -2,6 +2,7 @@ package bridge
 
 import "core:fmt"
 import "core:os"
+import "core:path/filepath"
 import "core:strings"
 import "core:sys/linux"
 import "core:testing"
@@ -83,4 +84,33 @@ test_hotreload_symlink_free_ignores_missing :: proc(t: ^testing.T) {
 	// guard must not treat "unreadable" as "unsafe" (that would wedge reload).
 	_, ok := hotreload_paths_symlink_free([]string{"does/not/exist.fnl"})
 	testing.expect(t, ok, "missing watched path is not treated as a symlink")
+}
+
+// #250 I4: runtime_watch_files is hand-maintained. A new src/runtime/*.fnl
+// module that isn't listed escapes both the mtime watch and the symlink guard
+// that runs before require("init") loads it transitively via fennel.path. This
+// asserts the list covers every runtime module so that omission is a CI
+// failure, not a silent gap.
+@(test)
+test_watch_list_covers_runtime_dir :: proc(t: ^testing.T) {
+	matches, err := filepath.glob("src/runtime/*.fnl", context.temp_allocator)
+	if err != nil || len(matches) == 0 {
+		// The suite may run from a cwd where the source tree isn't present;
+		// the guard only makes sense in-tree, so skip rather than fail.
+		fmt.eprintln("skipping watch-list coverage: src/runtime/*.fnl not found")
+		return
+	}
+	for m in matches {
+		base := filepath.base(m)
+		found := false
+		for w in runtime_watch_files {
+			if filepath.base(w) == base {
+				found = true
+				break
+			}
+		}
+		testing.expectf(t, found,
+			"src/runtime/%s is missing from runtime_watch_files (hotreload.odin); add it (#250 I4)",
+			base)
+	}
 }


### PR DESCRIPTION
## #250 I4 — hot-reload watch list is hard-coded

`hotreload_paths_symlink_free` (the symlink guard that runs before `require("init")`) only vets the fixed watch list. A future `src/runtime/*.fnl` module that lands but isn't added to that list won't be symlink-checked before it's loaded transitively via `fennel.path` — and, just as importantly for day-to-day dev, its edits won't trigger a hot reload at all. The `#183` comment in the file records that this exact omission already happened once (agent/markdown/canvas were initially left out).

The list matches `src/runtime/*.fnl` perfectly today, so this is a maintenance hazard rather than a live bug.

## Change

- Hoist the list out of `hotreload_init` to a package-level `runtime_watch_files`.
- Add `test_watch_list_covers_runtime_dir`, which globs `src/runtime/*.fnl` and fails if any module is missing from the list — turning "forgot to add the new module" into a CI failure.

Kept the list explicit rather than globbing at reload time, so the watch set stays deterministic and free of directory-read failure modes on the reload hot path; the test provides the sync guarantee instead.

## Verification

- Negative check: dropping one module from the list makes `test_watch_list_covers_runtime_dir` fail with `src/runtime/canvas.fnl is missing from runtime_watch_files ... add it (#250 I4)`.
- `odin test src/redin/bridge` → **161 tests pass** with the list complete.

Remaining #250 items: L1/L2/I1 in #252; I2/I3 are TOCTOUs the audit itself bounds to the same-user threat model (documented on the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
