### PR TITLE
fix(bridge): guard measure_text args; pin json numeric-key contract (#263 L2, L4)

### DIFF
--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -465,6 +465,11 @@ redin_now :: proc "c" (L: ^Lua_State) -> i32 {
 
 redin_measure_text :: proc "c" (L: ^Lua_State) -> i32 {
 	context = g_context
+	// #263 L2: same argument guard as every sibling cfunc. Without it a
+	// nil/table text reaches rl.MeasureTextEx as a NULL cstring; current
+	// raylib happens to NULL-guard TextLength, but that's its internal
+	// detail, not a contract.
+	if !lua_isstring(L, 1) do return 0
 	text := lua_tostring_raw(L, 1)
 	font_size := f32(lua_tonumber(L, 2))
 	font_name := "sans"

--- a/src/redin/bridge/json.odin
+++ b/src/redin/bridge/json.odin
@@ -159,10 +159,22 @@ lua_value_to_json_inner :: proc(b: ^strings.Builder, L: ^Lua_State, index: i32, 
 			first := true
 			lua_pushnil(L)
 			for lua_next(L, abs_idx) != 0 {
+				// Non-string keys are dropped: our lua_isstring is a
+				// strict LUA_TSTRING check (lua_api.odin), NOT the
+				// coercing C-API predicate — that strictness is
+				// load-bearing here. Lua 5.1 forbids lua_tolstring on a
+				// non-string key mid-lua_next (it converts the key slot
+				// in place and derails the traversal), so a coercing
+				// predicate would let numeric keys corrupt the walk
+				// (#263 L4). Stringify a copy anyway, so the invariant
+				// holds even if lua_isstring is ever aligned with the
+				// C API's coercion semantics.
 				if lua_isstring(L, -2) {
 					if !first do json_comma(b)
 					first = false
-					json_key(b, lua_tostring_len(L, -2))
+					lua_pushvalue(L, -2)
+					json_key(b, lua_tostring_len(L, -1))
+					lua_pop(L, 1)
 					lua_value_to_json_inner(b, L, -1, ctx)
 				}
 				lua_pop(L, 1)

--- a/src/redin/bridge/json_test.odin
+++ b/src/redin/bridge/json_test.odin
@@ -194,3 +194,36 @@ test_json_encode_preserves_embedded_nul :: proc(t: ^testing.T) {
 	testing.expectf(t, strings.contains(out, "0000"),
 		"embedded NUL should be escaped, not dropped; got %q (#173)", out)
 }
+
+// #263 L4 pinned down: the audit claimed lua_tolstring on a numeric key
+// mid-lua_next could derail the object-branch traversal (a real Lua 5.1
+// hazard — the coercing C-API lua_isstring answers true for numbers).
+// This codebase's lua_isstring binding is a STRICT LUA_TSTRING check, so
+// numeric keys never reach lua_tolstring: they are dropped from the
+// output, and the traversal is unaffected. This test pins both halves of
+// that contract — the drop and the surviving string keys — so a future
+// realignment of lua_isstring with C-API coercion semantics can't
+// silently reintroduce the hazard.
+@(test)
+test_json_encode_object_drops_numeric_key_keeps_rest :: proc(t: ^testing.T) {
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	// No [1] entry → object branch; one numeric key + one string key.
+	testing.expect(t,
+		luaL_dostring(L, `local t = {} t[2] = "b" t.x = "y" return t`) == 0,
+		"lua build failed")
+
+	b := strings.builder_make()
+	defer strings.builder_destroy(&b)
+	lua_value_to_json(&b, L, lua_gettop(L))
+	out := strings.to_string(b)
+
+	testing.expectf(t, strings.contains(out, `"x":"y"`),
+		"string keys must survive a numeric sibling key; got %q (#263 L4)", out)
+	testing.expectf(t, !strings.contains(out, `"b"`),
+		"numeric-keyed entries are dropped in the object branch; got %q (#263 L4)", out)
+	testing.expectf(t, strings.has_prefix(out, "{") && strings.has_suffix(out, "}"),
+		"object must stay structurally intact; got %q (#263 L4)", out)
+}

--- a/src/redin/bridge/measure_text_test.odin
+++ b/src/redin/bridge/measure_text_test.odin
@@ -1,0 +1,39 @@
+package bridge
+
+import "core:testing"
+
+// #263 L2: redin_measure_text skipped the lua_isstring guard that every
+// sibling host cfunc applies before dereferencing an argument, so a nil
+// (or table, or missing) text argument reached rl.MeasureTextEx as a NULL
+// cstring — strlen(NULL) → SIGSEGV. Reachable from app code with a plain
+// `(redin.measure_text nil 12)`, e.g. an accidental miss on a state field.
+// The guard returns before any font machinery is touched, so this test
+// runs headless.
+
+@(test)
+test_measure_text_nil_arg_no_crash :: proc(t: ^testing.T) {
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	// Host cfuncs enter through `context = g_context`, which bridge_init
+	// normally seeds; do the same here.
+	g_context = context
+
+	lua_pushnil(L)
+	lua_pushnumber(L, 12)
+	testing.expect_value(t, redin_measure_text(L), 0)
+}
+
+@(test)
+test_measure_text_table_arg_no_crash :: proc(t: ^testing.T) {
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	g_context = context
+
+	lua_newtable(L)
+	lua_pushnumber(L, 12)
+	testing.expect_value(t, redin_measure_text(L), 0)
+}


### PR DESCRIPTION
Covers #263 L2 and L4 — both verified against source before implementing; both findings' premises turned out partially wrong, details below.

## L2 — `redin.measure_text(nil)` (guard added; claimed crash does not reproduce)

`redin_measure_text` was indeed the one host cfunc without a `lua_isstring` argument guard, and a nil text does reach `rl.MeasureTextEx` as a NULL cstring. However the audit's `strlen(NULL) → SIGSEGV` does **not** reproduce: vendored raylib's `TextLength` NULL-guards, so the call returned a garbage measurement instead of crashing (pre-fix tests observed 2 return values, no crash). That behavior rests on a raylib internal detail, not a contract, so the guard is still the right call — added, returning 0 values like the sibling cfuncs. Tests: `measure_text_test.odin` (nil and table args, headless — the guard returns before any font machinery).

## L4 — JSON encoder numeric keys (invalid as filed; hardened and pinned)

The audit's premise is the C-API `lua_isstring`, which answers true for numbers — under that predicate, `lua_tolstring` on a numeric key mid-`lua_next` is the documented Lua 5.1 traversal-corruption hazard. But this codebase's `lua_isstring` binding (`lua_api.odin:118`) is a **strict `LUA_TSTRING` check**: numeric keys never reach `lua_tolstring`. Debug-verified: `lua_next` does yield the numeric key (type 3), the strict guard skips it, and the entry is dropped from the output by design — traversal unaffected, no mutation.

Changes anyway, both cheap:

- The encoder stringifies a **copy** of the key (`lua_pushvalue` → `lua_tolstring` → pop), so the no-mutation invariant survives even if `lua_isstring` is ever realigned with C-API coercion semantics.
- A comment at the guard marks the strictness as load-bearing.
- `test_json_encode_object_drops_numeric_key_keeps_rest` pins the actual contract (numeric-keyed entry dropped, string keys survive, object structurally intact), so a future binding change can't silently reintroduce the hazard.

## Verification

- `odin test src/redin/bridge` — 173/173 pass
- Release build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)