### PR TITLE
chore: sync odin-http fork main and re-pin submodule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       # gitlink whenever odin-http is intentionally rolled forward (#221 L1).
       - name: Verify odin-http submodule SHA
         run: |
-          expected=5576bb0b3cd0d5dbdfb3033307903a4dc66343e5
+          expected=ac3886ca6dda48fbff39ac5fdb248c4777aa1662
           actual=$(git -C lib/odin-http rev-parse HEAD)
           [ "$actual" = "$expected" ] || {
             echo "::error::odin-http submodule SHA mismatch (got $actual, expected $expected)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       # gitlink whenever odin-http is intentionally rolled forward (#221 L1).
       - name: Verify odin-http submodule SHA
         run: |
-          expected=5576bb0b3cd0d5dbdfb3033307903a4dc66343e5
+          expected=ac3886ca6dda48fbff39ac5fdb248c4777aa1662
           actual=$(git -C lib/odin-http rev-parse HEAD)
           [ "$actual" = "$expected" ] || {
             echo "::error::odin-http submodule SHA mismatch (got $actual, expected $expected)"
@@ -112,7 +112,7 @@ jobs:
       # gitlink whenever odin-http is intentionally rolled forward (#221 L1).
       - name: Verify odin-http submodule SHA
         run: |
-          expected=5576bb0b3cd0d5dbdfb3033307903a4dc66343e5
+          expected=ac3886ca6dda48fbff39ac5fdb248c4777aa1662
           actual=$(git -C lib/odin-http rev-parse HEAD)
           [ "$actual" = "$expected" ] || {
             echo "::error::odin-http submodule SHA mismatch (got $actual, expected $expected)"


### PR DESCRIPTION
## Summary
- Synced the `sstoehrm/odin-http` fork: merged `upgrade/upstream-2026-08` (the upstream-merged line redin already pins as `5576bb0`) into fork `main` and pushed → new head `ac3886c`. Fork `main` now contains all fork fixes (TLS verification, leak fixes) plus current upstream (`65f57ca`, openssl 4.0.1); upstream has not moved since.
- Bumped the submodule gitlink and the pinned SHA in `test.yml` (both jobs) and `release.yml` to `ac3886ca6dda48fbff39ac5fdb248c4777aa1662`.

`git diff 5576bb0 ac3886c` is empty — the new pin is tree-identical to the old one; this just moves the pin off a side branch onto `main`'s history.

## Verification
- Release build: OK
- Bridge unit tests (the odin-http consumer): 178 tests, all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)