### PR TITLE
fix(bridge): diagnose u8 path-step wrap at >256 direct children (#180, #263 L3)

### DIFF
--- a/src/redin/bridge/bridge.odin
+++ b/src/redin/bridge/bridge.odin
@@ -63,6 +63,11 @@ g_context: runtime.Context
 // one-time warning rather than crashing.
 MAX_VIEW_DEPTH :: 256
 g_view_depth_warned: bool
+// #180 / #263 L3: path steps are u8; a container with >256 direct
+// children wraps and its path-keyed identity (text selection) can
+// collide across siblings. Warned once, not fixed — see #180 for why
+// widening the encoding is deferred.
+g_path_step_overflow_warned: bool
 
 init :: proc(b: ^Bridge) {
 	g_bridge = b
@@ -1520,6 +1525,17 @@ lua_flatten_node :: proc(L: ^Lua_State, index: i32, cur: ^[dynamic]u8, b: ^Bridg
 				if len(cur) < MAX_VIEW_DEPTH {
 					child_idx := i32(len(b.nodes))
 					append(&child_indices, child_idx)
+					// #180 / #263 L3: the u8 step wraps past 255, so this
+					// child's path collides with an earlier sibling's.
+					// Selection identity may then resolve to the wrong
+					// node. Diagnose once; the encoding itself stays u8
+					// (widening is deferred, see #180).
+					if len(child_indices) - 1 > int(max(u8)) && !g_path_step_overflow_warned {
+						g_path_step_overflow_warned = true
+						fmt.eprintfln(
+							"redin: a container has more than 256 direct children; node path steps wrap and text-selection identity can collide across its children (#180)",
+						)
+					}
 					append(cur, u8(len(child_indices) - 1))
 					lua_flatten_node(L, lua_gettop(L), cur, b, my_idx)
 					pop(cur)

--- a/src/redin/bridge/flatten_depth_test.odin
+++ b/src/redin/bridge/flatten_depth_test.odin
@@ -51,3 +51,80 @@ return t`
 		MAX_VIEW_DEPTH,
 	)
 }
+
+// #180 (re-flagged as #263 L3): each path step is a u8, so a container
+// with more than 256 direct children wraps — child 256's step collides
+// with child 0's, and path-keyed identity (text selection, /selection)
+// can resolve to the wrong sibling. Widening the encoding was triaged in
+// #180 as too regression-prone to do casually (it must change every path
+// builder and comparer in lockstep); the agreed safe first step is a
+// one-time diagnostic so an affected app says so instead of silently
+// misbehaving.
+@(test)
+test_flatten_warns_once_on_path_step_overflow :: proc(t: ^testing.T) {
+	sync.lock(&g_test_bridge_global_mutex)
+	defer sync.unlock(&g_test_bridge_global_mutex)
+
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	b: Bridge
+	b.L = L
+	saved := g_bridge
+	g_bridge = &b
+	defer g_bridge = saved
+	defer clear_frame(&b)
+
+	g_path_step_overflow_warned = false
+	defer g_path_step_overflow_warned = false
+
+	// 300 direct children under one vbox — past the 256 wrap point.
+	code: cstring = `local t = {"vbox", {}}
+for i = 1, 300 do t[#t+1] = {"text", {}, "row"} end
+return t`
+	rc := luaL_dostring(L, code)
+	testing.expectf(t, rc == 0, "failed to build wide table (rc=%d)", rc)
+
+	cur: [dynamic]u8
+	defer delete(cur)
+	lua_flatten_node(L, lua_gettop(L), &cur, &b, -1)
+
+	testing.expect_value(t, len(b.nodes), 301) // vbox + 300 texts
+	testing.expect(t, g_path_step_overflow_warned,
+		"flatten must warn when a container exceeds 256 direct children (#180 / #263 L3)")
+}
+
+@(test)
+test_flatten_no_overflow_warning_under_wrap_point :: proc(t: ^testing.T) {
+	sync.lock(&g_test_bridge_global_mutex)
+	defer sync.unlock(&g_test_bridge_global_mutex)
+
+	L := luaL_newstate()
+	luaL_openlibs(L)
+	defer lua_close(L)
+
+	b: Bridge
+	b.L = L
+	saved := g_bridge
+	g_bridge = &b
+	defer g_bridge = saved
+	defer clear_frame(&b)
+
+	g_path_step_overflow_warned = false
+
+	// 256 children is the widest collision-free container (steps 0..255).
+	code: cstring = `local t = {"vbox", {}}
+for i = 1, 256 do t[#t+1] = {"text", {}, "row"} end
+return t`
+	rc := luaL_dostring(L, code)
+	testing.expectf(t, rc == 0, "failed to build wide table (rc=%d)", rc)
+
+	cur: [dynamic]u8
+	defer delete(cur)
+	lua_flatten_node(L, lua_gettop(L), &cur, &b, -1)
+
+	testing.expect_value(t, len(b.nodes), 257)
+	testing.expect(t, !g_path_step_overflow_warned,
+		"256 direct children are collision-free and must not warn (#180 / #263 L3)")
+}


### PR DESCRIPTION
#263 L3 is a duplicate of open issue #180 (u8 path-step truncation), which was already triaged there: widening the per-step encoding is deferred because it must hit every path builder and comparer in lockstep — an inconsistency breaks text-selection identity for **all** nodes, not just the >256-sibling edge case — and the agreed safe first step was a one-time diagnostic when a container exceeds the wrap point.

This PR implements exactly that agreed step, rather than the audit's suggested u8→u16 churn:

- One-time `stderr` warning (mirroring the #170 depth-cap warn-once pattern) when a container's 257th direct child is flattened, naming the consequence (path steps wrap; selection identity can collide across siblings) and pointing at #180.
- Verified the wrap site is the single live path builder: the parser-side truncation (`view_tree_parser.odin`) is dead/test-only per #180, and the markdown lowering builds no path bytes.

Tests: warn fires at 300 direct children; 256 children (steps 0..255, the widest collision-free container) stays silent.

Verification: `odin test src/redin/bridge` 172/172; release build clean.

The actual encoding widening stays tracked by #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)