### PR TITLE
fix(devserver): CRLF-anchor header lookups, JSON-safe /frames rects (#256 L1/L2)

### DIFF
--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -836,7 +836,12 @@ find_header_value :: proc(headers: string, name_lower: string) -> string {
 		rel := strings.index(lower[pos:], needle)
 		if rel < 0 do return ""
 		idx := pos + rel
-		if idx == start || lower[idx - 1] == '\n' {
+		// #256 L1: a header line starts only after the two-byte CRLF RFC 7230
+		// mandates. Accepting a bare '\n' let a LF byte embedded in another
+		// header's value smuggle a header past this lookup (and past
+		// header_count's duplicate rejection).
+		if idx == start ||
+		   (idx >= start + 2 && lower[idx - 2] == '\r' && lower[idx - 1] == '\n') {
 			rest := headers[idx + len(needle):]
 			end := strings.index_any(rest, "\r\n")
 			if end < 0 do end = len(rest)
@@ -938,7 +943,10 @@ header_count :: proc(headers: string, name_lower: string) -> int {
 		rel := strings.index(lower[pos:], needle)
 		if rel < 0 do break
 		idx := pos + rel
-		if idx == start || lower[idx - 1] == '\n' {
+		// #256 L1: anchor on the full CRLF, mirroring find_header_value —
+		// a bare '\n' inside a header value is not a line boundary.
+		if idx == start ||
+		   (idx >= start + 2 && lower[idx - 2] == '\r' && lower[idx - 1] == '\n') {
 			count += 1
 		}
 		pos = idx + len(needle)
@@ -1158,6 +1166,24 @@ handle_get_frames :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
 // For non-frame values (numbers, strings, primitive children inside
 // e.g. canvas attribute tables), defers to lua_value_to_json.
 //
+// rect_json renders a node's layout rect as the `,"rect":[x,y,w,h]`
+// attribute fragment spliced into /frames output (temp-allocated).
+// #256 L2: each coordinate goes through json_number (null for NaN/±Inf) —
+// %g printed non-finite values as bare tokens, which is not valid JSON.
+rect_json :: proc(r: rl.Rectangle) -> string {
+	b := strings.builder_make(context.temp_allocator)
+	strings.write_string(&b, `,"rect":[`)
+	json_number(&b, f64(r.x))
+	strings.write_byte(&b, ',')
+	json_number(&b, f64(r.y))
+	strings.write_byte(&b, ',')
+	json_number(&b, f64(r.width))
+	strings.write_byte(&b, ',')
+	json_number(&b, f64(r.height))
+	strings.write_byte(&b, ']')
+	return strings.to_string(b)
+}
+
 // Mirrors lua_read_node's flattening order. dfs_idx must be incremented
 // exactly once per node (vector with a tag at slot 1) — except for
 // [:markdown], which lowers to N flat-array nodes via flatten_subtree;
@@ -1200,8 +1226,7 @@ frame_value_to_json :: proc(
 	}
 	rect_str := ""
 	if my_idx >= 0 && my_idx < len(rects) {
-		r := rects[my_idx]
-		rect_str = fmt.tprintf(`,"rect":[%g,%g,%g,%g]`, r.x, r.y, r.width, r.height)
+		rect_str = rect_json(rects[my_idx])
 	} else {
 		rect_str = `,"rect":null`
 	}

--- a/src/redin/bridge/devserver_test.odin
+++ b/src/redin/bridge/devserver_test.odin
@@ -2,6 +2,7 @@ package bridge
 
 import "core:container/queue"
 import "core:fmt"
+import "core:math"
 import "core:os"
 import "core:strings"
 import "core:sync"
@@ -229,6 +230,61 @@ test_header_count_ignores_request_line :: proc(t: ^testing.T) {
 	// header lines, anchored at a line start, do (mirrors find_header_value).
 	headers := "GET /state/content-length:5 HTTP/1.1\r\nHost: localhost:8800"
 	testing.expect_value(t, header_count(headers, "content-length"), 0)
+}
+
+// #256 L1: header lines are terminated by CRLF (RFC 7230); a bare LF byte
+// embedded inside another header's value must not anchor a header line.
+// Previously `idx == start || lower[idx-1] == '\n'` accepted the bare-LF
+// position, so `X-Junk: \nAuthorization: ...` smuggled an Authorization
+// "header" past both the duplicate check (header_count) and the lookup
+// (find_header_value).
+
+@(test)
+test_find_header_value_bare_lf_not_line_boundary :: proc(t: ^testing.T) {
+	headers := "GET / HTTP/1.1\r\nX-Junk: \nAuthorization: Bearer smuggled\r\nHost: localhost:8800\r\n"
+	// The smuggled occurrence sits after a bare LF — not a header line.
+	testing.expect_value(t, find_header_value(headers, "authorization"), "")
+	// A real header after a proper CRLF is still found.
+	testing.expect_value(t, find_header_value(headers, "host"), "localhost:8800")
+}
+
+@(test)
+test_find_header_value_bare_cr_not_line_boundary :: proc(t: ^testing.T) {
+	// A lone CR (no LF) is not a line terminator either.
+	headers := "GET / HTTP/1.1\r\nX-Junk: \rAuthorization: Bearer smuggled\r\nHost: localhost:8800\r\n"
+	testing.expect_value(t, find_header_value(headers, "authorization"), "")
+}
+
+@(test)
+test_header_count_bare_lf_not_line_boundary :: proc(t: ^testing.T) {
+	headers := "GET / HTTP/1.1\r\nX-Junk: \nAuthorization: Bearer smuggled\r\nHost: localhost:8800\r\n"
+	testing.expect_value(t, header_count(headers, "authorization"), 0)
+	// The duplicate-rejection primitive must still see a bare-LF-smuggled
+	// second occurrence as NOT a second header (count stays 1)...
+	dup := "GET / HTTP/1.1\r\nHost: a\r\nX-Junk: \nHost: b\r\n"
+	testing.expect_value(t, header_count(dup, "host"), 1)
+	// ...while two real CRLF-anchored occurrences still count as 2.
+	real_dup := "GET / HTTP/1.1\r\nHost: a\r\nHost: b\r\n"
+	testing.expect_value(t, header_count(real_dup, "host"), 2)
+}
+
+// #256 L2: /frames rect coordinates were emitted with %g, which prints
+// NaN/±Inf as bare unquoted tokens — invalid JSON. rect_json routes each
+// coordinate through json_number (null for non-finite), matching the
+// convention adopted for /scroll-info (#250 L2) and PUT /aspects.
+
+@(test)
+test_rect_json_finite :: proc(t: ^testing.T) {
+	testing.expect_value(t, rect_json(rl.Rectangle{1, 2.5, 3, 4}), `,"rect":[1,2.5,3,4]`)
+}
+
+@(test)
+test_rect_json_non_finite_emits_null :: proc(t: ^testing.T) {
+	testing.expect_value(
+		t,
+		rect_json(rl.Rectangle{math.nan_f32(), 2, math.inf_f32(1), math.inf_f32(-1)}),
+		`,"rect":[null,2,null,null]`,
+	)
 }
 
 // #225 L1: /frames and /agent/nodes emitted the node `tag` / `id` raw, so a


### PR DESCRIPTION
Fixes findings L1 and L2 from the #256 audit.

**L1 — bare-LF header anchoring.** `find_header_value` / `header_count` accepted `lower[idx-1] == '\n'` as a header-line boundary. A bare LF byte embedded inside another header's value (`X-Junk: \nAuthorization: Bearer x\r\n`) was therefore treated as starting a real header line — smuggling an occurrence past both the duplicate-header rejection and the value lookup. Both helpers now require the two-byte CRLF sequence RFC 7230 mandates (first-line position still accepted). Not an auth bypass (the token comparison is unchanged), but closes the header-smuggling primitive.

**L2 — non-finite rect coordinates.** `/frames` emitted `"rect":[...]` via `%g`, which prints `NaN` / `+Inf` / `-Inf` as bare unquoted tokens — malformed JSON for every consumer of the endpoint. The emit is extracted into `rect_json`, routing each coordinate through `json_number` (emits `null` for non-finite), matching the convention adopted for `/scroll-info` and `PUT /aspects` in #250.

**Tests** (written first, watched fail):
- `test_find_header_value_bare_lf_not_line_boundary` — smuggled Authorization not returned; real Host after proper CRLF still found
- `test_find_header_value_bare_cr_not_line_boundary` — lone-CR pin
- `test_header_count_bare_lf_not_line_boundary` — smuggled duplicate not counted; real CRLF duplicate still counted
- `test_rect_json_finite` / `test_rect_json_non_finite_emits_null`

Verified: `odin test src/redin/bridge` (167 tests green), release + dev builds compile.

Part of #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)