### PR TITLE
chore: upgrade odin-http submodule (upstream through openssl 4.0.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       # gitlink whenever odin-http is intentionally rolled forward (#221 L1).
       - name: Verify odin-http submodule SHA
         run: |
-          expected=9f50972ec8a7f4e31bd050f245b79f63733f31f8
+          expected=5576bb0b3cd0d5dbdfb3033307903a4dc66343e5
           actual=$(git -C lib/odin-http rev-parse HEAD)
           [ "$actual" = "$expected" ] || {
             echo "::error::odin-http submodule SHA mismatch (got $actual, expected $expected)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       # gitlink whenever odin-http is intentionally rolled forward (#221 L1).
       - name: Verify odin-http submodule SHA
         run: |
-          expected=9f50972ec8a7f4e31bd050f245b79f63733f31f8
+          expected=5576bb0b3cd0d5dbdfb3033307903a4dc66343e5
           actual=$(git -C lib/odin-http rev-parse HEAD)
           [ "$actual" = "$expected" ] || {
             echo "::error::odin-http submodule SHA mismatch (got $actual, expected $expected)"
@@ -113,7 +113,7 @@ jobs:
       # gitlink whenever odin-http is intentionally rolled forward (#221 L1).
       - name: Verify odin-http submodule SHA
         run: |
-          expected=9f50972ec8a7f4e31bd050f245b79f63733f31f8
+          expected=5576bb0b3cd0d5dbdfb3033307903a4dc66343e5
           actual=$(git -C lib/odin-http rev-parse HEAD)
           [ "$actual" = "$expected" ] || {
             echo "::error::odin-http submodule SHA mismatch (got $actual, expected $expected)"


### PR DESCRIPTION
Bumps `lib/odin-http` to `5576bb0` — the merge of upstream laytan/odin-http into the fork's patched line, sstoehrm/odin-http#4.

Upstream commits pulled in:
- chunked-size parse via `parse_i64_of_base` + overflow-safe cap check (laytan#117) — this **subsumes** the fork's redin-#163 negative-chunk-size guard in `body.odin`, the one merge conflict, resolved in upstream's favor
- client cookie `_raw` freed with the cookies array's allocator
- `respond_file` honors an explicit `content_type`
- bundled Windows openssl libs → 4.0.1 (Linux uses system libssl; no effect here)

All fork patches redin depends on are carried forward unchanged: TLS certificate verification + hostname pinning, `dial()`/`request_on()` split, scanner-buffer and SSL error-path leak fixes, client-side negative-slice guards.

`.gitmodules` already declares `branch = main`; once sstoehrm/odin-http#4 merges (with a merge commit — noted there — so `5576bb0` stays reachable), the pinned commit is on the declared branch. **Merge order:** sstoehrm/odin-http#4 first, then this.

## Verification (redin at this pin)

- Release build clean
- `odin test src/redin/bridge` — 170/170, including the live `openssl s_server` TLS-verification test and the chunked/negative-size hardening tests
- Fennel runtime tests — 154/154
- Full headless UI suite (`test/ui/run-all.sh --headless`) — all suites pass
- Tracking-allocator leak check on smoke app — clean shutdown, no leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)