### PR TITLE
fix(devserver): never match an empty id on /agent/content/ (#263 L1)

### DIFF
--- a/src/redin/bridge/devserver.odin
+++ b/src/redin/bridge/devserver.odin
@@ -1374,6 +1374,12 @@ handle_get_agent_nodes :: proc(ds: ^Dev_Server, ch: ^Response_Channel) {
 // onto the Lua stack at -1 if found and return true. Otherwise leaves
 // the stack unchanged and returns false. Caller must lua_pop(L, 1) on success.
 agent_find_by_id :: proc(L: ^Lua_State, index: i32, target_id: string) -> bool {
+	// #263 L1: the walker defaults a node's id to "" when the attrs table
+	// has no `:id` field, so an empty target would match the first
+	// DFS-visited un-id'd node (in practice the root — or, on the PUT
+	// path, any `:agent :edit` node the app didn't bother to id). Absent
+	// must never equal empty; refuse the lookup outright.
+	if len(target_id) == 0 do return false
 	idx := index < 0 ? lua_gettop(L) + index + 1 : index
 	if !lua_istable(L, idx) do return false
 
@@ -1467,6 +1473,12 @@ emit_agent_content :: proc(b: ^strings.Builder, L: ^Lua_State, tag: string) {
 }
 
 handle_get_agent_content :: proc(ds: ^Dev_Server, ch: ^Response_Channel, id: string) {
+	// #263 L1 defence in depth: reject "/agent/content/" (empty id) before
+	// touching the frame; agent_find_by_id refuses empty targets too.
+	if len(id) == 0 {
+		respond_json_error(ch, 404, `{"error":"id required"}`)
+		return
+	}
 	L := ds.bridge.L
 	lua_getglobal(L, "require")
 	lua_pushstring(L, "view")
@@ -1498,6 +1510,11 @@ handle_get_agent_content :: proc(ds: ^Dev_Server, ch: ^Response_Channel, id: str
 }
 
 handle_put_agent_content :: proc(ds: ^Dev_Server, ch: ^Response_Channel, id: string, body: string) {
+	// #263 L1 defence in depth: see handle_get_agent_content.
+	if len(id) == 0 {
+		respond_json_error(ch, 404, `{"error":"id required"}`)
+		return
+	}
 	L := ds.bridge.L
 
 	// 1. Decode body. Expect {"content": <string-or-array>}.

--- a/src/redin/bridge/devserver_test.odin
+++ b/src/redin/bridge/devserver_test.odin
@@ -361,6 +361,37 @@ test_agent_nodes_id_is_json_escaped :: proc(t: ^testing.T) {
 	testing.expectf(t, strings.contains(out, `"mode":"edit"`), "mode present: %s", out)
 	testing.expectf(t, strings.contains(out, `"type":"text"`), "type present: %s", out)
 }
+// #263 L1: `GET/PUT /agent/content/` (trailing slash, empty id) reached
+// agent_find_by_id with target_id == "". The walker defaults a node's id
+// to "" when its attrs table has no `:id` field, so the empty target
+// matched the first DFS-visited un-id'd node — leaking the root subtree
+// on GET, and on PUT writing into any `:agent :edit` node that happens to
+// lack an id. An empty target must never match anything; the id attr is
+// the discriminator, and "absent" must not equal "empty".
+@(test)
+test_agent_find_by_id_empty_target_never_matches :: proc(t: ^testing.T) {
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	// Root without :id, child with agent=edit but no :id either — the
+	// exact shape the PUT-side authorization gap needs.
+	testing.expect(
+		t,
+		luaL_dostring(L, `return {'vbox', {}, {'input', {agent='edit'}, 'hello'}}`) == 0,
+		"lua build failed",
+	)
+
+	testing.expect(t, !agent_find_by_id(L, lua_gettop(L), ""),
+		"empty target id must not match a node whose attrs lack :id (#263 L1)")
+
+	// Sanity: a real id still matches.
+	testing.expect(t, luaL_dostring(L, `return {'vbox', {}, {'input', {agent='edit', id='x'}}}`) == 0,
+		"lua build failed")
+	testing.expect(t, agent_find_by_id(L, lua_gettop(L), "x"),
+		"non-empty id lookup must still work")
+	lua_pop(L, 1)
+}
 } // when REDIN_AGENT
 
 // Tests for the dev-server handler-pool queue introduced for

--- a/test/ui/test_agent.bb
+++ b/test/ui/test_agent.bb
@@ -49,6 +49,21 @@
                        {:headers (auth-headers) :throw false})]
     (assert (= 404 (:status resp)) (str "expected 404, got " (:status resp)))))
 
+;; #263 L1: an empty id ("/agent/content/" with trailing slash) used to match
+;; the first node whose attrs table has no :id — leaking the root subtree on
+;; GET and, on PUT, writing into any un-id'd :agent :edit node.
+(deftest agent-get-empty-id-404
+  (let [resp (http/get (str (base-url) "/agent/content/")
+                       {:headers (auth-headers) :throw false})]
+    (assert (= 404 (:status resp)) (str "expected 404 for empty id, got " (:status resp)))))
+
+(deftest agent-put-empty-id-404
+  (let [resp (http/put (str (base-url) "/agent/content/")
+                       {:headers (merge (auth-headers) {"Content-Type" "application/json"})
+                        :body (json/generate-string {:content "pwned"})
+                        :throw false})]
+    (assert (= 404 (:status resp)) (str "expected 404 for empty id, got " (:status resp)))))
+
 ;; -- PUT --
 
 (deftest agent-put-text-replaces-content


### PR DESCRIPTION
Fixes #263 L1.

`GET`/`PUT /agent/content/` (trailing slash → empty id) reached `agent_find_by_id` with `target_id == ""`. The walker defaults a node's id to `""` when its attrs table has no `:id` field, so the empty target matched the first DFS-visited un-id'd node: the root subtree leaked on GET, and PUT succeeded against any `:agent :edit` node that lacks an `:id` — an authorization gap, since the id match was supposed to be the discriminator.

Changes (both halves of the audit's suggested fix):

- `agent_find_by_id` returns false outright for an empty target — absent must never equal empty.
- Both handlers 404 an empty id up front (`{"error":"id required"}`), defence in depth.

Tests:

- Unit: `test_agent_find_by_id_empty_target_never_matches` (fails pre-fix — the empty target matched the un-id'd root) plus a sanity check that real id lookups still work.
- UI: `agent-get-empty-id-404` / `agent-put-empty-id-404` in `test_agent.bb` pin the endpoint behavior.

Verification: `odin test src/redin/bridge -define:REDIN_AGENT=true` 172/172; `test_agent.bb` 12/12 against a `REDIN_AGENT` dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)