### PR TITLE
fix(http): unpark timed-out tarpit workers, close the submit/destroy race (#263 M1, L5)

### DIFF
--- a/src/redin/bridge/http_client.odin
+++ b/src/redin/bridge/http_client.odin
@@ -189,8 +189,14 @@ http_client_destroy :: proc(hc: ^Http_Client) {
 	// after `execute_http_request` returns and decrement `workers_alive`
 	// LAST, so a worker count of 0 means no worker holds a pointer into
 	// `hc`. Atomic store so the socket hook can observe shutdown
-	// without locking `pending_mutex`.
+	// without locking `pending_mutex`. The store itself happens under
+	// pending_mutex (#263 L5): http_client_request checks the flag and
+	// bumps workers_alive under the same lock, so once we release it,
+	// every submitter either already bumped the count (we'll wait for its
+	// worker) or will observe the flag and reject.
+	sync.lock(&hc.pending_mutex)
 	sync.atomic_store(&hc.destroying, true)
+	sync.unlock(&hc.pending_mutex)
 
 	// Phase 1: wait up to 3 s for workers to drain naturally. The
 	// timeout sweep also runs here to mark long-running requests as
@@ -283,14 +289,14 @@ http_client_request :: proc(hc: ^Http_Client, req: Http_Request) {
 	// In-flight cap. Soft check: two simultaneous submitters could both
 	// see `inflight = 63` and both proceed, briefly reaching 65. That's
 	// fine — we're enforcing a soft cap, not a hard one. Issue #99 M1 B.
-	// We also peek at `destroying` under the same lock so a request issued
-	// concurrently with http_client_destroy can't write into a freed
-	// pending map. Production callers are main-thread only; this hardens
-	// the contract for callers on other threads.
+	// `destroying` is checked below, under the same pending_mutex hold as
+	// the insert, so a request issued concurrently with http_client_destroy
+	// can't write into a freed pending map. Production callers are
+	// main-thread only; this hardens the contract for callers on other
+	// threads.
 	sync.lock(&hc.pending_mutex)
 	inflight := len(hc.pending)
 	sync.unlock(&hc.pending_mutex)
-	shutting_down := sync.atomic_load(&hc.destroying)
 
 	if inflight >= MAX_INFLIGHT_HTTP {
 		// Move req.id into the rejection response (mirrors execute_http_request,
@@ -311,7 +317,36 @@ http_client_request :: proc(hc: ^Http_Client, req: Http_Request) {
 		return
 	}
 
+	timeout := req.timeout_ms <= 0 ? HTTP_DEFAULT_TIMEOUT_MS : req.timeout_ms
+
+	// Clone req.id for the pending map. The same allocation is used as
+	// both the map key and id_owned, so a single delete frees both.
+	// #263 L5: `destroying` must be read under the SAME pending_mutex hold
+	// as the insert and the workers_alive bump. Read outside it, destroy
+	// could flip the flag and observe workers_alive == 0 between our check
+	// and the insert, then free pending/sockets while we write into them
+	// and spawn a worker that reads them. http_client_destroy stores the
+	// flag under pending_mutex, so whichever side takes the lock first
+	// wins consistently: either we insert+bump before destroy sees the
+	// count, or we observe the flag and reject.
+	id_clone := strings.clone(req.id)
+	sync.lock(&hc.pending_mutex)
+	shutting_down := sync.atomic_load(&hc.destroying)
+	dup: bool
+	if !shutting_down {
+		_, dup = hc.pending[id_clone]
+		if !dup {
+			hc.pending[id_clone] = Pending_Http{
+				id_owned = id_clone,
+				deadline = time.time_add(time.now(), time.Duration(timeout) * time.Millisecond),
+			}
+			sync.atomic_add(&hc.workers_alive, 1)
+		}
+	}
+	sync.unlock(&hc.pending_mutex)
+
 	if shutting_down {
+		delete(id_clone)
 		r := Http_Response{
 			id        = req.id,
 			status    = 0,
@@ -325,21 +360,6 @@ http_client_request :: proc(hc: ^Http_Client, req: Http_Request) {
 		http_request_destroy(&req)
 		return
 	}
-
-	timeout := req.timeout_ms <= 0 ? HTTP_DEFAULT_TIMEOUT_MS : req.timeout_ms
-
-	// Clone req.id for the pending map. The same allocation is used as
-	// both the map key and id_owned, so a single delete frees both.
-	id_clone := strings.clone(req.id)
-	sync.lock(&hc.pending_mutex)
-	_, dup := hc.pending[id_clone]
-	if !dup {
-		hc.pending[id_clone] = Pending_Http{
-			id_owned = id_clone,
-			deadline = time.time_add(time.now(), time.Duration(timeout) * time.Millisecond),
-		}
-	}
-	sync.unlock(&hc.pending_mutex)
 
 	// #174: a duplicate in-flight id would overwrite the first entry's
 	// map-key allocation (leak) and cause the second worker's real response
@@ -373,9 +393,11 @@ http_client_request :: proc(hc: ^Http_Client, req: Http_Request) {
 	// odin-http logs Connection_Closed at log.errorf, which the test
 	// runner counts as a test failure even when it's the expected
 	// outcome of a slow/flaky remote.
+	// workers_alive was already bumped inside the pending_mutex hold above
+	// (#263 L5) so destroy can never observe 0 workers after we committed
+	// to spawning one.
 	worker_ctx := context
 	worker_ctx.logger = log.nil_logger()
-	sync.atomic_add(&hc.workers_alive, 1)
 	thread.create_and_start_with_data(data, http_thread_proc, init_context = worker_ctx, self_cleanup = true)
 }
 
@@ -398,6 +420,25 @@ http_client_poll :: proc(hc: ^Http_Client, results: ^[dynamic]Http_Response) {
 		delete_key(&hc.pending, id)
 	}
 	sync.unlock(&hc.pending_mutex)
+
+	// Phase 1b (#263 M1): shut down each timed-out request's socket so the
+	// worker actually unwinds. Removing the pending entry alone frees the
+	// in-flight slot while the worker stays parked in recv — a server that
+	// trickles bytes inside the per-recv Receive_Timeout window would pin
+	// the worker, its fd, and the sockets entry indefinitely, leaking one
+	// of each per request. Shutdown (never close) keeps fd ownership with
+	// the worker's own error path — same single-owner discipline as
+	// #260 L1. A socket still mid-connect answers ENOTCONN; that worker's
+	// connect loop is bounded by timeout_ms on its own.
+	if len(timed_out_ids) > 0 {
+		sync.lock(&hc.sockets_mutex)
+		for id in timed_out_ids {
+			if sock, ok := hc.sockets[id]; ok {
+				_ = net.shutdown(sock, .Both)
+			}
+		}
+		sync.unlock(&hc.sockets_mutex)
+	}
 
 	// Phase 2: synthesize timeout responses. Ownership of id (the
 	// erstwhile id_owned) transfers into Http_Response.id; the caller's
@@ -781,14 +822,24 @@ execute_http_request :: proc(req: Http_Request, client: ^Http_Client = nil) -> H
 
 	res, req_err := http_client.request_on(&http_req, sock, url, context.allocator)
 
-	if client != nil {
-		sync.lock(&client.sockets_mutex)
-		delete_key(&client.sockets, req.id)
-		sync.unlock(&client.sockets_mutex)
-	}
+	// #263 M1: the socket stays REGISTERED until just before whichever
+	// path closes it. It used to be deregistered here, right after
+	// request_on — but request_on only parses the response headers; the
+	// body is read below in response_body, on the same socket. A server
+	// that dripped its body one byte per Receive_Timeout window would park
+	// the worker in an unregistered-socket recv, where neither the
+	// timeout sweep in http_client_poll nor destroy's force-shutdown could
+	// reach it. Deregistration must precede the close (never follow it):
+	// a registered-but-closed fd is exactly the recycled-fd shutdown
+	// hazard of #260 L1.
 
 	if req_err != nil {
 		// `request_on` leaves socket ownership with us on error.
+		if client != nil {
+			sync.lock(&client.sockets_mutex)
+			delete_key(&client.sockets, req.id)
+			sync.unlock(&client.sockets_mutex)
+		}
 		net.close(sock)
 		// #162 L4: generic to the caller, detail to stderr. Certificate
 		// rejection is the one distinguishable case: the app must be able
@@ -833,6 +884,12 @@ execute_http_request :: proc(req: Http_Request, client: ^Http_Client = nil) -> H
 		response.headers[strings.clone(k)] = strings.clone(v)
 	}
 
+	// Deregister before response_destroy closes the fd (#263 M1, see above).
+	if client != nil {
+		sync.lock(&client.sockets_mutex)
+		delete_key(&client.sockets, req.id)
+		sync.unlock(&client.sockets_mutex)
+	}
 	http_client.response_destroy(&res, body, was_alloc)
 
 	return response

--- a/src/redin/bridge/http_client_test.odin
+++ b/src/redin/bridge/http_client_test.odin
@@ -1461,6 +1461,141 @@ test_tcp_connect_bounded_times_out :: proc(t: ^testing.T) {
 		"bounded connect took %v — timeout_ms was not honoured (#256 L3)", elapsed)
 }
 
+// #263 M1: the per-request deadline is enforced by http_client_poll, but
+// the timeout path only removed the `pending` entry — it never touched
+// `hc.sockets`. Against a server that trickles bytes faster than the
+// per-recv Receive_Timeout, SO_RCVTIMEO never fires either, so the worker
+// (and its fd) stayed parked long after the app was told "timeout" and the
+// in-flight slot was freed. Each new request against the same tarpit
+// leaked another worker + fd, unbounded. The fix shuts the socket down
+// (never closes — the worker keeps sole fd ownership, same discipline as
+// #260 L1) in the same poll that synthesizes the timeout response.
+
+@(private = "file")
+drip_mock_serve :: proc(m: ^Mock_Server) {
+	defer sync.sema_post(&m.done)
+	client, _, err := net.accept_tcp(m.sock)
+	if err != nil do return
+	defer net.close(client)
+	buf: [4096]u8
+	total := 0
+	for total < len(buf) {
+		n, rerr := net.recv_tcp(client, buf[total:])
+		if rerr != nil || n <= 0 do break
+		total += n
+		if strings.contains(string(buf[:total]), "\r\n\r\n") do break
+	}
+	// Full header block at once, then drip the body one byte per 100 ms —
+	// each recv is satisfied well inside the per-recv timeout, but the
+	// overall deadline is blown. ~3 s worst case bounds the test.
+	head := "HTTP/1.1 200 OK\r\nContent-Length: 10000\r\nConnection: close\r\n\r\n"
+	if _, serr := net.send_tcp(client, transmute([]u8)head); serr != nil do return
+	one := []u8{'x'}
+	for _ in 0 ..< 30 {
+		time.sleep(100 * time.Millisecond)
+		if _, serr := net.send_tcp(client, one); serr != nil do return
+	}
+}
+
+@(private = "file")
+mock_start_drip :: proc() -> ^Mock_Server {
+	m := mock_bind()
+	if m == nil do return nil
+	m.thread = thread.create_and_start_with_poly_data(m, drip_mock_serve, context)
+	return m
+}
+
+@(test)
+test_http_timeout_unparks_tarpit_worker :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+	allow_open_http()
+	defer set_http_whitelist(nil)
+
+	m := mock_start_drip()
+	if m == nil do testing.fail_now(t, "could not bind a loopback mock server")
+	defer mock_stop(m)
+
+	hc: Http_Client
+	http_client_init(&hc)
+	defer http_client_destroy(&hc)
+
+	req := Http_Request{
+		id         = strings.clone("tarpit-1"),
+		url        = strings.clone(fmt.tprintf("http://127.0.0.1:%d/", m.port)),
+		method     = strings.clone("GET"),
+		timeout_ms = 400, // mock drips a byte every 100 ms for ~3 s
+	}
+	http_client_request(&hc, req)
+
+	// Collect the app-facing timeout response.
+	deadline := time.time_add(time.now(), 2 * time.Second)
+	results: [dynamic]Http_Response
+	defer { for &r in results do http_response_destroy(&r); delete(results) }
+	for time.diff(time.now(), deadline) > 0 {
+		http_client_poll(&hc, &results)
+		if len(results) > 0 do break
+		time.sleep(50 * time.Millisecond)
+	}
+	testing.expect(t, len(results) == 1, "expected the synthesized timeout result")
+	if len(results) == 1 {
+		testing.expect(t, strings.contains(results[0].error_msg, "timeout"),
+			fmt.tprintf("expected 'timeout' in error_msg, got %q", results[0].error_msg))
+	}
+
+	// The worker must unwind promptly — the timeout poll shut its socket
+	// down. Pre-fix it stayed parked until the mock stopped dripping (~3 s).
+	drain_deadline := time.time_add(time.now(), 1 * time.Second)
+	for sync.atomic_load(&hc.workers_alive) != 0 && time.diff(time.now(), drain_deadline) > 0 {
+		time.sleep(20 * time.Millisecond)
+	}
+	testing.expect(t, sync.atomic_load(&hc.workers_alive) == 0,
+		"timed-out worker still parked against the drip server — poll must shut down the socket (#263 M1)")
+}
+
+// #263 L5: `destroying` was read outside pending_mutex, before the insert.
+// A destroy that flips the flag and observes workers_alive == 0 in that
+// window frees the pending/sockets maps while the submitter goes on to
+// insert and spawn a worker — UAF. The check now happens under
+// pending_mutex atomically with the insert and the workers_alive bump.
+@(test)
+test_http_request_during_destroy_rejected :: proc(t: ^testing.T) {
+	sync.lock(&g_test_http_state_mutex)
+	defer sync.unlock(&g_test_http_state_mutex)
+
+	hc: Http_Client
+	http_client_init(&hc)
+	defer http_client_destroy(&hc)
+
+	sync.atomic_store(&hc.destroying, true)
+
+	req := Http_Request{
+		id     = strings.clone("destroy-race-1"),
+		url    = strings.clone("http://127.0.0.1:1/"),
+		method = strings.clone("GET"),
+	}
+	http_client_request(&hc, req)
+
+	testing.expect(t, sync.atomic_load(&hc.workers_alive) == 0,
+		"a request submitted during destroy must not spawn a worker (#263 L5)")
+	sync.lock(&hc.pending_mutex)
+	pending_len := len(hc.pending)
+	sync.unlock(&hc.pending_mutex)
+	testing.expect(t, pending_len == 0,
+		"a request submitted during destroy must not insert into pending (#263 L5)")
+
+	results: [dynamic]Http_Response
+	defer { for &r in results do http_response_destroy(&r); delete(results) }
+	http_client_poll(&hc, &results)
+	found := false
+	for r in results {
+		if strings.contains(r.error_msg, "shutting down") do found = true
+	}
+	testing.expect(t, found, "expected a 'shutting down' rejection result")
+
+	sync.atomic_store(&hc.destroying, false) // let the deferred destroy run cleanly
+}
+
 @(test)
 test_tcp_connect_bounded_cancel :: proc(t: ^testing.T) {
 	// A pre-set cancel flag (http_client_destroy's `destroying`) must make


### PR DESCRIPTION
Fixes the two `http_client.odin` findings from the #263 audit.

## M1 — timed-out requests leaked the worker thread and socket fd (medium)

`http_client_poll`'s timeout sweep removed the `pending` entry (freeing the in-flight slot) but never touched the socket. Against a server that trickles bytes inside the per-recv `Receive_Timeout` window, `SO_RCVTIMEO` never fires, so the worker stayed parked in `recv` indefinitely — one leaked worker + fd per request against the tarpit, unbounded, while the app sees clean "timeout" responses.

Two changes:

- The timeout sweep now looks up each timed-out id in `hc.sockets` and `net.shutdown(sock, .Both)`s it, waking the parked `recv`. **Shutdown, not close** — the worker's own error/success path stays the sole fd owner, deliberately avoiding the #260 L1 double-close shape (same discipline as #261).
- The audit's suggested fix alone was insufficient: the worker deregistered the socket right after `request_on`, which only parses response **headers** — the body is read afterwards via `response_body` on the same socket, so a body-phase tarpit (the audit's own repro) parked the worker with the socket already out of the registry, unreachable by the sweep *and* by destroy's force-shutdown. The socket now stays registered through the body read and is deregistered just before whichever path closes the fd — never after, since a registered-but-closed fd is the recycled-fd hazard again.

Test: `test_http_timeout_unparks_tarpit_worker` drives a drip mock (full headers, then one body byte per 100 ms for ~3 s) with a 400 ms request timeout and asserts `workers_alive` drains within 1 s of the synthesized timeout. Fails pre-fix (worker parked until the drip ends), passes post-fix in ~500 ms.

## L5 — `destroying` read outside `pending_mutex` (low)

Destroy could flip `destroying` and observe `workers_alive == 0` between the submitter's flag check and its insert + spawn, then free the pending/sockets maps under a live worker (UAF; reachable only from non-main-thread callers, per the existing contract comment). Now:

- `http_client_destroy` stores the flag under `pending_mutex`;
- `http_client_request` checks the flag, inserts, and bumps `workers_alive` in one `pending_mutex` critical section.

Whichever side takes the lock first wins consistently: either the submitter commits (destroy waits for its worker) or it observes the flag and rejects.

Test: `test_http_request_during_destroy_rejected` pins the rejection path (no worker, no pending entry, "shutting down" result).

## Verification

- `odin test src/redin/bridge` — 172/172 pass
- Release build (`odin build src/cmd/redin ...`) clean

Note for review: this branch is independent of #261 (the #260 L1 fix, still open); both use shutdown-not-close and touch different functions, so they merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)