### PR TITLE
chore: bump pinned Odin toolchain to dev-2026-08

### DIFF
--- a/.claude/skills/redin-maintenance/SKILL.md
+++ b/.claude/skills/redin-maintenance/SKILL.md
@@ -15,7 +15,7 @@ odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -o
 
 `src/cmd/redin/` is the thin CLI entry point (`package main`, arg parsing + memory tracking + `redin.run` call). The framework itself lives in `src/redin/` (`package redin`).
 
-Requires: Odin dev-2026-07 or newer (raylib 6 ships in `vendor:raylib`), `libssl-dev`, the X11/GL dev libs (`libgl1-mesa-dev libx11-dev libxrandr-dev libxi-dev libxcursor-dev libxinerama-dev`), and the `lib/odin-http` git submodule (`git submodule update --init`).
+Requires: Odin dev-2026-08 or newer (raylib 6 ships in `vendor:raylib`), `libssl-dev`, the X11/GL dev libs (`libgl1-mesa-dev libx11-dev libxrandr-dev libxi-dev libxcursor-dev libxinerama-dev`), and the `lib/odin-http` git submodule (`git submodule update --init`).
 
 ## Fennel runtime tests
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,10 +58,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # Pin the Odin release: the default tracks master, which can
           # break core:sys APIs mid-cycle and turn CI red repo-wide.
-          # dev-2026-07 is the line the tree builds and tests clean on
-          # (non-parametric Sig_Action, vendored raylib 6). Bump
-          # deliberately, not silently.
-          release: dev-2026-07
+          # dev-2026-08 is the line the tree builds and tests clean on.
+          # Bump deliberately, not silently.
+          release: dev-2026-08
 
       - name: Run Fennel tests
         run: luajit test/lua/runner.lua test/lua/test_*.fnl
@@ -160,10 +159,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # Pin the Odin release: the default tracks master, which can
           # break core:sys APIs mid-cycle and turn CI red repo-wide.
-          # dev-2026-07 is the line the tree builds and tests clean on
-          # (non-parametric Sig_Action, vendored raylib 6). Bump
-          # deliberately, not silently.
-          release: dev-2026-07
+          # dev-2026-08 is the line the tree builds and tests clean on.
+          # Bump deliberately, not silently.
+          release: dev-2026-08
 
       - name: Run Fennel tests
         run: luajit test/lua/runner.lua test/lua/test_*.fnl

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ odin build src/cmd/redin -collection:lib=lib -collection:luajit=vendor/luajit -o
 
 | Dependency | Purpose | Required |
 |-----------|---------|----------|
-| **Odin** (dev-2026-07 or newer) | Compiles the host/renderer | Yes |
+| **Odin** (dev-2026-08 or newer) | Compiles the host/renderer | Yes |
 | **Raylib** (6.0) | Bundled with Odin (`vendor:raylib`) | -- |
 | **LuaJIT** (`luajit`) | Runs tests, AOT compiles Fennel; the C library is statically linked from `vendor/luajit/` so `libluajit-5.1-dev` is not required | Yes |
 | **OpenSSL** (`libssl-dev`) | HTTPS support via odin-http | Yes |


### PR DESCRIPTION
## Summary
- Bump the deliberately pinned Odin release in CI (`test.yml`, both jobs) from `dev-2026-07` to the latest release `dev-2026-08` (published 2026-08-06)
- Update minimum-version references in `README.md` and `.claude/skills/redin-maintenance/SKILL.md` to match
- `release.yml` intentionally doesn't pin, so it is unchanged

## Verification (local, on dev-2026-08-nightly:902106f)
- Release build: OK
- Fennel runtime tests: 154 passed, 0 failed
- Odin unit tests: 288 tests across 7 packages, all passed
- UI integration suite (headless): all suites passed

CI on this PR is the definitive check for the exact `dev-2026-08` release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)